### PR TITLE
fix: skip snyk on forks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 name: Go
-on: [push]
+on: 
+  pull_request:
+  push:
 jobs:
 
   build:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,6 +2,8 @@ name: Snyk
 on: [pull_request]
 jobs:
   security:
+    # skip running this action if the PR is coming from a fork:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Skipping the Snyk `action` on PRs coming from forks.
Tested here: https://github.com/auth0/auth0-cli/pull/240

![image](https://user-images.githubusercontent.com/11925502/114231721-2f4e6680-9951-11eb-941d-42aecc49dabb.png)

