### PR TITLE
Add `tenants open` and `apis open` [CLI-101] [CLI-133]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With the Auth0 CLI, you can:
 
 ### macOS
 
-#### Homebrew
+#### [Homebrew](https://brew.sh/)
 
 ```bash
 brew install auth0/auth0-cli/auth0
@@ -54,7 +54,7 @@ brew install auth0/auth0-cli/auth0
 
 ### Windows
 
-#### Scoop
+#### [Scoop](https://scoop.sh/)
 
 ```bash
 scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
-	"github.com/auth0/auth0-cli/internal/open"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"gopkg.in/auth0.v5/management"
@@ -22,7 +21,6 @@ const (
 	appTypeRegularWeb     = "regular_web"
 	appTypeNonInteractive = "non_interactive"
 	appDefaultURL         = "http://localhost:3000"
-	manageDomain          = "https://manage.auth0.com"
 )
 
 var (
@@ -669,7 +667,7 @@ func openAppCmd(cli *cli) *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Open application settings page in Auth0 Manage",
 		Long:    "Open application settings page in Auth0 Manage.",
-		Example: `auth0 apps open <id>`,
+		Example: "auth0 apps open <id>",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			prepareInteractivity(cmd)
 		},
@@ -683,14 +681,7 @@ func openAppCmd(cli *cli) *cobra.Command {
 				inputs.ID = args[0]
 			}
 
-			manageUrl := formatManageURL(cli.config, inputs.ID)
-			if manageUrl == "" {
-				cli.renderer.Warnf("Unable to format the correct URL, please ensure you have run auth0 login and try again.")
-				return nil
-			}
-			if err := open.URL(manageUrl); err != nil {
-				cli.renderer.Warnf("Couldn't open the URL, please do it manually: %s.", manageUrl)
-			}
+			openManageURL(cli, cli.config.DefaultTenant, formatAppSettingsPath(inputs.ID))
 			return nil
 		},
 	}
@@ -698,26 +689,11 @@ func openAppCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
-func formatManageURL(cfg config, id string) string {
-	if cfg.DefaultTenant == "" || id == "" {
+func formatAppSettingsPath(id string) string {
+	if len(id) == 0 {
 		return ""
 	}
-	// ex: dev-tti06f6y.us.auth0.com
-	s := strings.Split(cfg.DefaultTenant, ".")
-	if len(s) < 4 {
-		return ""
-	}
-	region := s[len(s)-3]
-	tenant := cfg.Tenants[cfg.DefaultTenant].Name
-	if tenant == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/dashboard/%s/%s/applications/%s/settings",
-		manageDomain,
-		region,
-		tenant,
-		id,
-	)
+	return fmt.Sprintf("applications/%s/settings", id)
 }
 
 func apiTypeFor(v string) string {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/open"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"gopkg.in/auth0.v5/management"
@@ -21,6 +22,7 @@ const (
 	appTypeRegularWeb     = "regular_web"
 	appTypeNonInteractive = "non_interactive"
 	appDefaultURL         = "http://localhost:3000"
+	manageDomain          = "https://manage.auth0.com"
 )
 
 var (
@@ -128,6 +130,7 @@ func appsCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(showAppCmd(cli))
 	cmd.AddCommand(updateAppCmd(cli))
 	cmd.AddCommand(deleteAppCmd(cli))
+	cmd.AddCommand(openAppCmd(cli))
 
 	return cmd
 }
@@ -654,6 +657,67 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 	appGrants.RegisterStringSliceU(cmd, &inputs.Grants, nil)
 
 	return cmd
+}
+
+func openAppCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "open",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Open application settings page in Auth0 Manage",
+		Long:    "Open application settings page in Auth0 Manage.",
+		Example: `auth0 apps open <id>`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			prepareInteractivity(cmd)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := appID.Pick(cmd, &inputs.ID, cli.appPickerOptions)
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			manageUrl := formatManageURL(cli.config, inputs.ID)
+			if manageUrl == "" {
+				cli.renderer.Warnf("Unable to format the correct URL, please ensure you have run auth0 login and try again.")
+				return nil
+			}
+			if err := open.URL(manageUrl); err != nil {
+				cli.renderer.Warnf("Couldn't open the URL, please do it manually: %s.", manageUrl)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func formatManageURL(cfg config, id string) string {
+	if cfg.DefaultTenant == "" || id == "" {
+		return ""
+	}
+	// ex: dev-tti06f6y.us.auth0.com
+	s := strings.Split(cfg.DefaultTenant, ".")
+	if len(s) < 4 {
+		return ""
+	}
+	region := s[len(s)-3]
+	tenant := cfg.Tenants[cfg.DefaultTenant].Name
+	if tenant == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/dashboard/%s/%s/applications/%s/settings",
+		manageDomain,
+		region,
+		tenant,
+		id,
+	)
 }
 
 func apiTypeFor(v string) string {

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -144,7 +144,7 @@ func (c *cli) tenantPickerOptions() (pickerOptions, error) {
 		return nil, fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
 	}
 
-    var priorityOpts, opts pickerOptions
+	var priorityOpts, opts pickerOptions
 
 	for _, t := range tens {
 		opt := pickerOption{value: t.Domain, label: t.Domain}

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -7,6 +7,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	tenantDomain = Argument{
+		Name: "Tenant",
+		Help: "Tenant to select",
+	}
+)
+
 func tenantsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tenants",
@@ -17,6 +24,7 @@ func tenantsCmd(cli *cli) *cobra.Command {
 	cmd.SetUsageTemplate(resourceUsageTemplate())
 	cmd.AddCommand(useTenantCmd(cli))
 	cmd.AddCommand(listTenantCmd(cli))
+	cmd.AddCommand(openTenantCmd(cli))
 	return cmd
 }
 
@@ -92,4 +100,68 @@ func useTenantCmd(cli *cli) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func openTenantCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Domain string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "open",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Open tenant settings page in Auth0 Manage",
+		Long:    "Open tenant settings page in Auth0 Manage.",
+		Example: "auth0 tenants open <tenant>",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			prepareInteractivity(cmd)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := tenantDomain.Pick(cmd, &inputs.Domain, cli.tenantPickerOptions)
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.Domain = args[0]
+
+				if _, ok := cli.config.Tenants[inputs.Domain]; !ok {
+					return fmt.Errorf("Unable to find tenant %s; run 'auth0 login' to configure a new tenant", inputs.Domain)
+				}
+			}
+
+			openManageURL(cli, inputs.Domain, "tenant/general")
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func (c *cli) tenantPickerOptions() (pickerOptions, error) {
+	tens, err := c.listTenants()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+	}
+
+	var (
+		priorityOpts, opts pickerOptions
+	)
+
+	for _, t := range tens {
+		opt := pickerOption{value: t.Domain, label: t.Domain}
+
+		// check if this is currently the default tenant.
+		if t.Domain == c.config.DefaultTenant {
+			priorityOpts = append(priorityOpts, opt)
+		} else {
+			opts = append(opts, opt)
+		}
+	}
+
+	if len(opts)+len(priorityOpts) == 0 {
+		return nil, errNoApps
+	}
+
+	return append(priorityOpts, opts...), nil
 }

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -144,7 +144,7 @@ func (c *cli) tenantPickerOptions() (pickerOptions, error) {
 		return nil, fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
 	}
 
-          var priorityOpts, opts pickerOptions
+    var priorityOpts, opts pickerOptions
 
 	for _, t := range tens {
 		opt := pickerOption{value: t.Domain, label: t.Domain}


### PR DESCRIPTION
### Description

This PR adds the following commands:
- `tenants open` that opens the tenant's settings page on the Dashboard. It takes the tenant's domain as a parameter.
- `apis open` that opens the API's settings page on the Dashboard. It takes either the API Id or audience as a parameter.

This is important as it provides a handy escape hatch, because the CLI does not support every parameter available for APIs, and does not allow to configure tenants ATM.

This PR also fixes a bug that caused the open logic to not work with PUS1 tenants, that do not have the region in the URL.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
