### PR TITLE
Don't require being logged in to call help command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,6 +53,11 @@ func Execute() {
 				return nil
 			}
 
+			// Getting help shouldn't trigger a login.
+			if cmd.CalledAs() == "help" && cmd.Parent().Use == "auth0" {
+				return nil
+			}
+
 			// Initialize everything once. Later callers can then
 			// freely assume that config is fully primed and ready
 			// to go.


### PR DESCRIPTION
### Description

When logged out or on a fresh install, the `help` command was blocked from running:

```
❯ go run cmd/auth0/main.go help

===  error

▸    Not yet configured. Try auth0 login.
exit status 1
```


### References

https://auth0team.atlassian.net/browse/CLI-112

### Testing

The main `help` command, `help` on a subcommand, and `--help` flags should all return help instead of an error to log in:

```
go run cmd/auth0/main.go logs list --help
go run cmd/auth0/main.go logs --help
go run cmd/auth0/main.go logs help
go run cmd/auth0/main.go help logs
go run cmd/auth0/main.go help
```


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
