### PR TITLE
apps: improve UX on create and show screens

### DIFF
--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -216,7 +216,14 @@ func (r *Renderer) ApplicationCreate(client *management.Client, revealSecrets bo
 
 	r.Result(v)
 
-	r.Infof("\nQuickstarts: %s", quickstartsURIFor(client.AppType))
+	r.Newline()
+	r.Infof("Quickstarts: %s", quickstartsURIFor(client.AppType))
+
+	// TODO(cyx): possibly guard this with a --no-hint flag.
+	r.Infof("%s: You might wanna try `auth0 test login --client-id %s`",
+		ansi.Faint("Hint"),
+		client.GetClientID(),
+	)
 }
 
 func (r *Renderer) ApplicationUpdate(client *management.Client, revealSecrets bool) {

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -39,6 +39,10 @@ func NewRenderer() *Renderer {
 	}
 }
 
+func (r *Renderer) Newline() {
+	fmt.Fprintln(r.MessageWriter)
+}
+
 func (r *Renderer) Infof(format string, a ...interface{}) {
 	fmt.Fprint(r.MessageWriter, aurora.Green(" ▸    "))
 	fmt.Fprintf(r.MessageWriter, format+"\n", a...)
@@ -105,7 +109,17 @@ func (r *Renderer) Result(data View) {
 		// many changes in other places. In the future we should
 		// enforce `KeyValues` on all `View` types.
 		if v, ok := data.(interface{ KeyValues() [][]string }); ok {
-			writeTable(r.ResultWriter, nil, v.KeyValues())
+			var kvs [][]string
+			for _, pair := range v.KeyValues() {
+				k := pair[0]
+				v := pair[1]
+
+				// NOTE(cyx): We can either nuke it or annotate with `<none>`. For now we're choosing to nuke it.
+				if v != "" {
+					kvs = append(kvs, []string{k, v})
+				}
+			}
+			writeTable(r.ResultWriter, nil, kvs)
 		}
 	}
 }


### PR DESCRIPTION
for create / update / show, we should utilize the key value display.

Similarly, add the hint to guide the user what to do next.

```
$ auth0 apps create
 Name: my awesome app
 Type: Regular Web Application
 Description: dev tester
Creating application... done

=== cyx application created

  NAME           my awesome app
  TYPE           regular web application
  CLIENT ID      vXAtoaFdhlmtWjpIrjb9AUnrGEAOH2MM
  CLIENT SECRET  <redacted>

 ▸    Quickstarts: https://auth0.com/docs/quickstart/webapp
 ▸    Hint: You might wanna try `auth0 test login --client-id vXAtoaFdhlmtWjpIrjb9AUnrGEAOH2MM`
```