### PR TITLE
Use domains for tenant name in config.json and for display

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -137,7 +137,7 @@ func (c *cli) setup(ctx context.Context) error {
 			Client:  http.DefaultClient,
 		}
 
-		res, err := tr.Refresh(ctx, t.Name)
+		res, err := tr.Refresh(ctx, t.Domain)
 		if err != nil {
 			// ask and guide the user through the login process:
 			c.renderer.Errorf("failed to renew access token, %s", err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -222,7 +222,7 @@ func (c *cli) addTenant(ten tenant) error {
 	// If there's no existing DefaultTenant yet, might as well set the
 	// first successfully logged in tenant during onboarding.
 	if c.config.DefaultTenant == "" {
-		c.config.DefaultTenant = ten.Name
+		c.config.DefaultTenant = ten.Domain
 	}
 
 	// If we're dealing with an empty file, we'll need to initialize this
@@ -231,7 +231,7 @@ func (c *cli) addTenant(ten tenant) error {
 		c.config.Tenants = map[string]tenant{}
 	}
 
-	c.config.Tenants[ten.Name] = ten
+	c.config.Tenants[ten.Domain] = ten
 
 	if err := c.persistConfig(); err != nil {
 		return fmt.Errorf("unexpected error persisting config: %w", err)
@@ -305,7 +305,7 @@ func (c *cli) setDefaultAppID(id string) error {
 
 	tenant.DefaultAppID = id
 
-	c.config.Tenants[tenant.Name] = tenant
+	c.config.Tenants[tenant.Domain] = tenant
 	if err := c.persistConfig(); err != nil {
 		return fmt.Errorf("Unexpected error persisting config: %w", err)
 	}
@@ -333,7 +333,7 @@ func (c *cli) setFirstCommandRun(clientID string, command string) error {
 		}
 	}
 
-	c.config.Tenants[tenant.Name] = tenant
+	c.config.Tenants[tenant.Domain] = tenant
 
 	if err := c.persistConfig(); err != nil {
 		return fmt.Errorf("Unexpected error persisting config: %w", err)

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -62,11 +62,11 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) error {
 	}
 
 	cli.renderer.Infof("Successfully logged in.")
-	cli.renderer.Infof("Tenant: %s\n", res.Tenant)
+	cli.renderer.Infof("Tenant: %s\n", res.Domain)
 
 	// store the refresh token
 	secretsStore := &auth.Keyring{}
-	err = secretsStore.Set(auth.SecretsNamespace, res.Tenant, res.RefreshToken)
+	err = secretsStore.Set(auth.SecretsNamespace, res.Domain, res.RefreshToken)
 	if err != nil {
 		// log the error but move on
 		cli.renderer.Warnf("Could not store the refresh token locally, please expect to login again once your access token expired. See https://github.com/auth0/auth0-cli/blob/main/KNOWN-ISSUES.md.")
@@ -84,12 +84,12 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) error {
 		return fmt.Errorf("Unexpected error adding tenant to config: %w", err)
 	}
 
-	if cli.config.DefaultTenant != res.Tenant {
-		promptText := fmt.Sprintf("Your default tenant is %s. Do you want to change it to %s?", cli.config.DefaultTenant, res.Tenant)
+	if cli.config.DefaultTenant != res.Domain {
+		promptText := fmt.Sprintf("Your default tenant is %s. Do you want to change it to %s?", cli.config.DefaultTenant, res.Domain)
 		if confirmed := prompt.Confirm(promptText); !confirmed {
 			return nil
 		}
-		cli.config.DefaultTenant = res.Tenant
+		cli.config.DefaultTenant = res.Domain
 		if err := cli.persistConfig(); err != nil {
 			return fmt.Errorf("An error occurred while setting the default tenant: %w", err)
 		}

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -30,7 +30,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 
 				tenNames := make([]string, len(tens))
 				for i, t := range tens {
-					tenNames[i] = t.Name
+					tenNames[i] = t.Domain
 				}
 
 				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to logout", tenNames, tenNames[0], true)
@@ -43,7 +43,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 				if !ok {
 					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
 				}
-				selectedTenant = t.Name
+				selectedTenant = t.Domain
 			}
 
 			if err := cli.removeTenant(selectedTenant); err != nil {

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -34,7 +34,7 @@ func listTenantCmd(cli *cli) *cobra.Command {
 
 			tenNames := make([]string, len(tens))
 			for i, t := range tens {
-				tenNames[i] = t.Name
+				tenNames[i] = t.Domain
 			}
 
 			cli.renderer.ShowTenants(tenNames)
@@ -63,10 +63,10 @@ func useTenantCmd(cli *cli) *cobra.Command {
 
 				tenNames := make([]string, len(tens))
 				for i, t := range tens {
-					tenNames[i] = t.Name
+					tenNames[i] = t.Domain
 				}
 
-				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to activate", tenNames, "", true)
+				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to activate", tenNames, tenNames[0], true)
 				if err := prompt.AskOne(input, &selectedTenant); err != nil {
 					return fmt.Errorf("An unexpected error occurred: %w", err)
 				}
@@ -76,7 +76,7 @@ func useTenantCmd(cli *cli) *cobra.Command {
 				if !ok {
 					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
 				}
-				selectedTenant = t.Name
+				selectedTenant = t.Domain
 			}
 
 			cli.config.DefaultTenant = selectedTenant


### PR DESCRIPTION
Also, fix a bug and use first selection for `tenant use` if no selection is made.

### Description

Use the domain name instead of tenant name for display and re-key config.json to use domain instead of name for the `tenants` object.

### References

https://auth0team.atlassian.net/browse/CLI-130

### Testing

- Remove your config file as this contains breaking changes
- Login
- `tenants list`
- `tenants use`
- Login to another tenant and repeat the above commands, using a different tenant
- Verify the default tenant is set correctly in your config
- Use other commands that show the tenant header and verify the domain is displayed instead of the tenant name (e.g. `apis list`
- Logout
- Verify logged out tenant is removed from the config and the default is set correctly

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
