### PR TITLE
fix: json format and spinner

### DIFF
--- a/internal/ansi/spinner.go
+++ b/internal/ansi/spinner.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -21,7 +22,7 @@ func Spinner(text string, fn func() error) error {
 	go func() {
 		defer close(done)
 
-		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 		s.Prefix = text + spinnerTextEllipsis + " "
 		s.FinalMSG = s.Prefix + spinnerTextDone
 


### PR DESCRIPTION
the spinner was breaking the --json=format when piped (to jq).
Setting the spinner option for the writer (os.Stderr) fixes this.

For some reason, the spinner color is lost if the command is piped, otherwise is still there.

**before**
```bash
```❯ go run ./cmd/auth0 clients list --format=json | jq=== jorgehack21 clients

parse error: Invalid numeric literal at line 1, column 3```while the format seems correct:

```

**after**
(piping to jq, without spinner color)

https://user-images.githubusercontent.com/11925502/105847739-c47dc800-5fbc-11eb-9509-9434829a0829.mov

(without piping, keep the spinner color)

https://user-images.githubusercontent.com/11925502/105847838-ec6d2b80-5fbc-11eb-8255-b6d473029ad6.mov

