### PR TITLE
fix: extend select page size to the actual number of options

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -56,9 +56,12 @@ func BoolInput(name string, message string, help string, required bool) *survey.
 }
 
 func SelectInput(name string, message string, help string, options []string, required bool) *survey.Question {
+	// force options "page" size to full,
+	// since there's not visual clue about extra options.
+	pageSize := len(options)
 	input := &survey.Question{
 		Name:   name,
-		Prompt: &survey.Select{Message: message, Help: help, Options: options},
+		Prompt: &survey.Select{Message: message, Help: help, Options: options, PageSize: pageSize},
 	}
 
 	if required {


### PR DESCRIPTION
Since there's no a visual clue on the `prompter` about extra options available for "scrolling", auto-extend to the actual number of options.

**before**:

![image](https://user-images.githubusercontent.com/11925502/111162359-d8848580-857a-11eb-86f6-24f3a03c48e3.png)


**after**:
![image](https://user-images.githubusercontent.com/11925502/111162378-dc180c80-857a-11eb-9c0c-ff35f2f7bc8e.png)
