### PR TITLE
Fix duplicated hint copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Creating application... done
   CLIENT SECRET  QXV0aDAgaXMgaGlyaW5nISBhdXRoMC5jb20vY2FyZWVycyAK
 
  ▸    Quickstarts: https://auth0.com/docs/quickstart/webapp
- ▸    Hint: You might wanna try `auth0 test login --client-id vXAtoaFdhlmtWjpIrjb9AUnrGEAOH2MM`
+ ▸    Hint: You might wanna try 'auth0 test login --client-id vXAtoaFdhlmtWjpIrjb9AUnrGEAOH2MM'
 ```
 
 As you might observe, the next thing to do would likely be to try logging in

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -234,7 +234,7 @@ func (r *Renderer) ApplicationCreate(client *management.Client, revealSecrets bo
 	r.Infof("Quickstarts: %s", quickstartsURIFor(client.AppType))
 
 	// TODO(cyx): possibly guard this with a --no-hint flag.
-	r.Infof("%s You might wanna try 'auth0 test login --client-id %s'",
+	r.Infof("%s Test this app's login box with 'auth0 test login --client-id %s'",
 		ansi.Faint("Hint:"),
 		client.GetClientID(),
 	)


### PR DESCRIPTION
### Description

Currently, when you create an app you get hits with duplicated copy.

<img width="685" alt="Screen Shot 2021-04-02 at 14 48 54" src="https://user-images.githubusercontent.com/5055789/113440508-f1869680-93c2-11eb-8205-d7a710d1e738.png">

This PR changes the copy of the first hint to a more informative message.

<img width="759" alt="Screen Shot 2021-04-02 at 14 50 54" src="https://user-images.githubusercontent.com/5055789/113440513-f3e8f080-93c2-11eb-8b96-312f70aba2c9.png">


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
