### PR TITLE
CLI-18: customize error messages for test command

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
@@ -47,7 +46,7 @@ Launch a browser to try out your universal login box for the given client.
 			if clientID == "" {
 				client, err := getOrCreateCLITesterClient(cli.api.Client)
 				if err != nil {
-					return errors.New("Unable to test the login box; please check your internet connection and verify you haven't reached your apps limit")
+					return fmt.Errorf("Unable to create an app for testing the login box: %w", err)
 				}
 				clientID = client.GetClientID()
 			}
@@ -119,7 +118,7 @@ Fetch an access token for the given client and API.
 			if clientID == "" {
 				client, err := getOrCreateCLITesterClient(cli.api.Client)
 				if err != nil {
-					return errors.New("Unable to fetch a token; please check your internet connection and verify you haven't reached your apps limit")
+					return fmt.Errorf("Unable to create an app to test getting a token: %w", err)
 				}
 				clientID = client.GetClientID()
 			}


### PR DESCRIPTION
### Description
After talking with @Widcket, our error style guide is writing custom error messages for errors with known causes and prefixing and passing through unknown errors.

This PR takes a pass at error messages for the `test` command.

### References
https://auth0team.atlassian.net/wiki/spaces/~474568858/pages/1675758375/Auth0+CLI+DX+Proposal#Keep-error-messages-user-focused
https://auth0team.atlassian.net/jira/software/projects/CLI/boards/1063?selectedIssue=CLI-18

### Testing
Tested manually

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
