### PR TITLE
Refactor arguments in apps and apis commands [CLI-78]

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
@@ -10,11 +9,12 @@ import (
 	"gopkg.in/auth0.v5/management"
 )
 
-const (
-	apiID = "id"
-)
-
 var (
+	apiID = Argument{
+		Name:       "Id",
+		Help:       "Id of the API.",
+		IsRequired: true,
+	}
 	apiName = Flag{
 		Name:       "Name",
 		LongForm:   "name",
@@ -116,14 +116,8 @@ auth0 apis show <id>
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(apiID, "Id:", "Id of the API.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please include an API Id")
+				if err := apiID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]
@@ -232,14 +226,8 @@ auth0 apis update <id> --name myapi
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(apiID, "Id:", "Id of the API.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please include an API Id")
+				if err := apiID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]
@@ -314,14 +302,8 @@ auth0 apis delete <id>
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(apiID, "Id:", "Id of the API.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please include an API Id")
+				if err := apiID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]
@@ -364,14 +346,8 @@ auth0 apis scopes list <id>
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(apiID, "Id:", "Id of the API.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please include an API Id")
+				if err := apiID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -12,11 +11,12 @@ import (
 	"gopkg.in/auth0.v5/management"
 )
 
-const (
-	appID = "id"
-)
-
 var (
+	appID = Argument{
+		Name:       "Client ID",
+		Help:       "Id of the application.",
+		IsRequired: true,
+	}
 	appName = Flag{
 		Name:       "Name",
 		LongForm:   "name",
@@ -157,14 +157,8 @@ auth0 apps show <id>
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(appID, "Client Id:", "Id of the application.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please provide an application Id")
+				if err := appID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]
@@ -209,14 +203,8 @@ auth0 apps delete <id>
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(appID, "Client Id:", "Id of the application.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please provide an application Id")
+				if err := appID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]
@@ -351,14 +339,8 @@ auth0 apps update <id> --name myapp --type [native|spa|regular|m2m]
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				if canPrompt(cmd) {
-					input := prompt.TextInput(appID, "Client Id:", "Id of the application.", true)
-
-					if err := prompt.AskOne(input, &inputs); err != nil {
-						return fmt.Errorf("An unexpected error occurred: %w", err)
-					}
-				} else {
-					return errors.New("Please provide an application Id")
+				if err := appID.Ask(cmd, &inputs.ID); err != nil {
+					return err
 				}
 			} else {
 				inputs.ID = args[0]

--- a/internal/cli/arguments.go
+++ b/internal/cli/arguments.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type Argument struct {
+	Name       string
+	Help       string
+	IsRequired bool
+}
+
+func (a Argument) GetName() string {
+	return a.Name
+}
+
+func (a Argument) GetLabel() string {
+	return inputLabel(a.Name)
+}
+
+func (a Argument) GetHelp() string {
+	return a.Help
+}
+
+func (a Argument) GetIsInputRequired() bool {
+	return a.IsRequired
+}
+
+func (a *Argument) Ask(cmd *cobra.Command, value interface{}) error {
+	return askArgument(cmd, a, value)
+}
+
+func askArgument(cmd *cobra.Command, i CommandInput, value interface{}) error {
+	if canPrompt(cmd) {
+		return ask(cmd, i, value, true)
+	} else {
+		return fmt.Errorf("Missing a required argument: %s", i.GetName())
+	}
+}

--- a/internal/cli/arguments.go
+++ b/internal/cli/arguments.go
@@ -24,7 +24,7 @@ func (a Argument) GetHelp() string {
 	return a.Help
 }
 
-func (a Argument) GetIsInputRequired() bool {
+func (a Argument) GetIsRequired() bool {
 	return a.IsRequired
 }
 

--- a/internal/cli/arguments.go
+++ b/internal/cli/arguments.go
@@ -32,7 +32,7 @@ func (a *Argument) Ask(cmd *cobra.Command, value interface{}) error {
 	return askArgument(cmd, a, value)
 }
 
-func askArgument(cmd *cobra.Command, i CommandInput, value interface{}) error {
+func askArgument(cmd *cobra.Command, i commandInput, value interface{}) error {
 	if canPrompt(cmd) {
 		return ask(cmd, i, value, true)
 	} else {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -26,7 +26,7 @@ func (f Flag) GetHelp() string {
 	return f.Help
 }
 
-func (f Flag) GetIsInputRequired() bool {
+func (f Flag) GetIsRequired() bool {
 	return f.IsRequired
 }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -88,7 +88,7 @@ func askFlag(cmd *cobra.Command, f *Flag, value interface{}, isUpdate bool) erro
 
 func selectFlag(cmd *cobra.Command, f *Flag, value interface{}, options []string, isUpdate bool) error {
 	if shouldAsk(cmd, f, isUpdate) {
-		_select(cmd, f, value, options, isUpdate)
+		return _select(cmd, f, value, options, isUpdate)
 	}
 
 	return nil

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,20 +14,36 @@ type Flag struct {
 	IsRequired bool
 }
 
+func (f Flag) GetName() string {
+	return f.Name
+}
+
+func (f Flag) GetLabel() string {
+	return inputLabel(f.Name)
+}
+
+func (f Flag) GetHelp() string {
+	return f.Help
+}
+
+func (f Flag) GetIsInputRequired() bool {
+	return f.IsRequired
+}
+
 func (f *Flag) Ask(cmd *cobra.Command, value interface{}) error {
-	return askInput(cmd, f, value, false)
+	return askFlag(cmd, f, value, false)
 }
 
 func (f *Flag) AskU(cmd *cobra.Command, value interface{}) error {
-	return askInput(cmd, f, value, true)
+	return askFlag(cmd, f, value, true)
 }
 
 func (f *Flag) Select(cmd *cobra.Command, value interface{}, options []string) error {
-	return selectInput(cmd, f, value, options, false)
+	return selectFlag(cmd, f, value, options, false)
 }
 
 func (f *Flag) SelectU(cmd *cobra.Command, value interface{}, options []string) error {
-	return selectInput(cmd, f, value, options, true)
+	return selectFlag(cmd, f, value, options, true)
 }
 
 func (f *Flag) RegisterString(cmd *cobra.Command, value *string, defaultValue string) {
@@ -51,6 +66,10 @@ func (f *Flag) RegisterInt(cmd *cobra.Command, value *int, defaultValue int) {
 	registerInt(cmd, f, value, defaultValue, false)
 }
 
+func (f *Flag) RegisterIntU(cmd *cobra.Command, value *int, defaultValue int) {
+	registerInt(cmd, f, value, defaultValue, true)
+}
+
 func (f *Flag) RegisterBool(cmd *cobra.Command, value *bool, defaultValue bool) {
 	registerBool(cmd, f, value, defaultValue, false)
 }
@@ -59,36 +78,28 @@ func (f *Flag) RegisterBoolU(cmd *cobra.Command, value *bool, defaultValue bool)
 	registerBool(cmd, f, value, defaultValue, true)
 }
 
-func (f *Flag) RegisterIntU(cmd *cobra.Command, value *int, defaultValue int) {
-	registerInt(cmd, f, value, defaultValue, true)
-}
-
-func (f *Flag) label() string {
-	return fmt.Sprintf("%s:", f.Name)
-}
-
-func askInput(cmd *cobra.Command, f *Flag, value interface{}, isUpdate bool) error {
+func askFlag(cmd *cobra.Command, f *Flag, value interface{}, isUpdate bool) error {
 	if shouldAsk(cmd, f, isUpdate) {
-		input := prompt.TextInput("", f.label(), f.Help, f.IsRequired)
-
-		if err := prompt.AskOne(input, value); err != nil {
-			return unexpectedError(err)
-		}
+		return ask(cmd, f, value, isUpdate)
 	}
 
 	return nil
 }
 
-func selectInput(cmd *cobra.Command, f *Flag, value interface{}, options []string, isUpdate bool) error {
+func selectFlag(cmd *cobra.Command, f *Flag, value interface{}, options []string, isUpdate bool) error {
 	if shouldAsk(cmd, f, isUpdate) {
-		input := prompt.SelectInput("", f.label(), f.Help, options, f.IsRequired)
-
-		if err := prompt.AskOne(input, value); err != nil {
-			return unexpectedError(err)
-		}
+		_select(cmd, f, value, options, isUpdate)
 	}
 
 	return nil
+}
+
+func shouldAsk(cmd *cobra.Command, f *Flag, isUpdate bool) bool {
+	if isUpdate {
+		return shouldPromptWhenFlagless(cmd, f.LongForm)
+	}
+
+	return shouldPrompt(cmd, f.LongForm)
 }
 
 func registerString(cmd *cobra.Command, f *Flag, value *string, defaultValue string, isUpdate bool) {
@@ -121,14 +132,6 @@ func registerBool(cmd *cobra.Command, f *Flag, value *bool, defaultValue bool, i
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
 		panic(unexpectedError(err)) // TODO: Handle
 	}
-}
-
-func shouldAsk(cmd *cobra.Command, f *Flag, isUpdate bool) bool {
-	if isUpdate {
-		return shouldPromptWhenFlagless(cmd, f.LongForm)
-	}
-
-	return shouldPrompt(cmd, f.LongForm)
 }
 
 func markFlagRequired(cmd *cobra.Command, f *Flag, isUpdate bool) error {

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -7,14 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type CommandInput interface {
+type commandInput interface {
 	GetName() string
 	GetLabel() string
 	GetHelp() string
 	GetIsRequired() bool
 }
 
-func ask(cmd *cobra.Command, i CommandInput, value interface{}, isUpdate bool) error {
+func ask(cmd *cobra.Command, i commandInput, value interface{}, isUpdate bool) error {
 	isRequired := !isUpdate && i.GetIsRequired()
 	input := prompt.TextInput("", i.GetLabel(), i.GetHelp(), isRequired)
 
@@ -25,7 +25,7 @@ func ask(cmd *cobra.Command, i CommandInput, value interface{}, isUpdate bool) e
 	return nil
 }
 
-func _select(cmd *cobra.Command, i CommandInput, value interface{}, options []string, isUpdate bool) error {
+func _select(cmd *cobra.Command, i commandInput, value interface{}, options []string, isUpdate bool) error {
 	isRequired := !isUpdate && i.GetIsRequired()
 	input := prompt.SelectInput("", i.GetLabel(), i.GetHelp(), options, isRequired)
 

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/auth0-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+type CommandInput interface {
+	GetName() string
+	GetLabel() string
+	GetHelp() string
+	GetIsInputRequired() bool
+}
+
+func ask(cmd *cobra.Command, i CommandInput, value interface{}, isUpdate bool) error {
+	isRequired := !isUpdate && i.GetIsInputRequired()
+	input := prompt.TextInput("", i.GetLabel(), i.GetHelp(), isRequired)
+
+	if err := prompt.AskOne(input, value); err != nil {
+		return unexpectedError(err)
+	}
+
+	return nil
+}
+
+func _select(cmd *cobra.Command, i CommandInput, value interface{}, options []string, isUpdate bool) error {
+	isRequired := !isUpdate && i.GetIsInputRequired()
+	input := prompt.SelectInput("", i.GetLabel(), i.GetHelp(), options, isRequired)
+
+	if err := prompt.AskOne(input, value); err != nil {
+		return unexpectedError(err)
+	}
+
+	return nil
+}
+
+func inputLabel(name string) string {
+	return fmt.Sprintf("%s:", name)
+}

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -11,11 +11,11 @@ type CommandInput interface {
 	GetName() string
 	GetLabel() string
 	GetHelp() string
-	GetIsInputRequired() bool
+	GetIsRequired() bool
 }
 
 func ask(cmd *cobra.Command, i CommandInput, value interface{}, isUpdate bool) error {
-	isRequired := !isUpdate && i.GetIsInputRequired()
+	isRequired := !isUpdate && i.GetIsRequired()
 	input := prompt.TextInput("", i.GetLabel(), i.GetHelp(), isRequired)
 
 	if err := prompt.AskOne(input, value); err != nil {
@@ -26,7 +26,7 @@ func ask(cmd *cobra.Command, i CommandInput, value interface{}, isUpdate bool) e
 }
 
 func _select(cmd *cobra.Command, i CommandInput, value interface{}, options []string, isUpdate bool) error {
-	isRequired := !isUpdate && i.GetIsInputRequired()
+	isRequired := !isUpdate && i.GetIsRequired()
 	input := prompt.SelectInput("", i.GetLabel(), i.GetHelp(), options, isRequired)
 
 	if err := prompt.AskOne(input, value); err != nil {


### PR DESCRIPTION
### Description

This command encapsulates and extracts the repetitive logic to define and prompt for the value of arguments on `apps` and `apis` commands.

Each argument is defined once in a struct instance that acts as a single source of truth for all the commands of a given resource.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
