### PR TITLE
docs: link the pkg managers on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With the Auth0 CLI, you can:
 
 ### macOS
 
-#### Homebrew
+#### [Homebrew](https://brew.sh/)
 
 ```bash
 brew install auth0/auth0-cli/auth0
@@ -54,7 +54,7 @@ brew install auth0/auth0-cli/auth0
 
 ### Windows
 
-#### Scoop
+#### [Scoop](https://scoop.sh/)
 
 ```bash
 scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git


### PR DESCRIPTION
minor doc change to link the pkg manager (if you're on a fresh OS installation, you probably don't have homebrew or scoop)