### PR TITLE
fix: app row order

### DIFF
--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -51,7 +51,7 @@ func TestClientsListCmd(t *testing.T) {
 	expectTable(t, stdout.String(),
 		[]string{"CLIENT ID", "NAME", "TYPE"},
 		[][]string{
-			{"some-name", "generic", "some-id"},
+			{"some-id", "some-name", "generic"},
 		},
 	)
 }

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -142,16 +142,16 @@ func (v *applicationListView) AsTableHeader() []string {
 func (v *applicationListView) AsTableRow() []string {
 	if v.revealSecret {
 		return []string{
+			ansi.Faint(v.ClientID),
 			v.Name,
 			v.Type,
-			ansi.Faint(v.ClientID),
 			ansi.Italic(v.ClientSecret),
 		}
 	}
 	return []string{
+		ansi.Faint(v.ClientID),
 		v.Name,
 		v.Type,
-		ansi.Faint(v.ClientID),
 	}
 }
 


### PR DESCRIPTION
Fix apps row representation to match table header order:

**before**
![image](https://user-images.githubusercontent.com/11925502/111160554-f7821800-8578-11eb-99b4-31b8d443fec9.png)

**after**
![image](https://user-images.githubusercontent.com/11925502/111160593-010b8000-8579-11eb-8c1f-a21eb1a1d326.png)
