### PR TITLE
Special case the Next.js callback URL on `qs download` [CLI-111]

### DIFF
--- a/internal/ansi/spinner.go
+++ b/internal/ansi/spinner.go
@@ -36,6 +36,7 @@ func loading(initialMsg, doneMsg, failMsg string, fn func() error) error {
 		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 		s.Prefix = initialMsg
 		s.FinalMSG = doneMsg
+		s.HideCursor = true
 
 		if err := s.Color(spinnerColor); err != nil {
 			panic(err)


### PR DESCRIPTION
### Description

- When the stack is `Next.js`, checks if the callback URLs contain `http://localhost:3000/api/auth/callback`. If not, prompts to add that URL to the callbacks while keeping `http://localhost:3000` for the rest of the URLs.
- Fixes the previous logic which would not prompt if any of the URLs were set. This would be the case for Next.js, if the user created the app with the CLI and added the default suggested callback URL (`http://localhost:3000`).
- Fixes the previous logic in the case of SPAs which would not prompt to add the allowed origin and allowed web origins URLs if the callback or logout URLs were set.
- Also hides the cursor when the spinner is active.

<img width="706" alt="Screen Shot 2021-03-29 at 13 35 06" src="https://user-images.githubusercontent.com/5055789/112872112-5cb82c00-9096-11eb-86b0-94e98334cffa.png">

<img width="633" alt="Screen Shot 2021-03-29 at 13 35 23" src="https://user-images.githubusercontent.com/5055789/112872119-60e44980-9096-11eb-9958-6886204d263d.png">

### References

Fixes https://github.com/auth0/auth0-cli/issues/200

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
