### PR TITLE
rules editor create/update tweaks

### DIFF
--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
-	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"gopkg.in/auth0.v5/management"
 )
@@ -37,6 +36,14 @@ var (
 		LongForm:  "enabled",
 		ShortForm: "e",
 		Help:      "Enable (or disable) a rule.",
+	}
+
+	ruleScript = Flag{
+		Name:       "Script",
+		LongForm:   "script",
+		ShortForm:  "s",
+		Help:       "Script contents for the rule",
+		IsRequired: true,
 	}
 
 	ruleTemplateOptions = pickerOptions{
@@ -100,6 +107,7 @@ func createRuleCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		Name     string
 		Template string
+		Script   string
 		Enabled  bool
 	}
 
@@ -126,12 +134,12 @@ auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false`,
 			// TODO(cyx): we can re-think this once we have
 			// `--stdin` based commands. For now we don't have
 			// those yet, so keeping this simple.
-			script, err := prompt.CaptureInputViaEditor(
+			err := ruleScript.EditorPrompt(
+				cmd,
+				&inputs.Script,
 				ruleTemplateOptions.getValue(inputs.Template),
 				inputs.Name+".*.js",
-				func() {
-					cli.renderer.Infof("%s once you close the editor, the rule will be saved. To cancel, CTRL+C.", ansi.Faint("Hint:"))
-				},
+				cli.ruleEditorHint,
 			)
 			if err != nil {
 				return fmt.Errorf("Failed to capture input from the editor: %w", err)
@@ -139,7 +147,7 @@ auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false`,
 
 			rule := &management.Rule{
 				Name:    &inputs.Name,
-				Script:  auth0.String(script),
+				Script:  auth0.String(inputs.Script),
 				Enabled: &inputs.Enabled,
 			}
 
@@ -251,6 +259,7 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		ID      string
 		Name    string
+		Script  string
 		Enabled bool
 	}
 
@@ -291,12 +300,12 @@ auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 			// TODO(cyx): we can re-think this once we have
 			// `--stdin` based commands. For now we don't have
 			// those yet, so keeping this simple.
-			script, err := prompt.CaptureInputViaEditor(
+			err = ruleScript.EditorPromptU(
+				cmd,
+				&inputs.Script,
 				rule.GetScript(),
 				rule.GetName()+".*.js",
-				func() {
-					cli.renderer.Infof("%s once you close the editor, the rule will be saved. To cancel, CTRL+C.", ansi.Faint("Hint:"))
-				},
+				cli.ruleEditorHint,
 			)
 			if err != nil {
 				return fmt.Errorf("Failed to capture input from the editor: %w", err)
@@ -312,7 +321,7 @@ auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 			// display.
 			rule = &management.Rule{
 				Name:    &inputs.Name,
-				Script:  &script,
+				Script:  &inputs.Script,
 				Enabled: &inputs.Enabled,
 			}
 
@@ -351,4 +360,8 @@ func (c *cli) rulePickerOptions() (pickerOptions, error) {
 	}
 
 	return opts, nil
+}
+
+func (c *cli) ruleEditorHint() {
+	c.renderer.Infof("%s once you close the editor, the rule will be saved. To cancel, CTRL+C.", ansi.Faint("Hint:"))
 }

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -42,7 +42,7 @@ var (
 		Name:       "Script",
 		LongForm:   "script",
 		ShortForm:  "s",
-		Help:       "Script contents for the rule",
+		Help:       "Script contents for the rule.",
 		IsRequired: true,
 	}
 

--- a/internal/prompt/surveyext.go
+++ b/internal/prompt/surveyext.go
@@ -1,0 +1,135 @@
+package prompt
+
+import (
+	"path/filepath"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+)
+
+// EXTENDED to enable different prompting behavior
+type Editor struct {
+	*survey.Editor
+	EditorCommand string
+	BlankAllowed  bool
+}
+
+func (e *Editor) editorCommand() string {
+	if e.EditorCommand == "" {
+		return getDefaultEditor()
+	}
+
+	return e.EditorCommand
+}
+
+// EXTENDED to change prompt text
+var EditorQuestionTemplate = `
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
+  {{- if and .Default (not .HideDefault)}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+	{{- color "cyan"}}[(e) to launch {{ .EditorCommand }}{{- if .BlankAllowed }}, enter to skip{{ end }}] {{color "reset"}}
+{{- end}}`
+
+// EXTENDED to pass editor name (to use in prompt)
+type EditorTemplateData struct {
+	survey.Editor
+	EditorCommand string
+	BlankAllowed  bool
+	Answer        string
+	ShowAnswer    bool
+	ShowHelp      bool
+	Config        *survey.PromptConfig
+}
+
+// EXTENDED to augment prompt text and keypress handling
+func (e *Editor) prompt(initialValue string, config *survey.PromptConfig) (interface{}, error) {
+	err := e.Render(
+		EditorQuestionTemplate,
+		// EXTENDED to support printing editor in prompt and BlankAllowed
+		EditorTemplateData{
+			Editor:        *e.Editor,
+			BlankAllowed:  e.BlankAllowed,
+			EditorCommand: filepath.Base(e.editorCommand()),
+			Config:        config,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// start reading runes from the standard in
+	rr := e.NewRuneReader()
+	_ = rr.SetTermMode()
+	defer func() { _ = rr.RestoreTermMode() }()
+
+	cursor := e.NewCursor()
+	cursor.Hide()
+	defer cursor.Show()
+
+	for {
+		// EXTENDED to handle the e to edit / enter to skip behavior + BlankAllowed
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == 'e' {
+			break
+		}
+		if r == '\r' || r == '\n' {
+			if e.BlankAllowed {
+				return "", nil
+			} else {
+				continue
+			}
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		if string(r) == config.HelpInput && e.Help != "" {
+			err = e.Render(
+				EditorQuestionTemplate,
+				EditorTemplateData{
+					// EXTENDED to support printing editor in prompt, BlankAllowed
+					Editor:        *e.Editor,
+					BlankAllowed:  e.BlankAllowed,
+					EditorCommand: filepath.Base(e.editorCommand()),
+					ShowHelp:      true,
+					Config:        config,
+				},
+			)
+			if err != nil {
+				return "", err
+			}
+		}
+		continue
+	}
+
+	text, err := CaptureInputViaEditor(initialValue, e.FileName, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// check length, return default value on empty
+	if len(text) == 0 && !e.AppendDefault {
+		return e.Default, nil
+	}
+
+	return text, nil
+}
+
+// EXTENDED This is straight copypasta from survey to get our overridden prompt called.
+func (e *Editor) Prompt(config *survey.PromptConfig) (interface{}, error) {
+	initialValue := ""
+	if e.Default != "" && e.AppendDefault {
+		initialValue = e.Default
+	}
+	return e.prompt(initialValue, config)
+}


### PR DESCRIPTION
## Description

This adds basic changes for the create/update path. For now we're
keeping them separate with an assertion that we want the straightforward
edit paths to bypass the survey bits -- since that becomes unnecessary
(e.g. when creating a rule, there's only way to do that -- and that's by
editing the rule).

For update, we'll utilize the surveyext bits heavily bollowed from
github to have the `?` prompt.

## Demo

[![asciicast](https://asciinema.org/a/KMfak9WiCxEwtxYKlg4LwbBZ2.svg)](https://asciinema.org/a/KMfak9WiCxEwtxYKlg4LwbBZ2)