### PR TITLE
[A0CLI-27] feat: Delete a rule by specifying an ID

### DIFF
--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -97,7 +97,7 @@ func deleteRulesCmd(cli *cli) *cobra.Command {
 	auth0 rules delete --id "12345"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := &management.Rule{ID: &flags.id}
-			
+
 			// TODO: Should add validation of rule
 			// TODO: Would be nice to prompt user confirmation before proceeding with delete
 
@@ -113,7 +113,7 @@ func deleteRulesCmd(cli *cli) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.id, "id", "i", "", "ID of the rule to delete (required)")
+	cmd.Flags().StringVar(&flags.id, "id", "", "ID of the rule to delete (required)")
 
 	return cmd
 }


### PR DESCRIPTION
### Description

This provides the basic functionality to delete a rule by specifying an ID. In the future, could use the following improvements:

* Validation of the rule ID provided
* Confirmation from user before proceeding with rule deletion
* Bulk deletes by specifying a comma-separated list (or CSV)
* Maybe even deletion by rule name? 
