### PR TITLE
While perusing found this subtle bug

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -366,7 +366,7 @@ func shouldPromptWhenFlagless(cmd *cobra.Command, flag string) bool {
 	isSet := false
 
 	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
-		if f.Changed {
+		if f.Name == flag && f.Changed {
 			isSet = true
 		}
 	})


### PR DESCRIPTION
We should be comparing the name as well.
