### PR TITLE
CLI-127: refactor: change disable-color flag to no-color

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -27,7 +27,7 @@ var (
 
 	logsNoColor = Flag{
 		Name:     "Disable Color",
-		LongForm: "disable-color",
+		LongForm: "no-color",
 		Help:     "Disable colored log output.",
 	}
 )


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Changed the `--disable-color` flag in logs command to `--no-color` for consistency. 


### References
- https://auth0team.atlassian.net/browse/CLI-127

### Testing
Ran make test.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
