### PR TITLE
[A0CLI-57] feat: add 'scopes list' subcommand

### DIFF
--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -1,6 +1,8 @@
 package display
 
 import (
+	"fmt"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"gopkg.in/auth0.v5/management"
@@ -10,47 +12,83 @@ type apiView struct {
 	ID         string
 	Name       string
 	Identifier string
+	Scopes     int
 }
 
 func (v *apiView) AsTableHeader() []string {
-	return []string{"ID", "Name", "Identifier"}
+	return []string{"ID", "Name", "Identifier", "Scopes"}
 }
 
 func (v *apiView) AsTableRow() []string {
-	return []string{ansi.Faint(v.ID), v.Name, v.Identifier}
+	return []string{ansi.Faint(v.ID), v.Name, v.Identifier, fmt.Sprint(v.Scopes)}
 }
 
 func (r *Renderer) ApiList(apis []*management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "APIs\n")
 
-	var res []View
+	results := []View{}
 
 	for _, api := range apis {
-		res = append(res, makeView(api))
+		results = append(results, makeApiView(api))
 	}
 
-	r.Results(res)
+	r.Results(results)
 }
 
 func (r *Renderer) ApiShow(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API\n")
-	r.Results([]View{makeView(api)})
+	r.Results([]View{makeApiView(api)})
 }
 
 func (r *Renderer) ApiCreate(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API created\n")
-	r.Results([]View{makeView(api)})
+	r.Results([]View{makeApiView(api)})
 }
 
 func (r *Renderer) ApiUpdate(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API updated\n")
-	r.Results([]View{makeView(api)})
+	r.Results([]View{makeApiView(api)})
 }
 
-func makeView(api *management.ResourceServer) *apiView {
+func makeApiView(api *management.ResourceServer) *apiView {
+	scopes := len(api.Scopes)
+
 	return &apiView{
 		ID:         auth0.StringValue(api.ID),
 		Name:       auth0.StringValue(api.Name),
 		Identifier: auth0.StringValue(api.Identifier),
+		Scopes:     auth0.IntValue(&scopes),
+	}
+}
+
+type scopeView struct {
+	Scope       string
+	Description string
+}
+
+func (v *scopeView) AsTableHeader() []string {
+	return []string{"Scope", "Description"}
+}
+
+func (v *scopeView) AsTableRow() []string {
+	return []string{v.Scope, v.Description}
+}
+
+func (r *Renderer) ScopesList(api string, scopes []*management.ResourceServerScope) {
+	r.Heading(ansi.Bold(r.Tenant), fmt.Sprintf("Scopes of %s\n", ansi.Bold(api)))
+
+	results := []View{}
+
+	for _, scope := range scopes {
+		results = append(results, makeScopeView(scope))
+	}
+
+	r.Results(results)
+}
+
+func makeScopeView(scope *management.ResourceServerScope) *scopeView {
+	return &scopeView{
+		Scope:       auth0.StringValue(scope.Value),
+		Description: auth0.StringValue(scope.Description),
 	}
 }


### PR DESCRIPTION
### Description

This PR adds the command `apis scopes list --id` that lists the scopes of a given API, and allows to add scopes when creating an API or replacing them when updating.

https://user-images.githubusercontent.com/5055789/106083895-07928500-60fc-11eb-8fb3-5dfb1e4f7146.mov


