### PR TITLE
fix: escape sequences on windows powershell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-cmp v0.5.5
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.11.9 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/lestrrat-go/jwx v1.1.4
@@ -33,7 +34,7 @@ require (
 	github.com/zalando/go-keyring v0.1.1
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-	golang.org/x/sys v0.0.0-20210305023407-0d6cb8bd5a4b // indirect
+	golang.org/x/sys v0.0.0-20210305023407-0d6cb8bd5a4b
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/auth0.v5 v5.11.0

--- a/internal/ansi/init.go
+++ b/internal/ansi/init.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package ansi
+
+// InitConsole initializes any platform-specific aspect of the terminal.
+// This method will run for all except Windows.
+func InitConsole() {}

--- a/internal/ansi/init_windows.go
+++ b/internal/ansi/init_windows.go
@@ -4,7 +4,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// IinitConsole configures the standard output and error streams
+// InitConsole configures the standard output and error streams
 // on Windows systems. This is necessary to enable colored and ANSI output.
 // This is the Windows implementation of ansi/init.go.
 func InitConsole() {

--- a/internal/ansi/init_windows.go
+++ b/internal/ansi/init_windows.go
@@ -1,0 +1,21 @@
+package ansi
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// IinitConsole configures the standard output and error streams
+// on Windows systems. This is necessary to enable colored and ANSI output.
+// This is the Windows implementation of ansi/init.go.
+func InitConsole() {
+	setWindowsConsoleMode(windows.Stdout, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	setWindowsConsoleMode(windows.Stderr, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+func setWindowsConsoleMode(handle windows.Handle, flags uint32) {
+	var mode uint32
+	// set the console mode if not already there:
+	if err := windows.GetConsoleMode(handle, &mode); err == nil {
+		_ = windows.SetConsoleMode(handle, mode|flags)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -110,7 +110,7 @@ func Execute() {
 
 	// platform specific terminal initialization:
 	// this should run for all commands,
-	// for most of the architechtures there's no requirements:
+	// for most of the architectures there's no requirements:
 	ansi.InitConsole()
 
 	if err := rootCmd.ExecuteContext(context.TODO()); err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/buildinfo"
 	"github.com/auth0/auth0-cli/internal/display"
 	"github.com/auth0/auth0-cli/internal/instrumentation"
@@ -106,6 +107,11 @@ func Execute() {
 			instrumentation.ReportException(err)
 		}
 	}()
+
+	// platform specific terminal initialization:
+	// this should run for all commands,
+	// for most of the architechtures there's no requirements:
+	ansi.InitConsole()
 
 	if err := rootCmd.ExecuteContext(context.TODO()); err != nil {
 		cli.renderer.Heading("error")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -116,6 +116,7 @@ github.com/hashicorp/hcl/json/token
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+## explicit
 github.com/kballard/go-shellquote
 # github.com/klauspost/compress v1.11.9
 ## explicit


### PR DESCRIPTION
Fix escape sequences for powershell. With this custom initialization for windows the newlines and colors are displayed properly. On the other hand, emojis are still missing due to a powershell default settings limitation according to this: https://stackoverflow.com/questions/49476326/displaying-unicode-in-powershell/49481797#49481797

**before**
![image](https://user-images.githubusercontent.com/11925502/113636793-96b2a080-9649-11eb-851b-2b0bc0cf3292.png)


**after**
![image](https://user-images.githubusercontent.com/11925502/113636807-9dd9ae80-9649-11eb-979a-1d8b10605579.png)
