### PR TITLE
Display empty KV fields

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -113,11 +113,7 @@ func (r *Renderer) Result(data View) {
 			for _, pair := range v.KeyValues() {
 				k := pair[0]
 				v := pair[1]
-
-				// NOTE(cyx): We can either nuke it or annotate with `<none>`. For now we're choosing to nuke it.
-				if v != "" {
-					kvs = append(kvs, []string{k, v})
-				}
+				kvs = append(kvs, []string{k, v})
 			}
 			writeTable(r.ResultWriter, nil, kvs)
 		}


### PR DESCRIPTION
### Description

We need to show even the empty fields on the key-list view, to signal that they're indeed empty and that is not the CLI that's not showing them.

<img width="484" alt="Screen Shot 2021-03-12 at 20 22 33" src="https://user-images.githubusercontent.com/5055789/111008825-b4555880-8370-11eb-9f80-9388c4c1de05.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
