### PR TITLE
[CLI-62] cli command to list tenants available

### DIFF
--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -2,9 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/olekukonko/tablewriter"
 	"os"
 
+	"github.com/olekukonko/tablewriter"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -39,8 +39,8 @@ func listTenantCmd(cli *cli) *cobra.Command {
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetHeader([]string{"Available tenants"})
 			for _, val := range tenNames {
-				b := []string{val}
-				table.Append(b)
+				res := []string{val}
+				table.Append(res)
 			}
 
 			table.Render()

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-
-	"github.com/olekukonko/tablewriter"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -25,25 +22,19 @@ func listTenantCmd(cli *cli) *cobra.Command {
 		Use: "list",
 		Short: "List your tenants",
 		Long: `auth0 tenants list`,
+		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			listTenant, err := cli.listTenants()
+			tens, err := cli.listTenants()
 			if err != nil {
 				return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
 			}
 
-			tenNames := make([]string, len(listTenant))
-			for i, t := range listTenant {
+			tenNames := make([]string, len(tens))
+			for i, t := range tens {
 				tenNames[i] = t.Name
 			}
 
-			table := tablewriter.NewWriter(os.Stdout)
-			table.SetHeader([]string{"Available tenants"})
-			for _, val := range tenNames {
-				res := []string{val}
-				table.Append(res)
-			}
-
-			table.Render()
+			cli.renderer.ShowTenants(tenNames)
 			return nil
 		},
 	}

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"os"
 
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
@@ -14,8 +16,40 @@ func tenantsCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.AddCommand(useTenantCmd(cli))
+	cmd.AddCommand(listTenantCmd(cli))
 	return cmd
 }
+
+func listTenantCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "list",
+		Short: "List your tenants",
+		Long: `auth0 tenants list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listTenant, err := cli.listTenants()
+			if err != nil {
+				return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+			}
+
+			tenNames := make([]string, len(listTenant))
+			for i, t := range listTenant {
+				tenNames[i] = t.Name
+			}
+
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Available tenants"})
+			for _, val := range tenNames {
+				b := []string{val}
+				table.Append(b)
+			}
+
+			table.Render()
+			return nil
+		},
+	}
+	return cmd
+}
+
 
 func useTenantCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/display/tenants.go
+++ b/internal/display/tenants.go
@@ -1,7 +1,5 @@
 package display
 
-//import "gopkg.in/auth0.v5"
-
 type tenantView struct {
 	Name 		string
 }

--- a/internal/display/tenants.go
+++ b/internal/display/tenants.go
@@ -1,0 +1,26 @@
+package display
+
+//import "gopkg.in/auth0.v5"
+
+type tenantView struct {
+	Name 		string
+}
+
+func (v *tenantView) AsTableHeader() []string {
+	return []string{"Available tenants"}
+}
+
+func (v *tenantView) AsTableRow() []string {
+	return []string{v.Name}
+}
+
+func (r *Renderer) ShowTenants(data []string) {
+	var results []View
+	for _, item := range data {
+		results = append(results, &tenantView{
+			Name: item,
+		})
+	}
+
+	r.Results(results)
+}


### PR DESCRIPTION
### Description

 add a command in internal/cli/tenants.go that lists in a table the tenants available to the user:

```
auth0 tenants list

+-------------------+
| AVAILABLE TENANTS |
+-------------------+
| bap-tenants       |
| bpoku             |
| test-bpoku        |
+-------------------+
```

### References

https://auth0team.atlassian.net/browse/CLI-62?atlOrigin=eyJpIjoiMTlhZjY0ZTY5NTk3NDFkMjk2NjNlZjAyMDg4M2ZlNTEiLCJwIjoiaiJ9

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X ] The correct base branch is being used, if not `master`
