### PR TITLE
Display all single views as list of key values

### DIFF
--- a/internal/display/actions.go
+++ b/internal/display/actions.go
@@ -22,12 +22,12 @@ func (v *actionView) AsTableHeader() []string {
 }
 
 func (v *actionView) AsTableRow() []string {
-	return []string{v.ID, v.Name, v.Type, v.CreatedAt}
+	return []string{ansi.Faint(v.ID), v.Name, v.Type, v.CreatedAt}
 }
 
 func (v *actionView) KeyValues() [][]string {
 	return [][]string{
-		[]string{"ID", v.ID},
+		[]string{"ID", ansi.Faint(v.ID)},
 		[]string{"NAME", v.Name},
 		[]string{"TYPE", v.Type},
 		[]string{"CREATED AT", v.CreatedAt},
@@ -49,7 +49,7 @@ func (v *triggerView) AsTableHeader() []string {
 }
 
 func (v *triggerView) AsTableRow() []string {
-	return []string{v.ID, v.ActionID, v.DisplayName}
+	return []string{ansi.Faint(v.ID), v.ActionID, v.DisplayName}
 }
 
 type actionVersionView struct {
@@ -70,13 +70,13 @@ func (v *actionVersionView) AsTableHeader() []string {
 }
 
 func (v *actionVersionView) AsTableRow() []string {
-	return []string{v.Number, v.getID(), v.ActionID, v.ActionName, v.Runtime, v.Status, v.CreatedAt, v.Deployed}
+	return []string{v.Number, ansi.Faint(v.getID()), v.ActionID, v.ActionName, v.Runtime, v.Status, v.CreatedAt, v.Deployed}
 }
 
 func (v *actionVersionView) KeyValues() [][]string {
 	return [][]string{
 		[]string{"Number", v.Number},
-		[]string{"ID", v.getID()},
+		[]string{"ID", ansi.Faint(v.getID())},
 		[]string{"ActionID", v.ActionID},
 		[]string{"ActionName", v.ActionName},
 		[]string{"RUNTIME", v.ActionName},
@@ -142,7 +142,7 @@ func (r *Renderer) Action(action *management.Action) {
 		raw:       action,
 	}
 
-	r.Results([]View{v})
+	r.Result(v)
 }
 
 func (r *Renderer) ActionTriggersList(bindings []*management.ActionBinding) {
@@ -185,7 +185,7 @@ func (r *Renderer) ActionVersion(version *management.ActionVersion) {
 
 	v := ActionVersionView(version)
 
-	r.Results([]View{v})
+	r.Result(v)
 }
 
 func (r *Renderer) ActionVersionList(list []*management.ActionVersion) {

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -28,7 +28,7 @@ func (v *apiView) AsTableRow() []string {
 
 func (v *apiView) KeyValues() [][]string {
 	return [][]string{
-		[]string{"ID", v.ID},
+		[]string{"ID", ansi.Faint(v.ID)},
 		[]string{"NAME", v.Name},
 		[]string{"IDENTIFIER", v.Identifier},
 		[]string{"SCOPES", strconv.Itoa(v.Scopes)},
@@ -58,12 +58,12 @@ func (r *Renderer) ApiShow(api *management.ResourceServer) {
 
 func (r *Renderer) ApiCreate(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API created\n")
-	r.Results([]View{makeApiView(api)})
+	r.Result(makeApiView(api))
 }
 
 func (r *Renderer) ApiUpdate(api *management.ResourceServer) {
 	r.Heading(ansi.Bold(r.Tenant), "API updated\n")
-	r.Results([]View{makeApiView(api)})
+	r.Result(makeApiView(api))
 }
 
 func makeApiView(api *management.ResourceServer) *apiView {


### PR DESCRIPTION
### Description

This PR displays all single views of `apis` and `actions` as list of key values.

<img width="450" alt="Screen Shot 2021-03-05 at 22 25 49" src="https://user-images.githubusercontent.com/5055789/110190731-810c4a00-7e03-11eb-8e20-28f383395e30.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
