### PR TITLE
feat: adds app open [id] command

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -683,14 +683,12 @@ func openAppCmd(cli *cli) *cobra.Command {
 				inputs.ID = args[0]
 			}
 
-			cfg := cli.config
-			manageUrl := formatManageURL(cfg, inputs.ID)
+			manageUrl := formatManageURL(cli.config, inputs.ID)
 			if manageUrl == "" {
 				cli.renderer.Warnf("Unable to formate the correct URL, please ensure you have run auth0 login and try again.")
 				return nil
 			}
-			err := open.URL(manageUrl)
-			if err != nil {
+			if err := open.URL(manageUrl); err != nil {
 				cli.renderer.Warnf("Couldn't open the URL, please do it manually: %s.", manageUrl)
 			}
 			return nil

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -685,7 +685,7 @@ func openAppCmd(cli *cli) *cobra.Command {
 
 			manageUrl := formatManageURL(cli.config, inputs.ID)
 			if manageUrl == "" {
-				cli.renderer.Warnf("Unable to formate the correct URL, please ensure you have run auth0 login and try again.")
+				cli.renderer.Warnf("Unable to format the correct URL, please ensure you have run auth0 login and try again.")
 				return nil
 			}
 			if err := open.URL(manageUrl); err != nil {


### PR DESCRIPTION
### Description

Adds `apps open <clientID>` command for opening the app settings page in Manage (browser).

<img width="725" alt="Screen Shot 2021-04-16 at 2 14 10 PM" src="https://user-images.githubusercontent.com/70534960/115079462-70e59100-9ebe-11eb-954b-e4ea20f74951.png">
<img width="901" alt="Screen Shot 2021-04-16 at 2 20 14 PM" src="https://user-images.githubusercontent.com/70534960/115079752-e5203480-9ebe-11eb-9835-5613929209cf.png">


