### PR TITLE
Use 'auth0' as the name of the Scoop manifest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,7 @@ brews:
         (zsh_completion/"_auth0").write `#{bin}/auth0 completion zsh`
     caveats: "Thanks for installing the Auth0 CLI"
 scoop:
+    name: auth0
     bucket:
       owner: auth0
       name: scoop-auth0-cli


### PR DESCRIPTION
### Description

This PR updates the goreleaser configuration so that the generated Scoop App Manifest will be `auth0.json` instead of `auth0-cli.json`, which impacts the install command the user has to run.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
