### PR TITLE
[A0CLI-54] feat: Adding the update rule subcommand

### DIFF
--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -31,6 +31,7 @@ func rulesCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(disableRuleCmd(cli))
 	cmd.AddCommand(createRulesCmd(cli))
 	cmd.AddCommand(deleteRulesCmd(cli))
+	cmd.AddCommand(updateRulesCmd(cli))
 
 	return cmd
 }
@@ -350,6 +351,100 @@ func deleteRulesCmd(cli *cli) *cobra.Command {
 
 	cmd.Flags().StringVarP(&flags.ID, ruleID, "i", "", "ID of the rule to delete (required)")
 	cmd.Flags().StringVarP(&flags.Name, ruleName, "n", "", "Name of the rule to delete")
+
+	return cmd
+}
+
+func updateRulesCmd(cli *cli) *cobra.Command {
+	var flags struct {
+		ID      string
+		Name    string
+		Script  string
+		Order   int
+		Enabled bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "update a rule",
+		Long: `Update a rule:
+
+    auth0 rules update --id "12345" --name "My Updated Rule" --script "function (user, context, callback) { console.log( 'Hello, world!' ); return callback(null, user, context); }" --order 1 --enabled true
+		`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			prepareInteractivity(cmd)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if shouldPrompt(cmd, ruleID) {
+				input := prompt.TextInput(ruleID, "Id:", "Id of the rule.", "", true)
+
+				if err := prompt.AskOne(input, &flags); err != nil {
+					return err
+				}
+			}
+
+			if shouldPrompt(cmd, ruleName) {
+				input := prompt.TextInput(
+					"name", "Name:",
+					"Name of the rule. You can change the rule name later in the rule settings.",
+					"",
+					true)
+
+				if err := prompt.AskOne(input, &flags); err != nil {
+					return err
+				}
+			}
+
+			if shouldPrompt(cmd, ruleScript) {
+				input := prompt.TextInput(ruleScript, "Script:", "Script of the rule.", "", true)
+
+				if err := prompt.AskOne(input, &flags); err != nil {
+					return err
+				}
+			}
+
+			if shouldPrompt(cmd, ruleOrder) {
+				input := prompt.TextInput(ruleOrder, "Order:", "Order of the rule.", "0", false)
+
+				if err := prompt.AskOne(input, &flags); err != nil {
+					return err
+				}
+			}
+
+			if shouldPrompt(cmd, ruleEnabled) {
+				input := prompt.BoolInput(ruleEnabled, "Enabled:", "Enable the rule.", false)
+
+				if err := prompt.AskOne(input, &flags); err != nil {
+					return err
+				}
+			}
+
+			r := &management.Rule{
+				Name:    &flags.Name,
+				Script:  &flags.Script,
+				Order:   &flags.Order,
+				Enabled: &flags.Enabled,
+			}
+
+			err := ansi.Spinner("Updating rule", func() error {
+				return cli.api.Rule.Update(flags.ID, r)
+			})
+
+			if err != nil {
+				return err
+			}
+
+			cli.renderer.Infof("Your rule `%s` was successfully updated.", flags.Name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.ID, ruleID, "i", "", "ID of the rule to update (required)")
+	cmd.Flags().StringVarP(&flags.Name, ruleName, "n", "", "Name of this rule")
+	cmd.Flags().StringVarP(&flags.Script, ruleScript, "s", "", "Code to be executed when this rule runs")
+	cmd.Flags().IntVarP(&flags.Order, ruleOrder, "o", 0, "Order that this rule should execute in relative to other rules. Lower-valued rules execute first.")
+	cmd.Flags().BoolVarP(&flags.Enabled, ruleEnabled, "e", false, "Whether the rule is enabled (true), or disabled (false).")
+	mustRequireFlags(cmd, ruleID)
 
 	return cmd
 }


### PR DESCRIPTION
### Description

This adds the base for the `auth0 rules update` subcommand. Future TODOs include pressing `return` / `Enter` to skip updating a certain part of the rule (as not all args should be required if I just want to update the rule name, for example).