### PR TITLE
[CLI-122] throw an error for delete commands if item doesn't exit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,7 @@ brews:
         (zsh_completion/"_auth0").write `#{bin}/auth0 completion zsh`
     caveats: "Thanks for installing the Auth0 CLI"
 scoop:
+    name: auth0
     bucket:
       owner: auth0
       name: scoop-auth0-cli

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -310,21 +310,15 @@ auth0 apis delete <id>`,
 				}
 			}
 
-			var list *management.ResourceServer
-			err := ansi.Waiting(func() error {
-				var err error
-				list, err = cli.api.ResourceServer.Read(url.PathEscape(inputs.ID))
-				return err
-			})
-			_ = list
+			return ansi.Spinner("Deleting API", func() error {
+				_, err := cli.api.ResourceServer.Read(url.PathEscape(inputs.ID))
 
-			if err != nil {
-				return fmt.Errorf("Unable to delete API. The specified Id: %v  doesn't exist", inputs.ID)
-			} else {
-				return ansi.Spinner("Deleting API", func() error {
-					return cli.api.ResourceServer.Delete(url.PathEscape(inputs.ID))
-				})
-			}
+				if err != nil {
+					return fmt.Errorf("Unable to delete API. The specified Id: %v doesn't exist", inputs.ID)
+				}
+
+				return cli.api.ResourceServer.Delete(url.PathEscape(inputs.ID))
+			})
 		},
 	}
 

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -310,13 +310,20 @@ auth0 apis delete <id>`,
 				}
 			}
 
-			return ansi.Spinner("Deleting API", func() error {
-				err := cli.api.ResourceServer.Delete(url.PathEscape(inputs.ID))
-				if err != nil {
-					return fmt.Errorf("An unexpected error occurred while attempting to delete an API with Id '%s': %w", inputs.ID, err)
-				}
-				return nil
+			var list *management.ResourceServer
+			err := ansi.Waiting(func() error {
+				var err error
+				list, err = cli.api.ResourceServer.Read(url.PathEscape(inputs.ID))
+				return err
 			})
+
+			if err != nil {
+				return fmt.Errorf("Unable to delete API. The specified Id: %v  doesn't exist", inputs.ID)
+			} else {
+				return ansi.Spinner("Deleting API", func() error {
+					return cli.api.ResourceServer.Delete(url.PathEscape(inputs.ID))
+				})
+			}
 		},
 	}
 

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -316,6 +316,7 @@ auth0 apis delete <id>`,
 				list, err = cli.api.ResourceServer.Read(url.PathEscape(inputs.ID))
 				return err
 			})
+			_ = list
 
 			if err != nil {
 				return fmt.Errorf("Unable to delete API. The specified Id: %v  doesn't exist", inputs.ID)

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -290,6 +290,7 @@ auth0 apps delete <id>`,
 				list, err = cli.api.Client.Read(inputs.ID)
 				return err
 			})
+			_ = list
 
 			if err != nil {
 				return fmt.Errorf("Unable to delete application. The specified Id: %v  doesn't exist", inputs.ID)

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -284,21 +284,15 @@ auth0 apps delete <id>`,
 				}
 			}
 
-			var list *management.Client
-			err := ansi.Waiting(func() error {
-				var err error
-				list, err = cli.api.Client.Read(inputs.ID)
-				return err
-			})
-			_ = list
+			return ansi.Spinner("Deleting Application", func() error {
+				_, err := cli.api.Client.Read(inputs.ID)
 
-			if err != nil {
-				return fmt.Errorf("Unable to delete application. The specified Id: %v  doesn't exist", inputs.ID)
-			} else {
-				return ansi.Spinner("Deleting Application", func() error {
-					return cli.api.Client.Delete(inputs.ID)
-				})
-			}
+				if err != nil {
+					return fmt.Errorf("Unable to delete application. The specified Id: %v doesn't exist", inputs.ID)
+				}
+
+				return cli.api.Client.Delete(inputs.ID)
+			})
 		},
 	}
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -284,9 +284,20 @@ auth0 apps delete <id>`,
 				}
 			}
 
-			return ansi.Spinner("Deleting application", func() error {
-				return cli.api.Client.Delete(inputs.ID)
+			var list *management.Client
+			err := ansi.Waiting(func() error {
+				var err error
+				list, err = cli.api.Client.Read(inputs.ID)
+				return err
 			})
+
+			if err != nil {
+				return fmt.Errorf("Unable to delete application. The specified Id: %v  doesn't exist", inputs.ID)
+			} else {
+				return ansi.Spinner("Deleting Application", func() error {
+					return cli.api.Client.Delete(inputs.ID)
+				})
+			}
 		},
 	}
 

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -244,21 +244,15 @@ auth0 rules delete <rule-id>`,
 				}
 			}
 
-			var rule *management.Rule
-			err := ansi.Waiting(func() error {
-				var err error
-				rule, err = cli.api.Rule.Read(inputs.ID)
-				return err
-			})
-			_ = rule
+			return ansi.Spinner("Deleting Rule", func() error {
+				_, err := cli.api.Rule.Read(inputs.ID)
 
-			if err != nil {
-				return fmt.Errorf("Unable to delete rule. The specified Id: %v  doesn't exist", inputs.ID)
-			} else {
-				return ansi.Spinner("Deleting rule", func() error {
-					return cli.api.Rule.Delete(inputs.ID)
-				})
-			}
+				if err != nil {
+					return fmt.Errorf("Unable to delete application. The specified Id: %v doesn't exist", inputs.ID)
+				}
+
+				return cli.api.Rule.Delete(inputs.ID)
+			})
 		},
 	}
 

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -244,15 +244,20 @@ auth0 rules delete <rule-id>`,
 				}
 			}
 
-			err := ansi.Spinner("Deleting rule", func() error {
-				return cli.api.Rule.Delete(inputs.ID)
+			var rule *management.Rule
+			err := ansi.Waiting(func() error {
+				var err error
+				rule, err = cli.api.Rule.Read(inputs.ID)
+				return err
 			})
 
 			if err != nil {
-				return err
+				return fmt.Errorf("Unable to delete rule. The specified Id: %v  doesn't exist", inputs.ID)
+			} else {
+				return ansi.Spinner("Deleting rule", func() error {
+					return cli.api.Rule.Delete(inputs.ID)
+				})
 			}
-
-			return nil
 		},
 	}
 

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -250,6 +250,7 @@ auth0 rules delete <rule-id>`,
 				rule, err = cli.api.Rule.Read(inputs.ID)
 				return err
 			})
+			_ = rule
 
 			if err != nil {
 				return fmt.Errorf("Unable to delete rule. The specified Id: %v  doesn't exist", inputs.ID)


### PR DESCRIPTION

### Description

This PR allows the `delete commands` for `apis`, `apps` and `rules`  to return an error if item doesn't exit
as shown below

<img width="1174" alt="Screen Shot 2021-04-09 at 1 29 22 PM" src="https://user-images.githubusercontent.com/75628344/114219279-72e8a680-9938-11eb-8f0c-e4081ffc32c7.png">


### References

https://auth0team.atlassian.net/browse/CLI-122

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X ] The correct base branch is being used, if not `master`
