### PR TITLE
change spinner behavior

### DIFF
--- a/internal/ansi/spinner.go
+++ b/internal/ansi/spinner.go
@@ -1,7 +1,6 @@
 package ansi
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -13,18 +12,30 @@ const (
 	spinnerTextDone     = "done"
 	spinnerTextFailed   = "failed"
 
-	spinnerColor = "red"
+	spinnerColor = "blue"
 )
 
+func Waiting(fn func() error) error {
+	return loading("", "", "", fn)
+}
+
 func Spinner(text string, fn func() error) error {
+	initialMsg := text + spinnerTextEllipsis + " "
+	doneMsg := initialMsg + spinnerTextDone
+	failMsg := initialMsg + spinnerTextFailed
+
+	return loading(initialMsg, doneMsg, failMsg, fn)
+}
+
+func loading(initialMsg, doneMsg, failMsg string, fn func() error) error {
 	done := make(chan struct{})
 	errc := make(chan error)
 	go func() {
 		defer close(done)
 
 		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
-		s.Prefix = text + spinnerTextEllipsis + " "
-		s.FinalMSG = s.Prefix + spinnerTextDone
+		s.Prefix = initialMsg
+		s.FinalMSG = doneMsg
 
 		if err := s.Color(spinnerColor); err != nil {
 			panic(err)
@@ -33,7 +44,7 @@ func Spinner(text string, fn func() error) error {
 		s.Start()
 		err := <-errc
 		if err != nil {
-			s.FinalMSG = s.Prefix + spinnerTextFailed
+			s.FinalMSG = failMsg
 		}
 
 		s.Stop()
@@ -42,6 +53,5 @@ func Spinner(text string, fn func() error) error {
 	err := fn()
 	errc <- err
 	<-done
-	fmt.Println()
 	return err
 }

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -121,7 +121,7 @@ Lists your existing applications. To create one try:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var list *management.ClientList
 
-			err := ansi.Spinner("Loading applications", func() error {
+			err := ansi.Waiting(func() error {
 				var err error
 				list, err = cli.api.Client.List()
 				return err
@@ -172,7 +172,7 @@ auth0 apps show <id>
 
 			a := &management.Client{ClientID: &inputs.ID}
 
-			err := ansi.Spinner("Loading application", func() error {
+			err := ansi.Waiting(func() error {
 				var err error
 				a, err = cli.api.Client.Read(inputs.ID)
 				return err
@@ -294,7 +294,7 @@ auth0 apps create --name myapp --type [native|spa|regular|m2m]
 				a.GrantTypes = apiGrantsFor(inputs.Grants)
 			}
 
-			err := ansi.Spinner("Creating application", func() error {
+			err := ansi.Waiting(func() error {
 				return cli.api.Client.Create(a)
 			})
 
@@ -382,7 +382,7 @@ auth0 apps update <id> --name myapp --type [native|spa|regular|m2m]
 
 			a := &management.Client{}
 
-			err := ansi.Spinner("Updating application", func() error {
+			err := ansi.Waiting(func() error {
 				current, err := cli.api.Client.Read(inputs.ID)
 
 				if err != nil {


### PR DESCRIPTION
As I use the CLI more, I find the spinner text that gets left behind
isn't actually useful -- it's only useful while it's happening.

After the message was completed, the user will have two states:

1. It was successful, at which point the informational text that tells
   them why they're waiting is no longer useful.
2. It failed, at which point, we'd also have separate error messages
   below the spinner text.

In summary, it's good to have the text in transient form, and clear it
out when done.

## Proposal

1. `Waiting` - used just to indicate that there's activity going on. No
   message necessary since after the wait, the outcome is obvious.

2. `Spinner` - same behavior as before. Useful for scenarios like
   deleting, since there's nothing to show after, and having the
   classic:

   `Deleting application... done`

   Text is better UX.

## Before

[![asciicast](https://asciinema.org/a/Cw29ogzHyw6XFvRvwE4asaGa8.svg)](https://asciinema.org/a/Cw29ogzHyw6XFvRvwE4asaGa8)

## After

[![asciicast](https://asciinema.org/a/Bh4goroRh3WLzTdw79aax2OFy.svg)](https://asciinema.org/a/Bh4goroRh3WLzTdw79aax2OFy)