### PR TITLE
fix: polling faster error #252

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	clientID           = "2iZo3Uczt5LFHacKdM0zzgUO2eG2uDjT"
-	deviceCodeEndpoint = "https://auth0.auth0.com/oauth/device/code"
-	oauthTokenEndpoint = "https://auth0.auth0.com/oauth/token"
-	audiencePath       = "/api/v2/"
+	clientID               = "2iZo3Uczt5LFHacKdM0zzgUO2eG2uDjT"
+	deviceCodeEndpoint     = "https://auth0.auth0.com/oauth/device/code"
+	oauthTokenEndpoint     = "https://auth0.auth0.com/oauth/token"
+	audiencePath           = "/api/v2/"
+	waitThresholdInSeconds = 3
 
 	// namespace used to set/get values from the keychain
 	SecretsNamespace = "auth0-cli"
@@ -59,7 +60,7 @@ type State struct {
 }
 
 func (s *State) IntervalDuration() time.Duration {
-	return time.Duration(s.Interval) * time.Second
+	return time.Duration(s.Interval+waitThresholdInSeconds) * time.Second
 }
 
 // Start kicks-off the device authentication flow


### PR DESCRIPTION
Adding a threshold to prevent this error:
```
login error: You are polling faster than the specified interval of (...)
```
fixes #252

![image](https://user-images.githubusercontent.com/11925502/115907362-26748f00-a43f-11eb-8140-44fc2587ebd7.png)
