### PR TITLE
Add the get-tokens command

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -18,6 +18,7 @@ func apisCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(createApiCmd(cli))
 	cmd.AddCommand(updateApiCmd(cli))
 	cmd.AddCommand(deleteApiCmd(cli))
+	cmd.AddCommand(getTokenApiCmd(cli))
 
 	return cmd
 }
@@ -162,6 +163,31 @@ auth0 apis delete --id id
 	cmd.Flags().StringVarP(&flags.id, "id", "i", "", "ID of the API.")
 
 	mustRequireFlags(cmd, "id")
+
+	return cmd
+}
+
+func getTokenApiCmd(cli *cli) *cobra.Command {
+	var flags struct {
+		id string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get-token",
+		Short: "Get a user token",
+		Long: `Get a user token for an API:
+
+auth0 apis get-token --audience url
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.id, "audience", "a", "", "Audience URL")
+
+	mustRequireFlags(cmd, "audience")
 
 	return cmd
 }


### PR DESCRIPTION
### Description

Adds a command to get a token that can be used to access an API via curl, postman, insomnia, etc.

### References

- https://auth0team.atlassian.net/browse/A0CLI-20

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
