### PR TITLE
CLI-19: Replace --verbose with --debug.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -52,7 +52,7 @@ var errUnauthenticated = errors.New("Not yet configured. Try `auth0 login`.")
 //
 // 1. --format
 // 2. --tenant
-// 3. --verbose
+// 3. --debug
 //
 type cli struct {
 	// core primitives exposed to command builders.
@@ -60,7 +60,7 @@ type cli struct {
 	renderer *display.Renderer
 
 	// set of flags which are user specified.
-	verbose bool
+	debug   bool
 	tenant  string
 	format  string
 	force   bool
@@ -103,7 +103,7 @@ func (c *cli) setup() error {
 	} else if t.AccessToken != "" {
 		m, err := management.New(t.Domain,
 			management.WithStaticToken(t.AccessToken),
-			management.WithDebug(c.verbose),
+			management.WithDebug(c.debug),
 			management.WithUserAgent(userAgent))
 		if err != nil {
 			return err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,8 +44,8 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&cli.tenant,
 		"tenant", cli.config.DefaultTenant, "Specific tenant to use.")
 
-	rootCmd.PersistentFlags().BoolVar(&cli.verbose,
-		"verbose", false, "Enable verbose mode.")
+	rootCmd.PersistentFlags().BoolVar(&cli.debug,
+		"debug", false, "Enable debug mode.")
 
 	rootCmd.PersistentFlags().StringVar(&cli.format,
 		"format", "", "Command output format. Options: json.")


### PR DESCRIPTION
### Description

Replace --verbose with --debug.


### References

 - [CLI-19](https://auth0team.atlassian.net/browse/CLI-19)

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
