### PR TITLE
Do not wrap 'logged out' error

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -52,7 +52,7 @@ type app struct {
 	FirstRuns map[string]bool `json:"first_runs"`
 }
 
-var errUnauthenticated = errors.New("Not logged in. Try `auth0 login`.")
+var errUnauthenticated = errors.New("Not logged in. Try 'auth0 login'.")
 
 // cli provides all the foundational things for all the commands in the CLI,
 // specifically:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -52,7 +52,7 @@ type app struct {
 	FirstRuns map[string]bool `json:"first_runs"`
 }
 
-var errUnauthenticated = errors.New("Not yet configured. Try `auth0 login`.")
+var errUnauthenticated = errors.New("Not logged in. Try `auth0 login`.")
 
 // cli provides all the foundational things for all the commands in the CLI,
 // specifically:

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -21,7 +21,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 			if len(args) == 0 {
 				tens, err := cli.listTenants()
 				if err != nil {
-					return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+					return err // This error is already formatted for display
 				}
 
 				if len(tens) == 0 {


### PR DESCRIPTION
### Description

When running the `auth logout` command when there are no logged in tenants, the error message displayed `Unable to load tenants due to an unexpected error: Not yet configured. Try 'auth0 login'.` is not really appropriate as there are no tenants to load.
This PR changes the error message to simply `Not logged in. Try 'auth0 login'.`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
