### PR TITLE
[CLI-131] Handle interrupts in 'logout' and 'tenants use' prompts

### DIFF
--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -35,7 +35,7 @@ func logoutCmd(cli *cli) *cobra.Command {
 
 				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to logout", tenNames, tenNames[0], true)
 				if err := prompt.AskOne(input, &selectedTenant); err != nil {
-					return fmt.Errorf("An unexpected error occurred: %w", err)
+					return handleInputError(err)
 				}
 			} else {
 				requestedTenant := args[0]

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -68,7 +68,7 @@ func useTenantCmd(cli *cli) *cobra.Command {
 
 				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to activate", tenNames, "", true)
 				if err := prompt.AskOne(input, &selectedTenant); err != nil {
-					return fmt.Errorf("An unexpected error occurred: %w", err)
+					return handleInputError(err)
 				}
 			} else {
 				requestedTenant := args[0]


### PR DESCRIPTION
### Description
Use `handleInputError` to handle prompt errors. This change fixes the issue of the user getting an error message when they do a keyboard interrupt.


### References
https://auth0team.atlassian.net/jira/software/projects/CLI/boards/1063?selectedIssue=CLI-131

### Testing
`auth0 logout` with keyboard interrupt:
<img width="437" alt="Screen Shot 2021-04-09 at 1 11 40 PM" src="https://user-images.githubusercontent.com/23509639/114235553-349db800-9935-11eb-9129-a7468f51b9ad.png">

`auth0 logout` without keyboard interrupt:
<img width="330" alt="Screen Shot 2021-04-09 at 1 11 57 PM" src="https://user-images.githubusercontent.com/23509639/114235529-2d76aa00-9935-11eb-8bd3-a20703c7154b.png">


`auth0 tenants use` with keyboard interrupt:
<img width="404" alt="Screen Shot 2021-04-09 at 1 10 15 PM" src="https://user-images.githubusercontent.com/23509639/114235371-f0121c80-9934-11eb-9648-37d1bdea4535.png">

`auth0 tenants use` without keyboard interrupt:
<img width="313" alt="Screen Shot 2021-04-09 at 1 08 50 PM" src="https://user-images.githubusercontent.com/23509639/114235242-be00ba80-9934-11eb-92c5-135e99e2d9c8.png">

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
