### PR TITLE
Fix passing client-id as a flag on qs download

### DIFF
--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -78,7 +78,7 @@ func downloadQuickstart(cli *cli) *cobra.Command {
 			prepareInteractivity(cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !shouldPrompt(cmd, "client-id") {
+			if !canPrompt(cmd) {
 				return errors.New("This command can only be run on interactive mode")
 			}
 


### PR DESCRIPTION
### Description

By using `!canPrompt(cmd)` instead of `!shouldPrompt(cmd, "client-id")`, it is possible to pass the client-id as a flag:

<img width="495" alt="Screen Shot 2021-03-16 at 22 07 37" src="https://user-images.githubusercontent.com/5055789/111399441-25b04680-86a4-11eb-9301-4728f1742f92.png">

Previously it resulted in an error.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
