### PR TITLE
[A0CLI-13] feat: initial implementation of creating a new rule

### DIFF
--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -52,7 +52,7 @@ func createRulesCmd(cli *cli) *cobra.Command {
 		Short: "Create a new rule",
 		Long: `Create a new rule:
 
-		auth0 rules create --name "My Rule" --script "function (user, context, callback) { console.log( 'Hello, world!' ); return callback(null, user, context); }"
+    auth0 rules create --name "My Rule" --script "function (user, context, callback) { console.log( 'Hello, world!' ); return callback(null, user, context); }"
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := &management.Rule{


### PR DESCRIPTION
### Description

Base for the `auth0 rules create` subcommand. Currently accepts a string `--script` / `-s`, but would like to expand on this to allow devs to specify a source file (and eventually, scaffold rules, too).