### PR TITLE
Always cleanup the test callback URL [CLI-116]

### DIFF
--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -158,7 +158,7 @@ func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, 
 		// remove it when we're done
 		defer func() {
 			if callbackAdded {
-				if err := removeLocalCallbackURLFromClient(cli.api.Client, c); err != nil {
+				if err := removeLocalCallbackURLFromClient(cli.api.Client, c); err != nil { // TODO: Make it a warning
 					cli.renderer.Errorf("Unable to remove callback URL '%s' from client: %s", cliLoginTestingCallbackURL, err)
 				}
 			}

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -156,11 +156,13 @@ func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, 
 
 		// if we added the local callback URL to the client then we need to
 		// remove it when we're done
-		if callbackAdded {
-			if err := removeLocalCallbackURLFromClient(cli.api.Client, c); err != nil {
-				return err
+		defer func() {
+			if callbackAdded {
+				if err := removeLocalCallbackURLFromClient(cli.api.Client, c); err != nil {
+					cli.renderer.Errorf("Unable to remove callback URL '%s' from client: %s", cliLoginTestingCallbackURL, err)
+				}
 			}
-		}
+		}()
 
 		return nil
 	})


### PR DESCRIPTION
### Description

When the test login fails, the callback URL added to perform the test login does not get removed from the client.
This PR will always remove it, even in case of login error.

### References

Fixes #216

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
