### PR TITLE
Cli 92

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -72,12 +72,14 @@ func scopesCmd(cli *cli) *cobra.Command {
 func listApisCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Aliases: []string{"ls"},
 		Short: "List your APIs",
 		Long: `auth0 apis list
 Lists your existing APIs. To create one try:
-
     auth0 apis create
 `,
+		Example: `auth0 apis list
+auth0 apis ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var list *management.ResourceServerList
 
@@ -106,10 +108,9 @@ func showApiCmd(cli *cli) *cobra.Command {
 		Use:   "show",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Show an API",
-		Long: `Show an API:
-
-auth0 apis show <id>
-`,
+		Long: `Show an API:`,
+		Example: `auth0 apis show 
+auth0 apis show <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -151,9 +152,10 @@ func createApiCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new API",
-		Long: `Create a new API:
-
-auth0 apis create --name myapi --identifier http://my-api
+		Long: `Create a new API`,
+		Example: `auth0 apis create 
+auth0 apis create --name myapi 
+auth0 apis create -n myapi --identifier http://my-api
 `,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
@@ -209,10 +211,10 @@ func updateApiCmd(cli *cli) *cobra.Command {
 		Use:   "update",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Update an API",
-		Long: `Update an API:
-
-auth0 apis update <id> --name myapi
-`,
+		Long: `Update an API:`,
+		Example: `auth0 apis update 
+auth0 apis update <id> 
+auth0 apis update <id> --name myapi`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -284,10 +286,9 @@ func deleteApiCmd(cli *cli) *cobra.Command {
 		Use:   "delete",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Delete an API",
-		Long: `Delete an API:
-
-auth0 apis delete <id>
-`,
+		Long: `Delete an API:`,
+		Example: `auth0 apis delete 
+auth0 apis delete <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -327,12 +328,12 @@ func listScopesCmd(cli *cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
+		Aliases: []string{"ls"},
 		Args:  cobra.MaximumNArgs(1),
 		Short: "List the scopes of an API",
-		Long: `List the scopes of an API:
-
-auth0 apis scopes list <id>
-`,
+		Long: `List the scopes of an API`,
+		Example: `auth0 apis scopes list 
+auth0 apis scopes ls <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -138,9 +138,8 @@ func useAppCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "use",
 		Short: "Choose a default application",
-		Long: `auth0 apps use <client-id>
-Specify your preferred application for interaction with the Auth0 CLI
-`,
+		Long: `Specify your preferred application for interaction with the Auth0 CLI`,
+		Example: `auth0 apps use <client-id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -181,12 +180,12 @@ Specify your preferred application for interaction with the Auth0 CLI
 func listAppsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Aliases: []string{"ls"},
 		Short: "List your applications",
-		Long: `auth0 apps list
-Lists your existing applications. To create one try:
-
-    auth0 apps create
-`,
+		Long: `Lists your existing applications. To create one try:
+auth0 apps create`,
+    	Example: `auth0 apps list
+auth0 apps ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var list *management.ClientList
 
@@ -215,10 +214,8 @@ func showAppCmd(cli *cli) *cobra.Command {
 		Use:   "show",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Show an application",
-		Long: `Show an application:
-
-auth0 apps show <id>
-`,
+		Long: `Show an application:`,
+		Example: `auth0 apps show <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -260,10 +257,8 @@ func deleteAppCmd(cli *cli) *cobra.Command {
 		Use:   "delete",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Delete an application",
-		Long: `Delete an application:
-
-auth0 apps delete <id>
-`,
+		Long: `Delete an application:`,
+		Example: `auth0 apps delete <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -310,10 +305,11 @@ func createAppCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new application",
-		Long: `Create a new application:
-
-auth0 apps create --name myapp --type [native|spa|regular|m2m]
-`,
+		Long: `Create a new application:`,
+		Example:`auth0 apps create 
+auth0 apps create --name myapp 
+auth0 apps create -n myapp --type [native|spa|regular|m2m]
+auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <description>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -453,10 +449,10 @@ func updateAppCmd(cli *cli) *cobra.Command {
 		Use:   "update",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Update an application",
-		Long: `Update an application:
-
-auth0 apps update <id> --name myapp --type [native|spa|regular|m2m]
-`,
+		Long: `Update an application`,
+		Example:`auth0 apps update <id> 
+auth0 apps update <id> --name myapp 
+auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -215,7 +215,8 @@ func showAppCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Show an application",
 		Long: `Show an application:`,
-		Example: `auth0 apps show <id>`,
+		Example: `auth0 apps show 
+auth0 apps show <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -258,7 +259,8 @@ func deleteAppCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Delete an application",
 		Long: `Delete an application:`,
-		Example: `auth0 apps delete <id>`,
+		Example: `auth0 apps delete 
+auth0 apps delete <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -306,7 +308,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 		Use:   "create",
 		Short: "Create a new application",
 		Long: `Create a new application:`,
-		Example:`auth0 apps create 
+		Example: `auth0 apps create 
 auth0 apps create --name myapp 
 auth0 apps create -n myapp --type [native|spa|regular|m2m]
 auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <description>`,
@@ -450,7 +452,7 @@ func updateAppCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Update an application",
 		Long: `Update an application`,
-		Example:`auth0 apps update <id> 
+		Example: `auth0 apps update <id> 
 auth0 apps update <id> --name myapp 
 auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -68,8 +68,11 @@ func rulesCmd(cli *cli) *cobra.Command {
 func listRulesCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Aliases: []string{"ls"},
 		Short: "List your rules",
 		Long:  `List the rules in your current tenant.`,
+		Example: `auth0 rules list
+auth0 rules ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var rules []*management.Rule
 			err := ansi.Waiting(func() error {
@@ -103,10 +106,11 @@ func createRuleCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new rule",
-		Long: `Create a new rule:
-
-auth0 rules create --name "My Rule" --template [empty-rule]"
-		`,
+		Long: `Create a new rule:`,
+		Example:`auth0 rules create 
+auth0 rules create --name "My Rule" 
+auth0 rules create -n "My Rule" --template "Empty rule"
+auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -165,10 +169,9 @@ func showRuleCmd(cli *cli) *cobra.Command {
 		Use:   "show",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Show a rule",
-		Long: `Show a rule:
-
-auth0 rules show <id>
-`,
+		Long: `Show a rule:`,
+		Example: `auth0 rules show 
+auth0 rules show <id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -210,8 +213,8 @@ func deleteRuleCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a rule",
-		Long: `Delete a rule:
-
+		Long: `Delete a rule`,
+		Example: `auth0 rules delete 
 auth0 rules delete <rule-id>`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
@@ -251,10 +254,10 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a rule",
-		Long: `Update a rule:
-
-auth0 rules update <rule-id> --name "My Updated Rule" --enabled=false
-		`,
+		Long: `Update a rule`,
+		Example:`auth0 rules update <rule-id> 
+auth0 rules update <rule-id> --name "My Updated Rule"
+auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -107,7 +107,7 @@ func createRuleCmd(cli *cli) *cobra.Command {
 		Use:   "create",
 		Short: "Create a new rule",
 		Long: `Create a new rule:`,
-		Example:`auth0 rules create 
+		Example: `auth0 rules create 
 auth0 rules create --name "My Rule" 
 auth0 rules create -n "My Rule" --template "Empty rule"
 auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false`,
@@ -255,7 +255,7 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 		Use:   "update",
 		Short: "Update a rule",
 		Long: `Update a rule`,
-		Example:`auth0 rules update <rule-id> 
+		Example: `auth0 rules update <rule-id> 
 auth0 rules update <rule-id> --name "My Updated Rule"
 auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 		PreRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION


### Description
This PR add Examples to `apps`, `apis` and `rules` commands by moving
 the example in the `Long` field to `Example` field

```
auth0 apps create -h
Create a new application:

Usage:
  auth0 apps create [flags]

Examples:
auth0 apps create 
auth0 apps create --name myapp 
auth0 apps create -n myapp --type [native|spa|regular|m2m]
auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <description>
```


### References

https://auth0team.atlassian.net/browse/CLI-92

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ X] The correct base branch is being used, if not `master`
