### PR TITLE
tenants use shouldn't trigger logins

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,11 @@ func Execute() {
 				return nil
 			}
 
+			// Selecting tenants shouldn't really trigger a login.
+			if cmd.Use == "use" && cmd.Parent().Use == "tenants" {
+				return nil
+			}
+
 			// Initialize everything once. Later callers can then
 			// freely assume that config is fully primed and ready
 			// to go.

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -57,6 +57,7 @@ func useTenantCmd(cli *cli) *cobra.Command {
 			if err := cli.persistConfig(); err != nil {
 				return fmt.Errorf("An error occurred while setting the default tenant: %w", err)
 			}
+			cli.renderer.Infof("Default tenant switched to: %s", selectedTenant)
 			return nil
 		},
 	}


### PR DESCRIPTION
Since this command shouldn't really touch logins, it should ideally not
be part of the set of commands triggering `RunLogin`.

