### PR TITLE
Add a hint to the 'Unable to find tenant' error message

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,7 +188,7 @@ func (c *cli) getTenant() (tenant, error) {
 
 	t, ok := c.config.Tenants[c.tenant]
 	if !ok {
-		return tenant{}, fmt.Errorf("Unable to find tenant: %s", c.tenant)
+		return tenant{}, fmt.Errorf("Unable to find tenant: %s; run `auth0 tenants use` to see your configured tenants or run `auth0 login` to configure a new tenant", c.tenant)
 	}
 
 	if t.Apps == nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,7 +188,7 @@ func (c *cli) getTenant() (tenant, error) {
 
 	t, ok := c.config.Tenants[c.tenant]
 	if !ok {
-		return tenant{}, fmt.Errorf("Unable to find tenant: %s; run `auth0 tenants use` to see your configured tenants or run `auth0 login` to configure a new tenant", c.tenant)
+		return tenant{}, fmt.Errorf("Unable to find tenant: %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", c.tenant)
 	}
 
 	if t.Apps == nil {

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -41,7 +41,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 				requestedTenant := args[0]
 				t, ok := cli.config.Tenants[requestedTenant]
 				if !ok {
-					return fmt.Errorf("Unable to find tenant %s; run `auth0 tenants use` to see your configured tenants or run `auth0 login` to configure a new tenant", requestedTenant)
+					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
 				}
 				selectedTenant = t.Name
 			}

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -73,7 +73,7 @@ func useTenantCmd(cli *cli) *cobra.Command {
 				requestedTenant := args[0]
 				t, ok := cli.config.Tenants[requestedTenant]
 				if !ok {
-					return fmt.Errorf("Unable to find tenant %s; run `auth0 tenants use` to see your configured tenants or run `auth0 login` to configure a new tenant", requestedTenant)
+					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
 				}
 				selectedTenant = t.Name
 			}


### PR DESCRIPTION
### Description

This PR adds a hint to the `Unable to find tenant <tenant>` error message, to read `Unable to find tenant: <tenant>; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant`. This is the same strig that is being used elsewhere in the codebase for this error.

Eventually we'll need to refactor `logout`and `tenants use` to use the `getTenant` method, and this error will be duplicated no more.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
