### PR TITLE
Style `auth0 test login` post-login page [CLI-126]

### DIFF
--- a/internal/auth/authutil/browser.go
+++ b/internal/auth/authutil/browser.go
@@ -33,9 +33,13 @@ func WaitForBrowserCallback(addr string) (code string, state string, err error) 
 		}
 
 		if cb.code == "" {
-			_, _ = w.Write([]byte("<p>&#10060; Unable to extract code from request, please try authenticating again.</p>"))
+			_, _ = w.Write([]byte(resultPage("Login Failed", 
+			"Unable to extract code from request, please try authenticating again.", 
+			"error-denied")))
 		} else {
-			_, _ = w.Write([]byte("<p>&#128075; You can close the window and go back to the CLI to see the user info and tokens.</p>"))
+			_, _ = w.Write([]byte(resultPage("Login Successful",
+			"You can close the window and go back to the CLI to see the user info and tokens.", 
+			"success-lock")))
 		}
 
 		cbCh <- cb
@@ -61,4 +65,107 @@ func WaitForBrowserCallback(addr string) (code string, state string, err error) 
 	case err := <-errCh:
 		return "", "", err
 	}
+}
+
+func resultPage(title string, message string, iconClass string) string {
+	html := `
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Auth0 CLI</title>
+	<link rel="shortcut icon" href="https://cdn.auth0.com/website/new-homepage/dark-favicon.png" id="favicon"/>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />	
+	<link rel="stylesheet" href="https://cdn.auth0.com/ulp/react-components/1.46.14/css/main.cdn.min.css" />
+	<style id="custom-styles-container">
+	body {
+	  background: #F0F1F3;
+	  font-family: ulp-font, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, sans-serif;
+	}
+	.caf10cc70 {
+	  background: #F0F1F3;
+	}
+	.c404c83d8.c302c4ba1 {
+	  background: #D00E17;
+	}
+	.c404c83d8.ccbc147ad {
+	  background: #0A8852;
+	}
+	.c9ade4631 {
+	  background-color: #635DFF;
+	  color: #ffffff;
+	}
+	.c9ade4631 a,
+	.c9ade4631 a:visited {
+	  color: #ffffff;
+	}
+	.c87085aeb {
+	  background-color: #0A8852;
+	}
+	.c8a6debc4 {
+	  background-color: #D00E17;
+	}
+	.input.c911ad6ee {
+	  border-color: #D00E17;
+	}
+	.error-cloud {
+	  background-color: #D00E17;
+	}
+	.error-fatal {
+	  background-color: #D00E17;
+	}
+	.error-local {
+	  background-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a {
+	  background-color: #D00E17;
+	  border-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a::before {
+	  border-bottom-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a::after {
+	  border-bottom-color: #D00E17;
+	}
+	#alert-trigger {
+	  background-color: #D00E17;
+	}
+	</style>
+	<style>
+	/* By default, hide features for javascript-disabled browsing */
+	/* We use !important to override any css with higher specificity */
+	/* It is also overriden by the styles in <noscript> in the header file */
+	.no-js { display: none !important; }
+	</style>
+	<noscript>
+	<style>
+		/* We use !important to override the default for js enabled */
+		/* If the display should be other than block, it should be defined specifically here */
+		.js-required { display: none !important; }
+		.no-js { display: block !important; }
+	</style>
+	</noscript>
+	<style>.__s16nu9 {display:none;}</style>
+</head>
+<body class="_widget-auto-layout">
+	<main class="_widget c58fd7e0a">
+		<section class="cb38f2048 _prompt-box-outer ced5b89f0 c471522a0">
+			<div class="ce794cbce c66a01acc">
+			<div class="c507241b0 c0fc42669 ca8df1f97" data-event-id="">
+				<div class="c598bf061 cc89f09a3">
+					<span class="c05afb577 %s"></span>
+				</div>
+				<section class="c780c82ff c15e7affd">
+					<h1 class="cd9c1d686 c67d39740 c0c89e88e">%s</h1>
+					<div class="c6db31a88 c1728f1a3 cb059f28c">%s</div>
+				</section>
+			</div>
+			</div>
+		</section>
+	</main>
+</body>
+</html>`
+
+	return fmt.Sprintf(html, iconClass, title, message)
 }

--- a/internal/auth/authutil/browser.go
+++ b/internal/auth/authutil/browser.go
@@ -2,6 +2,7 @@ package authutil
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,13 +34,13 @@ func WaitForBrowserCallback(addr string) (code string, state string, err error) 
 		}
 
 		if cb.code == "" {
-			_, _ = w.Write([]byte(resultPage("Login Failed", 
-			"Unable to extract code from request, please try authenticating again.", 
-			"error-denied")))
+			_, _ = w.Write([]byte(resultPage("Login Failed",
+				"Unable to extract code from request, please try authenticating again.",
+				"error-denied")))
 		} else {
 			_, _ = w.Write([]byte(resultPage("Login Successful",
-			"You can close the window and go back to the CLI to see the user info and tokens.", 
-			"success-lock")))
+				"You can close the window and go back to the CLI to see the user info and tokens.",
+				"success-lock")))
 		}
 
 		cbCh <- cb
@@ -67,105 +68,9 @@ func WaitForBrowserCallback(addr string) (code string, state string, err error) 
 	}
 }
 
-func resultPage(title string, message string, iconClass string) string {
-	html := `
-<!DOCTYPE html>
-<html>
-<head>
-	<title>Auth0 CLI</title>
-	<link rel="shortcut icon" href="https://cdn.auth0.com/website/new-homepage/dark-favicon.png" id="favicon"/>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />	
-	<link rel="stylesheet" href="https://cdn.auth0.com/ulp/react-components/1.46.14/css/main.cdn.min.css" />
-	<style id="custom-styles-container">
-	body {
-	  background: #F0F1F3;
-	  font-family: ulp-font, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, sans-serif;
-	}
-	.caf10cc70 {
-	  background: #F0F1F3;
-	}
-	.c404c83d8.c302c4ba1 {
-	  background: #D00E17;
-	}
-	.c404c83d8.ccbc147ad {
-	  background: #0A8852;
-	}
-	.c9ade4631 {
-	  background-color: #635DFF;
-	  color: #ffffff;
-	}
-	.c9ade4631 a,
-	.c9ade4631 a:visited {
-	  color: #ffffff;
-	}
-	.c87085aeb {
-	  background-color: #0A8852;
-	}
-	.c8a6debc4 {
-	  background-color: #D00E17;
-	}
-	.input.c911ad6ee {
-	  border-color: #D00E17;
-	}
-	.error-cloud {
-	  background-color: #D00E17;
-	}
-	.error-fatal {
-	  background-color: #D00E17;
-	}
-	.error-local {
-	  background-color: #D00E17;
-	}
-	.c03b79ab4.c41a3276a {
-	  background-color: #D00E17;
-	  border-color: #D00E17;
-	}
-	.c03b79ab4.c41a3276a::before {
-	  border-bottom-color: #D00E17;
-	}
-	.c03b79ab4.c41a3276a::after {
-	  border-bottom-color: #D00E17;
-	}
-	#alert-trigger {
-	  background-color: #D00E17;
-	}
-	</style>
-	<style>
-	/* By default, hide features for javascript-disabled browsing */
-	/* We use !important to override any css with higher specificity */
-	/* It is also overriden by the styles in <noscript> in the header file */
-	.no-js { display: none !important; }
-	</style>
-	<noscript>
-	<style>
-		/* We use !important to override the default for js enabled */
-		/* If the display should be other than block, it should be defined specifically here */
-		.js-required { display: none !important; }
-		.no-js { display: block !important; }
-	</style>
-	</noscript>
-	<style>.__s16nu9 {display:none;}</style>
-</head>
-<body class="_widget-auto-layout">
-	<main class="_widget c58fd7e0a">
-		<section class="cb38f2048 _prompt-box-outer ced5b89f0 c471522a0">
-			<div class="ce794cbce c66a01acc">
-			<div class="c507241b0 c0fc42669 ca8df1f97" data-event-id="">
-				<div class="c598bf061 cc89f09a3">
-					<span class="c05afb577 %s"></span>
-				</div>
-				<section class="c780c82ff c15e7affd">
-					<h1 class="cd9c1d686 c67d39740 c0c89e88e">%s</h1>
-					<div class="c6db31a88 c1728f1a3 cb059f28c">%s</div>
-				</section>
-			</div>
-			</div>
-		</section>
-	</main>
-</body>
-</html>`
+//go:embed data/result-page.html
+var resultHTML string
 
-	return fmt.Sprintf(html, iconClass, title, message)
+func resultPage(title string, message string, iconClass string) string {
+	return fmt.Sprintf(resultHTML, iconClass, title, message)
 }

--- a/internal/auth/authutil/data/result-page.html
+++ b/internal/auth/authutil/data/result-page.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Auth0 CLI</title>
+	<link rel="shortcut icon" href="https://cdn.auth0.com/website/new-homepage/dark-favicon.png" id="favicon"/>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="stylesheet" href="https://cdn.auth0.com/ulp/react-components/1.46.14/css/main.cdn.min.css" />
+	<style id="custom-styles-container">
+	body {
+	  background: #F0F1F3;
+	  font-family: ulp-font, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, sans-serif;
+	}
+	.caf10cc70 {
+	  background: #F0F1F3;
+	}
+	.c404c83d8.c302c4ba1 {
+	  background: #D00E17;
+	}
+	.c404c83d8.ccbc147ad {
+	  background: #0A8852;
+	}
+	.c9ade4631 {
+	  background-color: #635DFF;
+	  color: #ffffff;
+	}
+	.c9ade4631 a,
+	.c9ade4631 a:visited {
+	  color: #ffffff;
+	}
+	.c87085aeb {
+	  background-color: #0A8852;
+	}
+	.c8a6debc4 {
+	  background-color: #D00E17;
+	}
+	.input.c911ad6ee {
+	  border-color: #D00E17;
+	}
+	.error-cloud {
+	  background-color: #D00E17;
+	}
+	.error-fatal {
+	  background-color: #D00E17;
+	}
+	.error-local {
+	  background-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a {
+	  background-color: #D00E17;
+	  border-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a::before {
+	  border-bottom-color: #D00E17;
+	}
+	.c03b79ab4.c41a3276a::after {
+	  border-bottom-color: #D00E17;
+	}
+	#alert-trigger {
+	  background-color: #D00E17;
+	}
+	</style>
+	<style>
+	/* By default, hide features for javascript-disabled browsing */
+	/* We use !important to override any css with higher specificity */
+	/* It is also overriden by the styles in <noscript> in the header file */
+	.no-js { display: none !important; }
+	</style>
+	<noscript>
+	<style>
+		/* We use !important to override the default for js enabled */
+		/* If the display should be other than block, it should be defined specifically here */
+		.js-required { display: none !important; }
+		.no-js { display: block !important; }
+	</style>
+	</noscript>
+	<style>.__s16nu9 {display:none;}</style>
+</head>
+<body class="_widget-auto-layout">
+	<main class="_widget c58fd7e0a">
+		<section class="cb38f2048 _prompt-box-outer ced5b89f0 c471522a0">
+			<div class="ce794cbce c66a01acc">
+			<div class="c507241b0 c0fc42669 ca8df1f97" data-event-id="">
+				<div class="c598bf061 cc89f09a3">
+					<span class="c05afb577 %s"></span>
+				</div>
+				<section class="c780c82ff c15e7affd">
+					<h1 class="cd9c1d686 c67d39740 c0c89e88e">%s</h1>
+					<div class="c6db31a88 c1728f1a3 cb059f28c">%s</div>
+				</section>
+			</div>
+			</div>
+		</section>
+	</main>
+</body>
+</html>

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -65,7 +65,7 @@ func (r *Renderer) Heading(text ...string) {
 }
 
 func (r *Renderer) EmptyState(resource string) {
-	fmt.Fprintf(r.MessageWriter, "No %s available.\n", resource)
+	fmt.Fprintf(r.MessageWriter, "No %s available.\n\n", resource)
 }
 
 type View interface {


### PR DESCRIPTION
### Description

This PR styles the post-login page of the `auth0 test login` command, following the style of https://auth0.auth0.com/device/success

https://user-images.githubusercontent.com/5055789/114773638-ae72de80-9d45-11eb-9123-c7cd09fd50be.mp4

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
