### PR TITLE
Use RS256 alg by default on new apps

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -176,6 +176,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 		Grants            []string
 	}
 	var oidcConformant = true
+	var algorithm = "RS256"
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -233,6 +234,7 @@ auth0 apps create --name myapp --type [native|spa|regular|m2m]
 				AllowedLogoutURLs:       stringToInterfaceSlice(flags.AllowedLogoutURLs),
 				TokenEndpointAuthMethod: apiAuthMethodFor(flags.AuthMethod),
 				OIDCConformant:          &oidcConformant,
+				JWTConfiguration:        &management.ClientJWTConfiguration{Algorithm: &algorithm},
 			}
 
 			if len(flags.Grants) == 0 {


### PR DESCRIPTION
### Description

This PR sets the alg to `RS256` on app creation by default, as API2 will use `HS256` otherwise.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
