### PR TITLE
docs: add manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Stripe CLI, etc.
 
 ## Installation
 ### macOS
-1. Download the binaries from the latest release: https://github.com/auth0/auth0-cli/releases/latest/
+1. Download the binaries from: https://github.com/auth0/auth0-cli/releases/latest/
 1. Extract
-1. Move to `auth0` to `/usr/local/bin/auth0`, e.g.: `mv ~/Desktop/auth0 /usr/local/bin`
+1. Move `auth0` to `/usr/local/bin/auth0`, e.g.: `mv ~/Desktop/auth0 /usr/local/bin`
 1. Setup CLI commands completion for your terminal:
 	-  (**bash**) `auth0 completion bash > /usr/local/etc/bash_completion.d/auth0`
 	-  (**zsh**)  `auth0 completion zsh > "${fpath[1]}/_auth0"`
 	- (**fish**)  `auth0 completion fish | source`
 
-> see full completion options: `auth0 completion -h`
+> see more completion options: `auth0 completion -h`
 
 ## Dev Setup instructions
 


### PR DESCRIPTION
view rendered readme here: https://github.com/auth0/auth0-cli/blob/release/README.md

this is just a first step for internal use. Any Auth0 employee should have access to the releases of this `internal` repo.
as a next step we could work on homebrew or s3 bucket approach.