### PR TITLE
Render userinfo as json [CLI-73]

### DIFF
--- a/internal/display/try_login.go
+++ b/internal/display/try_login.go
@@ -3,13 +3,11 @@ package display
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
-	"strconv"
-	"time"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth/authutil"
-	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
 type userInfoAndTokens struct {
@@ -27,94 +25,20 @@ func isNotZero(v interface{}) bool {
 }
 
 func (r *Renderer) TryLogin(u *authutil.UserInfo, t *authutil.TokenResponse) {
-	r.Heading(ansi.Bold(auth0.StringValue(u.Sub)), "/userinfo\n")
+	r.Heading(ansi.Bold(r.Tenant), "/userinfo\n")
+
+	out := &userInfoAndTokens{UserInfo: u, Tokens: t}
+	b, err := json.MarshalIndent(out, "", "    ")
+	if err != nil {
+		r.Errorf("couldn't marshal results as JSON: %v", err)
+		return
+	}
+	jsonStr := string(b)
 
 	switch r.Format {
 	case OutputFormatJSON:
-		out := &userInfoAndTokens{UserInfo: u, Tokens: t}
-		b, err := json.MarshalIndent(out, "", "    ")
-		if err != nil {
-			r.Errorf("couldn't marshal results as JSON: %v", err)
-			return
-		}
-		fmt.Fprint(r.ResultWriter, string(b))
+		fmt.Fprint(r.ResultWriter, jsonStr)
 	default:
-		rows := make([][]string, 0)
-
-		// TODO: make this less verbose
-		if isNotZero(u.Name) {
-			rows = append(rows, []string{ansi.Faint("Name"), auth0.StringValue(u.Name)})
-		}
-		if isNotZero(u.GivenName) {
-			rows = append(rows, []string{ansi.Faint("GivenName"), auth0.StringValue(u.GivenName)})
-		}
-		if isNotZero(u.MiddleName) {
-			rows = append(rows, []string{ansi.Faint("MiddleName"), auth0.StringValue(u.MiddleName)})
-		}
-		if isNotZero(u.FamilyName) {
-			rows = append(rows, []string{ansi.Faint("FamilyName"), auth0.StringValue(u.FamilyName)})
-		}
-		if isNotZero(u.Nickname) {
-			rows = append(rows, []string{ansi.Faint("Nickname"), auth0.StringValue(u.Nickname)})
-		}
-		if isNotZero(u.PreferredUsername) {
-			rows = append(rows, []string{ansi.Faint("PreferredUsername"), auth0.StringValue(u.PreferredUsername)})
-		}
-		if isNotZero(u.Profile) {
-			rows = append(rows, []string{ansi.Faint("Profile"), auth0.StringValue(u.Profile)})
-		}
-		if isNotZero(u.Picture) {
-			rows = append(rows, []string{ansi.Faint("Picture"), auth0.StringValue(u.Picture)})
-		}
-		if isNotZero(u.Website) {
-			rows = append(rows, []string{ansi.Faint("Website"), auth0.StringValue(u.Website)})
-		}
-		if isNotZero(u.PhoneNumber) {
-			rows = append(rows, []string{ansi.Faint("PhoneNumber"), auth0.StringValue(u.PhoneNumber)})
-		}
-		if isNotZero(u.PhoneVerified) {
-			rows = append(rows, []string{ansi.Faint("PhoneVerified"), strconv.FormatBool(auth0.BoolValue(u.PhoneVerified))})
-		}
-		if isNotZero(u.Email) {
-			rows = append(rows, []string{ansi.Faint("Email"), auth0.StringValue(u.Email)})
-		}
-		if isNotZero(u.EmailVerified) {
-			rows = append(rows, []string{ansi.Faint("EmailVerified"), strconv.FormatBool(auth0.BoolValue(u.EmailVerified))})
-		}
-		if isNotZero(u.Gender) {
-			rows = append(rows, []string{ansi.Faint("Gender"), auth0.StringValue(u.Gender)})
-		}
-		if isNotZero(u.BirthDate) {
-			rows = append(rows, []string{ansi.Faint("BirthDate"), auth0.StringValue(u.BirthDate)})
-		}
-		if isNotZero(u.ZoneInfo) {
-			rows = append(rows, []string{ansi.Faint("ZoneInfo"), auth0.StringValue(u.ZoneInfo)})
-		}
-		if isNotZero(u.Locale) {
-			rows = append(rows, []string{ansi.Faint("Locale"), auth0.StringValue(u.Locale)})
-		}
-		if isNotZero(u.UpdatedAt) {
-			rows = append(rows, []string{ansi.Faint("UpdatedAt"), auth0.TimeValue(u.UpdatedAt).Format(time.RFC3339)})
-		}
-		if isNotZero(t.AccessToken) {
-			rows = append(rows, []string{ansi.Faint("AccessToken"), t.AccessToken})
-		}
-		if isNotZero(t.RefreshToken) {
-			rows = append(rows, []string{ansi.Faint("RefreshToken"), t.RefreshToken})
-		}
-		// TODO: This is a long string and it messes up formatting when printed
-		// to the table, so need to come back to this one and fix it later.
-		// if isNotZero(t.IDToken) {
-		// 	rows = append(rows, []string{ansi.Faint("IDToken"), t.IDToken})
-		// }
-		if isNotZero(t.TokenType) {
-			rows = append(rows, []string{ansi.Faint("TokenType"), t.TokenType})
-		}
-		if isNotZero(t.ExpiresIn) {
-			rows = append(rows, []string{ansi.Faint("ExpiresIn"), strconv.FormatInt(t.ExpiresIn, 10)})
-		}
-
-		tableHeader := []string{"Field", "Value"}
-		writeTable(r.ResultWriter, tableHeader, rows)
+		fmt.Fprintln(r.ResultWriter, ansi.ColorizeJSON(jsonStr, false, os.Stdout))
 	}
 }


### PR DESCRIPTION
### Description

This PR changes the rendering logic for the `auth0 test login` command to render the userinfo response as JSON.

<img width="722" alt="Screen Shot 2021-03-20 at 19 22 28" src="https://user-images.githubusercontent.com/5055789/111887555-7978a380-89b4-11eb-8143-8a97fa71afe0.png">

### References

Closes https://github.com/auth0/auth0-cli/issues/159

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
