### PR TITLE
Use zip for the Windows binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,9 @@ archives:
       amd64: x86_64
     files:
       - none*
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
### Description

This PR configures Goreleaser to compress the Windows `.exe` into a `.zip` instead of a `.tar.gz`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
