### PR TITLE
Fix copy pasta in table header for connections list

### DIFF
--- a/internal/display/connections.go
+++ b/internal/display/connections.go
@@ -13,7 +13,7 @@ type connectionView struct {
 }
 
 func (v *connectionView) AsTableHeader() []string {
-	return []string{"Name", "Type", "ClientID"}
+	return []string{"Name", "Type", "Connection ID"}
 }
 
 func (v *connectionView) AsTableRow() []string {


### PR DESCRIPTION
Header had CLIENTID instead of CONNECTION ID.