### PR TITLE
Make the `apps use` short description more helpful

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -137,7 +137,7 @@ func useAppCmd(cli *cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "use",
-		Short: "Choose a default application",
+		Short: "Choose a default application for the Auth0 CLI",
 		Long: `auth0 apps use <client-id>
 Specify your preferred application for interaction with the Auth0 CLI
 `,


### PR DESCRIPTION
### Description

This PR updates the short description of the `apps use` command to make it clearer that it is a CLI-specific thing.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
