### PR TITLE
api show: use proper formatting

### DIFF
--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
@@ -13,6 +14,8 @@ type apiView struct {
 	Name       string
 	Identifier string
 	Scopes     int
+
+	raw interface{}
 }
 
 func (v *apiView) AsTableHeader() []string {
@@ -21,6 +24,19 @@ func (v *apiView) AsTableHeader() []string {
 
 func (v *apiView) AsTableRow() []string {
 	return []string{ansi.Faint(v.ID), v.Name, v.Identifier, fmt.Sprint(v.Scopes)}
+}
+
+func (v *apiView) KeyValues() [][]string {
+	return [][]string{
+		[]string{"ID", v.ID},
+		[]string{"NAME", v.Name},
+		[]string{"IDENTIFIER", v.Identifier},
+		[]string{"SCOPES", strconv.Itoa(v.Scopes)},
+	}
+}
+
+func (v *apiView) Object() interface{} {
+	return v.raw
 }
 
 func (r *Renderer) ApiList(apis []*management.ResourceServer) {
@@ -37,7 +53,7 @@ func (r *Renderer) ApiList(apis []*management.ResourceServer) {
 
 func (r *Renderer) ApiShow(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API\n")
-	r.Results([]View{makeApiView(api)})
+	r.Result(makeApiView(api))
 }
 
 func (r *Renderer) ApiCreate(api *management.ResourceServer) {
@@ -58,6 +74,8 @@ func makeApiView(api *management.ResourceServer) *apiView {
 		Name:       auth0.StringValue(api.Name),
 		Identifier: auth0.StringValue(api.Identifier),
 		Scopes:     auth0.IntValue(&scopes),
+
+		raw: api,
 	}
 }
 

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -88,6 +88,28 @@ func (r *Renderer) Results(data []View) {
 	}
 }
 
+func (r *Renderer) Result(data View) {
+	switch r.Format {
+	case OutputFormatJSON:
+		// TODO(cyx): we're type asserting on the fly to prevent too
+		// many changes in other places. In the future we should
+		// enforce `Object` on all `View` types.
+		if v, ok := data.(interface{ Object() interface{} }); ok {
+			r.JSONResult(v.Object())
+		} else {
+			r.JSONResult(data)
+		}
+
+	default:
+		// TODO(cyx): we're type asserting on the fly to prevent too
+		// many changes in other places. In the future we should
+		// enforce `KeyValues` on all `View` types.
+		if v, ok := data.(interface{ KeyValues() [][]string }); ok {
+			writeTable(r.ResultWriter, nil, v.KeyValues())
+		}
+	}
+}
+
 func (r *Renderer) Stream(data []View, ch <-chan View) {
 	w := r.ResultWriter
 


### PR DESCRIPTION
This changes `api show` to use the key value tabular format.
Additionally took the liberty of making JSON formatting be the complete
JSON object.

So tl;dr we're introducing two interface methods for the `View`:

1. Object()
2. KeyValues()
