### PR TITLE
Prompt for allowed origins on SPA creation/update [CLI-105]

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -70,6 +70,7 @@ var (
 		ShortForm:  "o",
 		Help:       "Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.",
 		IsRequired: false,
+		AlwaysPrompt: true,
 	}
 	appWebOrigins = Flag{
 		Name:         "Allowed Web Origin URLs",
@@ -305,6 +306,15 @@ auth0 apps create --name myapp --type [native|spa|regular|m2m]
 				}
 			}
 
+			// Prompt for allowed origins URLs if app is SPA
+			if appIsSPA {
+				defaultValue := appDefaultURL
+
+				if err := appOrigins.AskMany(cmd, &inputs.AllowedOrigins, &defaultValue); err != nil {
+					return err
+				}
+			}
+
 			// Prompt for allowed web origins URLs if app is SPA
 			if appIsSPA {
 				defaultValue := appDefaultURL
@@ -454,6 +464,19 @@ auth0 apps update <id> --name myapp --type [native|spa|regular|m2m]
 				}
 
 				if err := appLogoutURLs.AskManyU(cmd, &inputs.AllowedLogoutURLs, &defaultValue); err != nil {
+					return err
+				}
+			}
+
+			// Prompt for allowed origins URLs if app is SPA
+			if appIsSPA {
+				defaultValue := appDefaultURL
+
+				if len(current.AllowedOrigins) > 0 {
+					defaultValue = stringSliceToCommaSeparatedString(interfaceToStringSlice(current.AllowedOrigins))
+				}
+
+				if err := appOrigins.AskManyU(cmd, &inputs.AllowedOrigins, &defaultValue); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
### Description

This PR adds support for prompting for Allowed Origins when creating or updating a SPA.

<img width="694" alt="Screen Shot 2021-03-26 at 23 26 38" src="https://user-images.githubusercontent.com/5055789/112707589-56099900-8e8b-11eb-8030-7da7c6b30ae8.png">

<img width="486" alt="Screen Shot 2021-03-26 at 23 28 12" src="https://user-images.githubusercontent.com/5055789/112707593-5a35b680-8e8b-11eb-87fc-4db6ab3ff1e5.png">

<img width="666" alt="Screen Shot 2021-03-26 at 23 28 48" src="https://user-images.githubusercontent.com/5055789/112707596-5c981080-8e8b-11eb-9295-6d37f2ae35f3.png">

### References

Fixes https://github.com/auth0/auth0-cli/issues/193

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`