### PR TITLE
Make the audience flag required in `test token`

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -26,7 +26,15 @@ var (
 		Name:      "Audience",
 		LongForm:  "audience",
 		ShortForm: "a",
-		Help:      "The unique identifier of the target Audience you want to access.",
+		Help:      "The unique identifier of the target API you want to access.",
+	}
+
+	testAudienceRequired = Flag{
+		Name:       testAudience.Name,
+		LongForm:   testAudience.LongForm,
+		ShortForm:  testAudience.ShortForm,
+		Help:       testAudience.Help,
+		IsRequired: true,
 	}
 
 	testScopes = Flag{
@@ -157,7 +165,7 @@ func testTokenCmd(cli *cli) *cobra.Command {
 		Short: "Fetch a token for the given client and API",
 		Long: `Fetch an access token for the given client.
 If --client-id is not provided, the default client "CLI Login Testing" will be used (and created if not exists).
-Additionally, you can also specify the --audience and --scope to use.`,
+Additionally, you can also specify the --audience (API Identifer) and --scope to use.`,
 		Example: `auth0 test token
 auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -228,7 +236,7 @@ auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
 	testClientID.RegisterString(cmd, &inputs.ClientID, "")
-	testAudience.RegisterString(cmd, &inputs.Audience, "")
+	testAudienceRequired.RegisterString(cmd, &inputs.Audience, "")
 	testScopes.RegisterStringSlice(cmd, &inputs.Scopes, nil)
 	return cmd
 }

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -165,7 +165,7 @@ func testTokenCmd(cli *cli) *cobra.Command {
 		Short: "Fetch a token for the given client and API",
 		Long: `Fetch an access token for the given client.
 If --client-id is not provided, the default client "CLI Login Testing" will be used (and created if not exists).
-Additionally, you can also specify the --audience (API Identifer) and --scope to use.`,
+Specify the API you want this token for with --audience (API Identifer). Additionally, you can also specify the --scope to use.`,
 		Example: `auth0 test token
 auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
### Description

In the `test token` command, if the `--audience` flag is missing, the command will produce no tokens unless there is a default audience set in the tenant.
This PR makes that flag required, so that the command will always produce a token.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
