### PR TITLE
feat: offer to add default urls for quickstart

### DIFF
--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -136,7 +136,7 @@ func downloadQuickstart(cli *cli) *cobra.Command {
 			cli.renderer.Infof("Quickstart sample sucessfully downloaded at %s", target)
 
 			qsType := quickstartsTypeFor(client.GetAppType())
-			if err := promptDefaultURLs(context.TODO(), cli, client, qsType); err != nil {
+			if err := promptDefaultURLs(cmd.Context(), cli, client, qsType); err != nil {
 				return err
 			}
 			return nil

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -35,10 +35,10 @@ var (
 
 // QuickStart app types and defaults
 const (
-	QSNative    = "native"
-	QSSpa       = "spa"
-	QSWebApp    = "webapp"
-	QSBackend   = "backend"
+	qsNative    = "native"
+	qsSpa       = "spa"
+	qsWebApp    = "webapp"
+	qsBackend   = "backend"
 	_defaultURL = "http://localhost:3000"
 )
 
@@ -299,13 +299,13 @@ func quickstartStacksFromType(t string) ([]string, error) {
 func quickstartsTypeFor(v string) string {
 	switch {
 	case v == "native":
-		return QSNative
+		return qsNative
 	case v == "spa":
-		return QSSpa
+		return qsSpa
 	case v == "regular_web":
-		return QSWebApp
+		return qsWebApp
 	case v == "non_interactive":
-		return QSBackend
+		return qsBackend
 	default:
 		return "generic"
 	}
@@ -316,7 +316,7 @@ func quickstartsTypeFor(v string) string {
 // If not, it prompts the user to add the default url and updates the application
 // if they accept.
 func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client, qsType string) error {
-	if !strings.EqualFold(qsType, QSSpa) && !strings.EqualFold(qsType, QSWebApp) {
+	if !strings.EqualFold(qsType, qsSpa) && !strings.EqualFold(qsType, qsWebApp) {
 		return nil
 	}
 	if containsStr(client.Callbacks, _defaultURL) || containsStr(client.AllowedLogoutURLs, _defaultURL) {
@@ -332,7 +332,7 @@ func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client,
 	if confirmed := prompt.Confirm(formatURLPrompt(qsType)); confirmed {
 		a.Callbacks = append(a.Callbacks, _defaultURL)
 		a.AllowedLogoutURLs = append(a.AllowedLogoutURLs, _defaultURL)
-		if strings.EqualFold(qsType, QSSpa) {
+		if strings.EqualFold(qsType, qsSpa) {
 			a.WebOrigins = append(a.WebOrigins, _defaultURL)
 		}
 		shouldUpdate = true
@@ -354,7 +354,7 @@ func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client,
 func formatURLPrompt(qsType string) string {
 	var p strings.Builder
 	p.WriteString("\nQuickstarts use localhost, do you want to add %s to the list of allowed callback URLs")
-	if strings.EqualFold(qsType, QSSpa) {
+	if strings.EqualFold(qsType, qsSpa) {
 		p.WriteString(", logout URLs, and web origins?")
 	} else {
 		p.WriteString(" and logout URLs?")

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -332,7 +332,9 @@ func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client,
 	if confirmed := prompt.Confirm(formatURLPrompt(qsType)); confirmed {
 		a.Callbacks = append(a.Callbacks, _defaultURL)
 		a.AllowedLogoutURLs = append(a.AllowedLogoutURLs, _defaultURL)
-		a.WebOrigins = append(a.WebOrigins, _defaultURL)
+		if strings.EqualFold(qsType, QSSpa) {
+			a.WebOrigins = append(a.WebOrigins, _defaultURL)
+		}
 		shouldUpdate = true
 	}
 	if shouldUpdate {

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -312,7 +312,7 @@ func quickstartsTypeFor(v string) string {
 }
 
 // promptDefaultURLs checks whether the application is SPA or WebApp and
-// whether the app has already default quickstart url to allowed url lists.
+// whether the app has already added the default quickstart url to allowed url lists.
 // If not, it prompts the user to add the default url and updates the application
 // if they accept.
 func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client, qsType string) error {

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -328,16 +328,14 @@ func promptDefaultURLs(ctx context.Context, cli *cli, client *management.Client,
 		WebOrigins:        client.WebOrigins,
 		AllowedLogoutURLs: client.AllowedLogoutURLs,
 	}
-	shouldUpdate := false
+
 	if confirmed := prompt.Confirm(formatURLPrompt(qsType)); confirmed {
 		a.Callbacks = append(a.Callbacks, _defaultURL)
 		a.AllowedLogoutURLs = append(a.AllowedLogoutURLs, _defaultURL)
 		if strings.EqualFold(qsType, qsSpa) {
 			a.WebOrigins = append(a.WebOrigins, _defaultURL)
 		}
-		shouldUpdate = true
-	}
-	if shouldUpdate {
+
 		err := ansi.Spinner("Updating application", func() error {
 			return cli.api.Client.Update(client.GetClientID(), a)
 		})

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -260,3 +260,13 @@ func generateState(size int) (string, error) {
 
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
+
+// check if slice contains a string
+func containsStr(s []interface{}, u string) bool {
+	for _, a := range s {
+		if a == u {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
### Description

Add prompts to update an application's allowed urls to include localhost:3000 after downloading quickstart. 

<img width="1151" alt="Screen Shot 2021-03-15 at 8 25 34 AM" src="https://user-images.githubusercontent.com/70534960/111169447-92262b00-8568-11eb-8c59-6ff5b3c4b7f9.png">


No prompt if the URLs have already been added
<img width="1133" alt="Screen Shot 2021-03-15 at 8 15 20 AM" src="https://user-images.githubusercontent.com/70534960/111169514-a538fb00-8568-11eb-9ed5-31e3a05b9caf.png">


- [x] Add prompts for adding url
- [x] Check if urls already exist before prompting

### References
https://github.com/auth0/auth0-cli/issues/128

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
