### PR TITLE
feat: login when scopes changed

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -32,6 +32,9 @@ var requiredScopes = []string{
 	"read:client_keys", "read:logs",
 }
 
+// RequiredScopes returns the scopes used for login.
+func RequiredScopes() []string { return requiredScopes }
+
 // SecretStore provides access to stored sensitive data.
 type SecretStore interface {
 	// Get gets the secret

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -79,6 +79,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) error {
 		ExpiresAt: time.Now().Add(
 			time.Duration(res.ExpiresIn) * time.Second,
 		),
+		Scopes: auth.RequiredScopes(),
 	})
 	if err != nil {
 		return fmt.Errorf("Unexpected error adding tenant to config: %w", err)


### PR DESCRIPTION
Check if the required scopes changed and re-triggers the login flow in that case.

The scopes used are persisted on the config (tenant entity) just like the expiration date. 

**first time running this version will trigger a login since the config files are outdated**

_running any command with scopes out of date_
![image](https://user-images.githubusercontent.com/11925502/115913651-4445f200-a447-11eb-8120-27d7a6178066.png)

_scopes persisted_
![image](https://user-images.githubusercontent.com/11925502/115913684-4c9e2d00-a447-11eb-82fe-3b4aa6a18b05.png)

_after that, until scopes change again, the login is not required_
![image](https://user-images.githubusercontent.com/11925502/115913782-6b9cbf00-a447-11eb-872f-0999c7b6f193.png)

