### PR TITLE
Fix quickstarts download issues [CLI-53]

### DIFF
--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"sort"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/prompt"
@@ -30,14 +29,6 @@ var (
 			panic(err)
 		}
 		return
-	}()
-	quickstartTypes = func() []string {
-		keys := make([]string, 0, len(quickstartsByType))
-		for k := range quickstartsByType {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		return keys
 	}()
 )
 


### PR DESCRIPTION
### Description

https://user-images.githubusercontent.com/5055789/109749181-e4566c00-7bb8-11eb-82f7-c5157f396be9.mov

#### Removed the 'type' flag and prompt
In the `quickstarts download` command, the first thing the code does is to use the `client-id` to fetch a **Client** instance from the Management API. In that instance, the app type is already available so there is no need to ask the user for it.

#### Added a prompt for 'client-id'
The` client-id` could only be passed via flag while all the other inputs could be prompted. Also added a shorthand letter for the flag.

#### Added a confirmation prompt before overriding
When the quickstart folder already existed, the command bailed out instructing the user to use the `--force` flag.

#### Removed existing quickstart folder before unzipping
The existing files in the folder could cause an error.

<img width="803" alt="Screen Shot 2021-03-03 at 00 10 22" src="https://user-images.githubusercontent.com/5055789/109749333-21baf980-7bb9-11eb-928c-77fc83a24cef.png">

#### Made texts consistent with other commands
Also edited them for clarity around what the command does. This command should probably be called `samples download`, though, since the quickstarts are tutorials that reference sample apps, but the sample apps are not quickstarts.

#### Returned an error when running in non-interactive mode
- The use case for this command only makes sense when run by a human being
- This can be changed later if other use cases pop up

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
