### PR TITLE
Explode scopes per resource

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -43,7 +43,7 @@ var requiredScopes = []string{
 	"create:hooks", "delete:hooks", "read:hooks", "update:hooks",
 	"create:resource_servers", "delete:resource_servers", "read:resource_servers", "update:resource_servers",
 	"create:rules", "delete:rules", "read:rules", "update:rules",
-	"read:logs",
+	"read:client_keys", "read:logs",
 }
 
 type Authenticator struct {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,49 @@
+package auth
+
+import "testing"
+
+func TestRequiredScopes(t *testing.T) {
+	t.Run("verify CRUD", func(t *testing.T) {
+		crudResources := []string{
+			"actions",
+			"clients",
+			"connections",
+			"hooks",
+			"resource_servers",
+			"rules",
+		}
+		crudPrefixes := []string{"create:", "delete:", "read:", "update:"}
+
+		for _, resource := range crudResources {
+			for _, prefix := range crudPrefixes {
+				scope := prefix + resource
+
+				if !strInArray(requiredScopes, scope) {
+					t.Fatalf("wanted scope: %q, list: %+v", scope, requiredScopes)
+				}
+			}
+		}
+	})
+
+	t.Run("verify special scopes", func(t *testing.T) {
+		list := []string{
+			"read:client_keys", "read:logs",
+		}
+
+		for _, v := range list {
+			if !strInArray(requiredScopes, v) {
+				t.Fatalf("wanted scope: %q, list: %+v", v, requiredScopes)
+			}
+		}
+	})
+}
+
+func strInArray(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This ideally makes the diffs more readable, but makes it clear which
resources we're trying to ask permissions for the future reader.
