### PR TITLE
Reduce-scopes

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -39,14 +39,9 @@ var requiredScopes = []string{
 	"openid",
 	"create:actions", "delete:actions", "read:actions", "update:actions",
 	"create:clients", "delete:clients", "read:clients", "update:clients",
-	"create:connections", "delete:connections", "read:connections", "update:connections",
-	"create:hooks", "delete:hooks", "read:hooks", "update:hooks",
 	"create:resource_servers", "delete:resource_servers", "read:resource_servers", "update:resource_servers",
 	"create:rules", "delete:rules", "read:rules", "update:rules",
 	"read:client_keys", "read:logs",
-	"create:roles", "delete:roles", "read:roles", "update:roles",
-	"create:custom_domains", "delete:custom_domains", "read:custom_domains", "update:custom_domains",
-	"read:users",
 }
 
 type Authenticator struct {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,8 +7,6 @@ func TestRequiredScopes(t *testing.T) {
 		crudResources := []string{
 			"actions",
 			"clients",
-			"connections",
-			"hooks",
 			"resource_servers",
 			"rules",
 		}


### PR DESCRIPTION
We're only gonna keep scopes to support the following commands for now:

- clients
- login
- logs
- test login
- test token
- apis
- quickstart
