### PR TITLE
Ask for rule enable/disable on 'rules update'

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -49,6 +49,14 @@ func (f *Flag) AskManyU(cmd *cobra.Command, value interface{}, defaultValue *str
 	return askManyFlag(cmd, f, value, defaultValue, true)
 }
 
+func (f *Flag) AskBool(cmd *cobra.Command, value *bool, defaultValue *bool) {
+	askBoolFlag(cmd, f, value, defaultValue, false)
+}
+
+func (f *Flag) AskBoolU(cmd *cobra.Command, value *bool, defaultValue *bool) {
+	askBoolFlag(cmd, f, value, defaultValue, true)
+}
+
 func (f *Flag) Select(cmd *cobra.Command, value interface{}, options []string, defaultValue *string) error {
 	return selectFlag(cmd, f, value, options, defaultValue, false)
 }
@@ -91,7 +99,7 @@ func (f *Flag) EditorPromptU(cmd *cobra.Command, value *string, initialValue, fi
 		},
 	}
 
-	if err := survey.Ask(questions, &response); err != nil {
+	if err := survey.Ask(questions, &response, prompt.Icons); err != nil {
 		return err
 	}
 
@@ -157,6 +165,12 @@ func askManyFlag(cmd *cobra.Command, f *Flag, value interface{}, defaultValue *s
 	*value.(*[]string) = commaSeparatedStringToSlice(strInput)
 
 	return nil
+}
+
+func askBoolFlag(cmd *cobra.Command, f *Flag, value *bool, defaultValue *bool, isUpdate bool) {
+	if shouldAsk(cmd, f, isUpdate) {
+		askBool(cmd, f, value, defaultValue)
+	}
 }
 
 func selectFlag(cmd *cobra.Command, f *Flag, value interface{}, options []string, defaultValue *string, isUpdate bool) error {

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -28,6 +28,11 @@ func ask(cmd *cobra.Command, i commandInput, value interface{}, defaultValue *st
 	return nil
 }
 
+func askBool(cmd *cobra.Command, i commandInput, value *bool, defaultValue *bool) {
+	result := prompt.ConfirmDefault(i.GetLabel(), auth0.BoolValue(defaultValue))
+	*value = result
+}
+
 func _select(cmd *cobra.Command, i commandInput, value interface{}, options []string, defaultValue *string, isUpdate bool) error {
 	isRequired := !isUpdate && i.GetIsRequired()
 

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -32,10 +32,11 @@ var (
 	}
 
 	ruleEnabled = Flag{
-		Name:      "Enabled",
-		LongForm:  "enabled",
-		ShortForm: "e",
-		Help:      "Enable (or disable) a rule.",
+		Name:         "Enabled",
+		LongForm:     "enabled",
+		ShortForm:    "e",
+		Help:         "Enable (or disable) a rule.",
+		AlwaysPrompt: true,
 	}
 
 	ruleScript = Flag{
@@ -300,6 +301,8 @@ auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 			if err := ruleName.AskU(cmd, &inputs.Name, rule.Name); err != nil {
 				return err
 			}
+
+			ruleEnabled.AskBoolU(cmd, &inputs.Enabled, rule.Enabled)
 
 			// TODO(cyx): we can re-think this once we have
 			// `--stdin` based commands. For now we don't have

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -8,20 +8,20 @@ import (
 
 var stdErrWriter = survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 
-var icons = survey.WithIcons(func(icons *survey.IconSet) {
+var Icons = survey.WithIcons(func(icons *survey.IconSet) {
 	icons.Question.Text = ""
 })
 
 func Ask(inputs []*survey.Question, response interface{}) error {
-	return survey.Ask(inputs, response, stdErrWriter, icons)
+	return survey.Ask(inputs, response, stdErrWriter, Icons)
 }
 
 func AskOne(input *survey.Question, response interface{}) error {
-	return survey.Ask([]*survey.Question{input}, response, stdErrWriter, icons)
+	return survey.Ask([]*survey.Question{input}, response, stdErrWriter, Icons)
 }
 
 func askOne(prompt survey.Prompt, response interface{}) error {
-	return survey.AskOne(prompt, response, stdErrWriter, icons)
+	return survey.AskOne(prompt, response, stdErrWriter, Icons)
 }
 
 func TextInput(name string, message string, help string, defaultValue string, required bool) *survey.Question {
@@ -37,10 +37,10 @@ func TextInput(name string, message string, help string, defaultValue string, re
 	return input
 }
 
-func BoolInput(name string, message string, help string, required bool) *survey.Question {
+func BoolInput(name string, message string, help string, defaultValue bool, required bool) *survey.Question {
 	input := &survey.Question{
 		Name:      name,
-		Prompt:    &survey.Confirm{Message: message, Help: help},
+		Prompt:    &survey.Confirm{Message: message, Help: help, Default: defaultValue},
 		Transform: survey.Title,
 	}
 
@@ -75,6 +75,20 @@ func Confirm(message string) bool {
 
 	if err := askOne(prompt, &result); err != nil {
 		return false
+	}
+
+	return result
+}
+
+func ConfirmDefault(message string, defaultValue bool) bool {
+	result := false
+	prompt := &survey.Confirm{
+		Message: message,
+		Default: defaultValue,
+	}
+
+	if err := askOne(prompt, &result); err != nil {
+		return defaultValue
 	}
 
 	return result


### PR DESCRIPTION
### Description

This PR modifies `rules update` to ask the user if the rule should be enabled or disabled, as there's no way to accomplish that interactively (at least until we add `rules enable` and `rules disable`).
Also removes the `?` from the editor prompt, to match all other prompts.

<img width="402" alt="Screen Shot 2021-04-02 at 20 54 48" src="https://user-images.githubusercontent.com/5055789/113462372-e9e0e500-93f6-11eb-90d1-59909e4d311b.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
