### PR TITLE
feat: support updating an action with new versions

### DIFF
--- a/internal/display/actions.go
+++ b/internal/display/actions.go
@@ -130,7 +130,7 @@ func (r *Renderer) ActionVersion(version *management.ActionVersion) {
 	v := &actionVersionView{
 		ID:         version.ID,
 		ActionID:   auth0.StringValue(version.Action.ID),
-		ActionName: auth0.StringValue(version.Action.ID),
+		ActionName: auth0.StringValue(version.Action.Name),
 		Runtime:    auth0.StringValue(&version.Runtime),
 		Status:     string(version.Status),
 		CreatedAt:  timeAgo(auth0.TimeValue(version.CreatedAt)),


### PR DESCRIPTION
### Description

Syntax-wise, this looks the same as `actions create`, only you need to provide the action id for the `--name` flag:
```
$./auth0 actions update --name b448822b-cd98-46f9-badd-7b6ebd9b5381 --script "module.exports = async (event, context) => {console.log("update!");return {};}"                      
Updating action... done                                                                                                                                                              
                                                                                                                                                                                     
=== iamjem action version                                                                                                                                                            
                                                                                                                                                                                     
  ID     ACTION ID                             ACTION NAME                           RUNTIME  STATUS  CREATED AT                                                                     
  draft  b448822b-cd98-46f9-badd-7b6ebd9b5381  b448822b-cd98-46f9-badd-7b6ebd9b5381  node12   built   2 minutes ago 
```