### PR TITLE
Fix quickstarts type mapping [CLI-55]

### DIFF
--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -254,27 +254,44 @@ func quickstartPathFor(client *management.Client) (p string, exists bool, err er
 	return target, exists, nil
 }
 
-func getQuickstart(typ, stack string) (quickstart, error) {
-	quickstarts, ok := quickstartsByType[typ]
+func getQuickstart(t, stack string) (quickstart, error) {
+	qsType := quickstartsTypeFor(t)
+	quickstarts, ok := quickstartsByType[qsType]
 	if !ok {
-		return quickstart{}, fmt.Errorf("unknown quickstart type %s", typ)
+		return quickstart{}, fmt.Errorf("unknown quickstart type %s", qsType)
 	}
 	for _, q := range quickstarts {
 		if q.Name == stack {
 			return q, nil
 		}
 	}
-	return quickstart{}, fmt.Errorf("quickstart not found for %s/%s", typ, stack)
+	return quickstart{}, fmt.Errorf("quickstart not found for %s/%s", qsType, stack)
 }
 
 func quickstartStacksFromType(t string) ([]string, error) {
-	_, ok := quickstartsByType[t]
+	qsType := quickstartsTypeFor(t)
+	_, ok := quickstartsByType[qsType]
 	if !ok {
-		return nil, fmt.Errorf("unknown quickstart type %s", t)
+		return nil, fmt.Errorf("unknown quickstart type %s", qsType)
 	}
-	stacks := make([]string, 0, len(quickstartsByType[t]))
-	for _, s := range quickstartsByType[t] {
+	stacks := make([]string, 0, len(quickstartsByType[qsType]))
+	for _, s := range quickstartsByType[qsType] {
 		stacks = append(stacks, s.Name)
 	}
 	return stacks, nil
+}
+
+func quickstartsTypeFor(v string) string {
+	switch {
+	case v == "native":
+		return "native"
+	case v == "spa":
+		return "spa"
+	case v == "regular_web":
+		return "webapp"
+	case v == "non_interactive":
+		return "backend"
+	default:
+		return "generic"
+	}
 }


### PR DESCRIPTION
### Description

This PR fixes the mapping of the keys used to look up into the QS dictionary (that comes from `quickstarts.json`).
The code was using the app type as key, while the json file has the following keys:

<img width="236" alt="Screen Shot 2021-03-05 at 17 43 36" src="https://user-images.githubusercontent.com/5055789/110171343-58238f00-7dda-11eb-9963-7ef026c1cb88.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
