### PR TITLE
goreleaser cleanup

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,13 +19,6 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Prepare instrumentation
-        run: |
-          echo -n "$SENTRY_DSN" >> $GITHUB_WORKSPACE/internal/instrumentation/sentrydsn.txt
-        shell: bash
-        env:
-          SENTRY_DSN : ${{secrets.SENTRY_DSN}}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.4.1
         with:
@@ -33,3 +26,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -5,9 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup repo
-      run: |
-        touch $GITHUB_WORKSPACE/internal/instrumentation/sentrydsn.txt
     - name: Run Snyk to check for vulnerabilities
       uses: snyk/actions/golang@master
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # project artifacts
 /auth0
-/internal/instrumentation/sentrydsn.txt
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
       - -X github.com/auth0/auth0-cli/internal/buildinfo.Revision={{.Commit}}
       - -X github.com/auth0/auth0-cli/internal/buildinfo.BuildUser=goreleaser'
       - -X github.com/auth0/auth0-cli/internal/buildinfo.BuildDate={{.Date}}'
+      - -X github.com/auth0/auth0-cli/internal/instrumentation.SentryDSN={{.Env.SENTRY_DSN}}
 archives:
   - replacements:
       darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,11 @@ generate:
 	go generate ./...
 .PHONY: generate
 
-setup:
-	@touch ./internal/instrumentation/sentrydsn.txt
-
-test: setup
+test:
 	CGO_ENABLED=1 go test -race ./... -count 1
 .PHONY: test
 
-lint: setup
+lint:
 	golangci-lint run -v --timeout=5m
 .PHONY: lint
 
@@ -56,7 +53,7 @@ build-all-platforms:
 .PHONY: build-all-platforms
 
 # Run all the tests and code checks
-ci: setup build-all-platforms test lint
+ci: build-all-platforms test lint
 .PHONY: ci
 
 $(GOBIN)/mockgen:

--- a/internal/instrumentation/instrumentation.go
+++ b/internal/instrumentation/instrumentation.go
@@ -7,17 +7,16 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-//go:embed sentrydsn.txt
-var sentryDSN string
+var SentryDSN string
 
 // ReportException is designed to be called once as the CLI exits. We're
 // purposefully initializing a client all the time given this context.
 func ReportException(err error) {
-	if sentryDSN == "" {
+	if SentryDSN == "" {
 		return
 	}
 
-	if err := sentry.Init(sentry.ClientOptions{Dsn: sentryDSN}); err != nil {
+	if err := sentry.Init(sentry.ClientOptions{Dsn: SentryDSN}); err != nil {
 		return
 	}
 


### PR DESCRIPTION
Followup from the previous stab, this is actually doing the right thing
now and using build tags instead of files.

Also skips the previous set of hacks that was added for applying the
file.
