### PR TITLE
Do not wrap logout error twice

### DIFF
--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -47,7 +47,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 			}
 
 			if err := cli.removeTenant(selectedTenant); err != nil {
-				return fmt.Errorf("Unexpected error logging out tenant: %s: %v", selectedTenant, err)
+				return err // This error is already formatted for display
 			}
 
 			cli.renderer.Infof("Successfully logged out tenant: %s", selectedTenant)


### PR DESCRIPTION
### Description

This PR returns the error from `removeTenant` as-is because it already has been formatted for display.

**Before**
`Unexpected error logging out tenant: : Unexpected error clearing tenant information: secret not found in keyring`

**After**
`Unexpected error clearing tenant information: secret not found in keyring`

Errors in general need some work.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
