### PR TITLE
Add default Token Endpoint Auth Method on `apps create` [CLI-115]

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -383,16 +383,22 @@ auth0 apps create --name myapp --type [native|spa|regular|m2m]
 
 			// Load values into a fresh app instance
 			a := &management.Client{
-				Name:                    &inputs.Name,
-				Description:             &inputs.Description,
-				AppType:                 auth0.String(apiTypeFor(inputs.Type)),
-				Callbacks:               stringToInterfaceSlice(inputs.Callbacks),
-				AllowedOrigins:          stringToInterfaceSlice(inputs.AllowedOrigins),
-				WebOrigins:              stringToInterfaceSlice(inputs.AllowedWebOrigins),
-				AllowedLogoutURLs:       stringToInterfaceSlice(inputs.AllowedLogoutURLs),
-				TokenEndpointAuthMethod: apiAuthMethodFor(inputs.AuthMethod),
-				OIDCConformant:          &oidcConformant,
-				JWTConfiguration:        &management.ClientJWTConfiguration{Algorithm: &algorithm},
+				Name:              &inputs.Name,
+				Description:       &inputs.Description,
+				AppType:           auth0.String(apiTypeFor(inputs.Type)),
+				Callbacks:         stringToInterfaceSlice(inputs.Callbacks),
+				AllowedOrigins:    stringToInterfaceSlice(inputs.AllowedOrigins),
+				WebOrigins:        stringToInterfaceSlice(inputs.AllowedWebOrigins),
+				AllowedLogoutURLs: stringToInterfaceSlice(inputs.AllowedLogoutURLs),
+				OIDCConformant:    &oidcConformant,
+				JWTConfiguration:  &management.ClientJWTConfiguration{Algorithm: &algorithm},
+			}
+
+			// Set token endpoint auth method
+			if len(inputs.AuthMethod) == 0 {
+				a.TokenEndpointAuthMethod = apiDefaultAuthMethodFor(inputs.Type)
+			} else {
+				a.TokenEndpointAuthMethod = apiAuthMethodFor(inputs.AuthMethod)
 			}
 
 			// Set grants
@@ -663,6 +669,17 @@ func apiAuthMethodFor(v string) *string {
 		return auth0.String("client_secret_post")
 	case "basic":
 		return auth0.String("client_secret_basic")
+	default:
+		return nil
+	}
+}
+
+func apiDefaultAuthMethodFor(t string) *string {
+	switch apiTypeFor(strings.ToLower(t)) {
+	case appTypeNative:
+		fallthrough
+	case appTypeSPA:
+		return auth0.String("none")
 	default:
 		return nil
 	}

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -674,9 +674,7 @@ func apiAuthMethodFor(v string) *string {
 
 func apiDefaultAuthMethodFor(t string) *string {
 	switch apiTypeFor(strings.ToLower(t)) {
-	case appTypeNative:
-		fallthrough
-	case appTypeSPA:
+	case appTypeNative, appTypeSPA:
 		return auth0.String("none")
 	default:
 		return nil


### PR DESCRIPTION
### Description

This PR adds a default value of `none` for the Token Endpoint Default Auth Method property on `apps create` when the Auth0 app a public client (SPA or Native).

Otherwise, the token exchange will fail with an `Oops... unauthorized` error.

<img width="687" alt="Screen Shot 2021-03-31 at 13 14 05" src="https://user-images.githubusercontent.com/5055789/113177676-29a3a300-9224-11eb-972c-4c74e7ce7bee.png">

<img width="804" alt="Screen Shot 2021-03-31 at 13 20 12" src="https://user-images.githubusercontent.com/5055789/113177450-e77a6180-9223-11eb-96ec-d1b1054f1fe1.png">

### References

Documentation: https://auth0.com/docs/get-started/dashboard/application-settings

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
