### PR TITLE
CLI-35: include tenant name, if it is set, when rendering command failures.

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/display"
 	"github.com/spf13/cobra"
 )
@@ -74,6 +75,11 @@ func Execute() {
 	// rootCmd.AddCommand(triggersCmd(cli))
 
 	if err := rootCmd.ExecuteContext(context.TODO()); err != nil {
+		header := []string{"error\n"}
+		if cli.tenant != "" {
+			header = append([]string{ansi.Bold(cli.tenant)}, header...)
+		}
+		cli.renderer.Heading(header...)
 		cli.renderer.Errorf(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
### Description

Include the tenant name when rendering a command failure:

With no tenant set in config file:
```bash
$ auth0 logs

=== error

 ▸    Not yet configured. Try `auth0 login`.
```
With a tenant set but token has expired or is invalid:
```bash
$ auth0 logs

=== cero error

 ▸    401 Unauthorized: Expired token received for JSON Web Token validation

$ auth0 logs
go build -o auth0 cmd/auth0/main.go

=== cero error

 ▸    401 Unauthorized: Invalid token
```
And with an artificial error injected:
```bash
$ git diff
diff --git a/internal/cli/logs.go b/internal/cli/logs.go
index e0ccfb8..9ecfd19 100644
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,6 +1,7 @@
 package cli

 import (
+       "errors"
        "fmt"
        "sort"
        "time"
@@ -44,6 +45,7 @@ Show the tenant logs.
                RunE: func(cmd *cobra.Command, args []string) error {
                        lastLogID := ""
                        list, err := getLatestLogs(cli, flags.Num)
+                       err = errors.New("fake error")
                        if err != nil {
                                return err
                        }
```
```bash
$ auth0 logs

=== cero error

 ▸    fake error
```

### References

 - [CLI-35](https://auth0team.atlassian.net/browse/CLI-35)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
