### PR TITLE
Make the logs view a little bit more compact

### DIFF
--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -77,7 +77,7 @@ func (v *logView) AsTableRow() []string {
 	return []string{
 		typ,
 		truncate(desc, 50),
-		ansi.Faint(truncate(timeAgo(v.GetDate()), 19)),
+		ansi.Faint(truncate(timeAgo(v.GetDate()), 17)),
 		conn,
 		clientName,
 	}
@@ -122,7 +122,7 @@ func (v *logView) typeDesc() (typ, desc string) {
 		typ = "..."
 	}
 
-	typ = truncate(chunks[0], 20)
+	typ = truncate(chunks[0], 22)
 
 	if len(chunks) == 2 {
 		desc = strings.TrimSuffix(chunks[1], ")")

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -76,7 +76,7 @@ func (v *logView) AsTableRow() []string {
 
 	return []string{
 		typ,
-		truncate(desc, 30),
+		truncate(desc, 50),
 		ansi.Faint(truncate(timeAgo(v.GetDate()), 14)),
 		conn,
 		clientName,

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -122,7 +122,7 @@ func (v *logView) typeDesc() (typ, desc string) {
 		typ = "..."
 	}
 
-	typ = truncate(chunks[0], 20)
+	typ = truncate(chunks[0], 25)
 
 	if len(chunks) == 2 {
 		desc = strings.TrimSuffix(chunks[1], ")")

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -77,7 +77,7 @@ func (v *logView) AsTableRow() []string {
 	return []string{
 		typ,
 		truncate(desc, 50),
-		ansi.Faint(truncate(timeAgo(v.GetDate()), 14)),
+		ansi.Faint(truncate(timeAgo(v.GetDate()), 19)),
 		conn,
 		clientName,
 	}
@@ -122,7 +122,7 @@ func (v *logView) typeDesc() (typ, desc string) {
 		typ = "..."
 	}
 
-	typ = truncate(chunks[0], 25)
+	typ = truncate(chunks[0], 20)
 
 	if len(chunks) == 2 {
 		desc = strings.TrimSuffix(chunks[1], ")")

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -76,8 +76,8 @@ func (v *logView) AsTableRow() []string {
 
 	return []string{
 		typ,
-		truncate(desc, 25),
-		ansi.Faint(truncate(timeAgo(v.GetDate()), 18)),
+		truncate(desc, 30),
+		ansi.Faint(truncate(timeAgo(v.GetDate()), 14)),
 		conn,
 		clientName,
 	}

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -69,15 +69,15 @@ func (v *logView) AsTableRow() []string {
 
 	conn := v.getConnection()
 	if conn == notApplicable {
-		conn = ansi.Faint(truncate(conn, 30))
+		conn = ansi.Faint(truncate(conn, 25))
 	} else {
-		conn = truncate(conn, 30)
+		conn = truncate(conn, 25)
 	}
 
 	return []string{
 		typ,
-		truncate(desc, 50),
-		ansi.Faint(truncate(timeAgo(v.GetDate()), 20)),
+		truncate(desc, 25),
+		ansi.Faint(truncate(timeAgo(v.GetDate()), 18)),
 		conn,
 		clientName,
 	}
@@ -122,7 +122,7 @@ func (v *logView) typeDesc() (typ, desc string) {
 		typ = "..."
 	}
 
-	typ = truncate(chunks[0], 30)
+	typ = truncate(chunks[0], 20)
 
 	if len(chunks) == 2 {
 		desc = strings.TrimSuffix(chunks[1], ")")


### PR DESCRIPTION
### Description

The view of `logs` was taking too much space by default, therefore requiring the use of a lot of horizontal space.
This PR tries to strike a more balanced approach, reducing the minimum horizontal space to 145 chars.

<img width="1137" alt="Screen Shot 2021-04-14 at 18 41 44" src="https://user-images.githubusercontent.com/5055789/114784081-1844b580-9d51-11eb-80fa-ae21e569aa6d.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
