### PR TITLE
Add empty states [CLI-33]

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -96,15 +96,13 @@ func askFlag(cmd *cobra.Command, f *Flag, value interface{}, defaultValue *strin
 }
 
 func askManyFlag(cmd *cobra.Command, f *Flag, value interface{}, defaultValue *string, isUpdate bool) error {
-	var strInput struct {
-		value string
-	}
+	var strInput string
 
-	if err := askFlag(cmd, f, &strInput.value, defaultValue, isUpdate); err != nil {
+	if err := askFlag(cmd, f, &strInput, defaultValue, isUpdate); err != nil {
 		return err
 	}
 
-	*value.(*[]string) = commaSeparatedStringToSlice(strInput.value)
+	*value.(*[]string) = commaSeparatedStringToSlice(strInput)
 
 	return nil
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -34,7 +34,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) error {
 	if expired {
 		cli.renderer.Warnf("Please sign in to re-authorize the CLI.")
 	} else {
-		cli.renderer.Heading("✪ Welcome to the Auth0 CLI 🎊.")
+		cli.renderer.Infof("✪ Welcome to the Auth0 CLI 🎊.")
 		cli.renderer.Infof("To set it up, you will need to sign in to your Auth0 account and authorize the CLI to access the API.")
 		cli.renderer.Infof("If you don't have an account, please go to https://auth0.com/signup, otherwise continue in the browser.\n\n")
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/buildinfo"
 	"github.com/auth0/auth0-cli/internal/display"
 	"github.com/spf13/cobra"
@@ -95,11 +94,7 @@ func Execute() {
 	// rootCmd.AddCommand(triggersCmd(cli))
 
 	if err := rootCmd.ExecuteContext(context.TODO()); err != nil {
-		header := []string{"error\n"}
-		if cli.tenant != "" {
-			header = append([]string{ansi.Bold(cli.tenant)}, header...)
-		}
-		cli.renderer.Heading(header...)
+		cli.renderer.Heading("error")
 		cli.renderer.Errorf(err.Error())
 		os.Exit(1)
 	}

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -40,7 +40,15 @@ func (v *apiView) Object() interface{} {
 }
 
 func (r *Renderer) ApiList(apis []*management.ResourceServer) {
-	r.Heading(ansi.Bold(r.Tenant), "APIs\n")
+	resource := "APIs"
+
+	r.Heading(resource)
+
+	if len(apis) == 0 {
+		r.EmptyState(resource)
+		r.Infof("Use 'auth0 apis create' to add one")
+		return
+	}
 
 	results := []View{}
 
@@ -52,17 +60,17 @@ func (r *Renderer) ApiList(apis []*management.ResourceServer) {
 }
 
 func (r *Renderer) ApiShow(api *management.ResourceServer) {
-	r.Heading(ansi.Bold(r.Tenant), "API\n")
+	r.Heading("API")
 	r.Result(makeApiView(api))
 }
 
 func (r *Renderer) ApiCreate(api *management.ResourceServer) {
-	r.Heading(ansi.Bold(r.Tenant), "API created\n")
+	r.Heading("API created")
 	r.Result(makeApiView(api))
 }
 
 func (r *Renderer) ApiUpdate(api *management.ResourceServer) {
-	r.Heading(ansi.Bold(r.Tenant), "API updated\n")
+	r.Heading("API updated")
 	r.Result(makeApiView(api))
 }
 
@@ -93,7 +101,14 @@ func (v *scopeView) AsTableRow() []string {
 }
 
 func (r *Renderer) ScopesList(api string, scopes []*management.ResourceServerScope) {
-	r.Heading(ansi.Bold(r.Tenant), fmt.Sprintf("Scopes of %s\n", ansi.Bold(api)))
+	resource := "scopes"
+
+	r.Heading(fmt.Sprintf("%s of %s", resource, ansi.Bold(api)))
+
+	if len(scopes) == 0 {
+		r.EmptyState(resource)
+		return
+	}
 
 	results := []View{}
 

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -157,7 +157,16 @@ func (v *applicationListView) AsTableRow() []string {
 }
 
 func (r *Renderer) ApplicationList(clients []*management.Client) {
-	r.Heading(ansi.Bold(r.Tenant), "applications\n")
+	resource := "applications"
+
+	r.Heading(resource)
+
+	if len(clients) == 0 {
+		r.EmptyState(resource)
+		r.Infof("Use 'auth0 apps create' to add one")
+		return
+	}
+
 	var res []View
 	for _, c := range clients {
 		if auth0.StringValue(c.Name) == deprecatedAppName {
@@ -175,7 +184,7 @@ func (r *Renderer) ApplicationList(clients []*management.Client) {
 }
 
 func (r *Renderer) ApplicationShow(client *management.Client, revealSecrets bool) {
-	r.Heading(ansi.Bold(r.Tenant), "application\n")
+	r.Heading("application")
 
 	v := &applicationView{
 		revealSecret:      revealSecrets,
@@ -197,7 +206,7 @@ func (r *Renderer) ApplicationShow(client *management.Client, revealSecrets bool
 }
 
 func (r *Renderer) ApplicationCreate(client *management.Client, revealSecrets bool) {
-	r.Heading(ansi.Bold(r.Tenant), "application created\n")
+	r.Heading("application created")
 
 	v := &applicationView{
 		revealSecret:      revealSecrets,
@@ -221,14 +230,14 @@ func (r *Renderer) ApplicationCreate(client *management.Client, revealSecrets bo
 	r.Infof("Quickstarts: %s", quickstartsURIFor(client.AppType))
 
 	// TODO(cyx): possibly guard this with a --no-hint flag.
-	r.Infof("%s: You might wanna try `auth0 test login --client-id %s`",
-		ansi.Faint("Hint"),
+	r.Infof("%s You might want to try 'auth0 test login --client-id %s'",
+		ansi.Faint("Hint:"),
 		client.GetClientID(),
 	)
 }
 
 func (r *Renderer) ApplicationUpdate(client *management.Client, revealSecrets bool) {
-	r.Heading(ansi.Bold(r.Tenant), "application updated\n")
+	r.Heading("application updated")
 
 	v := &applicationView{
 		revealSecret:      revealSecrets,

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -59,7 +59,12 @@ func (r *Renderer) Errorf(format string, a ...interface{}) {
 }
 
 func (r *Renderer) Heading(text ...string) {
-	fmt.Fprintf(r.MessageWriter, "\n%s %s\n", ansi.Faint("==="), strings.Join(text, " "))
+	heading := fmt.Sprintf("%s %s\n", ansi.Bold(r.Tenant), strings.Join(text, " "))
+	fmt.Fprintf(r.MessageWriter, "\n%s %s\n", ansi.Faint("==="), heading)
+}
+
+func (r *Renderer) EmptyState(resource string) {
+	fmt.Fprintf(r.MessageWriter, "No %s available.\n", resource)
 }
 
 type View interface {

--- a/internal/display/get_token.go
+++ b/internal/display/get_token.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (r *Renderer) GetToken(c *management.Client, t *authutil.TokenResponse) {
-	r.Heading(ansi.Bold(auth0.StringValue(c.Name)), "tokens\n")
+	r.Heading(fmt.Sprintf("tokens for %s", auth0.StringValue(c.Name)))
 
 	switch r.Format {
 	case OutputFormatJSON:

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -147,10 +147,14 @@ func (v *logView) typeDesc() (typ, desc string) {
 }
 
 func (r *Renderer) LogList(logs []*management.Log, ch <-chan []*management.Log, api auth0.ActionExecutionAPI, noColor, silent bool) {
-	r.Heading(ansi.Bold(r.Tenant), "logs\n")
+	resource := "logs"
 
-	if len(logs) < 1 {
-		r.Infof("No logs found; to generate logs, run a test command like `auth0 test login` or `auth0 test token`")
+	r.Heading(resource)
+
+	if len(logs) == 0 {
+		r.EmptyState(resource)
+		r.Infof("To generate logs, run a test command like 'auth0 test login' or 'auth0 test token'")
+		return
 	}
 
 	var res []View

--- a/internal/display/rules.go
+++ b/internal/display/rules.go
@@ -41,7 +41,16 @@ func (v *ruleView) Object() interface{} {
 }
 
 func (r *Renderer) RulesList(rules []*management.Rule) {
-	r.Heading(ansi.Bold(r.Tenant), "rules\n")
+	resource := "rules"
+
+	r.Heading(resource)
+
+	if len(rules) == 0 {
+		r.EmptyState(resource)
+		r.Infof("Use 'auth0 rules create' to add one")
+		return
+	}
+
 	var res []View
 
 	//@TODO Provide sort options via flags
@@ -63,28 +72,28 @@ func (r *Renderer) RulesList(rules []*management.Rule) {
 }
 
 func (r *Renderer) RuleCreate(rule *management.Rule) {
-	r.Heading(ansi.Bold(r.Tenant), "rule created\n")
+	r.Heading("rule created")
 	r.Result(makeRuleView(rule))
 	r.Newline()
 
 	// TODO(cyx): possibly guard this with a --no-hint flag.
-	r.Infof("%s: To edit this rule, do `auth0 rules update %s`",
-		ansi.Faint("Hint"),
+	r.Infof("%s To edit this rule, do 'auth0 rules update %s'",
+		ansi.Faint("Hint:"),
 		rule.GetID(),
 	)
 
-	r.Infof("%s: You might wanna try `auth0 test login",
-		ansi.Faint("Hint"),
+	r.Infof("%s You might wanna try 'auth0 test login'",
+		ansi.Faint("Hint:"),
 	)
 }
 
 func (r *Renderer) RuleUpdate(rule *management.Rule) {
-	r.Heading(ansi.Bold(r.Tenant), "rule updated\n")
+	r.Heading("rule updated")
 	r.Result(makeRuleView(rule))
 }
 
 func (r *Renderer) RuleShow(rule *management.Rule) {
-	r.Heading(ansi.Bold(r.Tenant), "rule\n")
+	r.Heading("rule")
 	r.Result(makeRuleView(rule))
 }
 

--- a/internal/display/tenants.go
+++ b/internal/display/tenants.go
@@ -13,6 +13,8 @@ func (v *tenantView) AsTableRow() []string {
 }
 
 func (r *Renderer) ShowTenants(data []string) {
+	r.Heading()
+
 	var results []View
 	for _, item := range data {
 		results = append(results, &tenantView{

--- a/internal/display/try_login.go
+++ b/internal/display/try_login.go
@@ -25,7 +25,7 @@ func isNotZero(v interface{}) bool {
 }
 
 func (r *Renderer) TryLogin(u *authutil.UserInfo, t *authutil.TokenResponse) {
-	r.Heading(ansi.Bold(r.Tenant), "/userinfo\n")
+	r.Heading("/userinfo")
 
 	out := &userInfoAndTokens{UserInfo: u, Tokens: t}
 	b, err := json.MarshalIndent(out, "", "    ")


### PR DESCRIPTION
### Description

This PR adds empty states for `apps`, `apis`, and `rules`. Also refactors the heading display logic to always include the current active tenant, to avoid having to copy and paste it everywhere. And adds the heading to the output of a command that was missing it (`tenants list`).

<img width="458" alt="Screen Shot 2021-03-22 at 13 19 12" src="https://user-images.githubusercontent.com/5055789/112022601-36801280-8b11-11eb-88a4-1637c0f418ea.png">

<img width="364" alt="Screen Shot 2021-03-22 at 12 34 24" src="https://user-images.githubusercontent.com/5055789/112022445-15b7bd00-8b11-11eb-9ce1-25ffe41728bc.png">

<img width="328" alt="Screen Shot 2021-03-22 at 12 32 28" src="https://user-images.githubusercontent.com/5055789/112022468-19e3da80-8b11-11eb-83ac-a312bf9c2617.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
