### PR TITLE
fix: Go SDK can't set an empty list of callbacks, so don't attempt to do so

### DIFF
--- a/internal/cli/try_login.go
+++ b/internal/cli/try_login.go
@@ -255,7 +255,7 @@ func removeLocalCallbackURLFromClient(clientManager auth0.ClientAPI, client *man
 	}
 
 	// can't update a client to have 0 callback URLs, so don't attempt it
-	if len(callbacks) == 1 {
+	if len(callbacks) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
This is a bug in the SDK, but also a general issue with Go.

We need to update the client to remove the callback URL we added previously, but if that results in an empty callback list, then Go will helpfully omit the `callbacks` property before sending (due to `omitempty`) and thus send an empty request to the manage API :(
