### PR TITLE
Add scoop config to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,10 +49,25 @@ brews:
       email: support@auth0.com
     homepage: https://cli.auth0.com
     description: Supercharge your developer workflow.
+    license: MIT
+    skip_upload: auto
     install: |
         bin.install "auth0"
 
         (bash_completion/"auth0").write `#{bin}/auth0 completion bash`
         (fish_completion/"auth0.fish").write `#{bin}/auth0 completion fish`
         (zsh_completion/"_auth0").write `#{bin}/auth0 completion zsh`
-    caveats: "Thanks for installing Auth0 CLI"
+    caveats: "Thanks for installing the Auth0 CLI"
+scoop:
+    bucket:
+      owner: auth0
+      name: scoop-auth0-cli
+    commit_author:
+      name: auth0
+      email: support@auth0.com
+    commit_msg_template: "Scoop manifest update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: https://github.com/auth0/auth0-cli
+    description: Supercharge your developer workflow.
+    license: MIT
+    skip_upload: auto
+    post_install: ["Write-Host 'Thanks for installing the Auth0 CLI'"]


### PR DESCRIPTION
### Description

This PR updates the goreleaser config to push a Scoop App Manifest to the [scoop-auth0-cli](https://github.com/auth0/scoop-auth0-cli) repo.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
