### PR TITLE
fix: wrong jwtconfig lifetime type

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -111,6 +111,12 @@ var (
 		Help:       "List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.",
 		IsRequired: false,
 	}
+	exludedFields = []string{
+		// woraround for issue when ocassionally
+		// (probably legacy apps) arrive at the SDK
+		// with a `lifetime_in_seconds` value as string instead of int:
+		"jwt_configuration.lifetime_in_seconds",
+	}
 )
 
 func appsCmd(cli *cli) *cobra.Command {
@@ -197,7 +203,7 @@ auth0 apps ls`,
 
 			if err := ansi.Waiting(func() error {
 				var err error
-				list, err = cli.api.Client.List()
+				list, err = cli.api.Client.List(management.ExcludeFields(exludedFields...))
 				return err
 			}); err != nil {
 				return fmt.Errorf("An unexpected error occurred: %w", err)

--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/auth0.v5/management"
 )
 
-func TestClientsListCmd(t *testing.T) {
+func TestAppsListCmd(t *testing.T) {
 	// Step 1: Setup our client mock for this test. We only care about
 	// Clients so no need to bootstrap other bits.
 	ctrl := gomock.NewController(t)
@@ -19,7 +19,7 @@ func TestClientsListCmd(t *testing.T) {
 
 	clientAPI := auth0.NewMockClientAPI(ctrl)
 	clientAPI.EXPECT().
-		List().
+		List(gomock.Any()).
 		Return(&management.ClientList{
 			Clients: []*management.Client{
 				{


### PR DESCRIPTION
Exclude the `jwt_configuration.lifetime_in_seconds` file from the Clients.List operation.
We experienced the following error in some cases:

```
 ▸    json: cannot unmarshal string into Go struct field ClientJWTConfiguration.clients.jwt_configuration.lifetime_in_seconds of type int
exit status 1
```

From the investigation, it seems that legacy application are returning a `jwt_configuration.lifetime_in_seconds` of type **string** instead of **int*. Since this field is not used on the CLI, we can safely ignore it for now.


_verifying that the field is being excluded_
![image](https://user-images.githubusercontent.com/11925502/115915378-a1db3e00-a449-11eb-92a3-3bb6a99bb4e6.png)

_apps list command working as expected since the excluded field is not used_
![image](https://user-images.githubusercontent.com/11925502/115915665-04343e80-a44a-11eb-95c6-435a23b6d5c6.png)


_replicated the issue when logged with a github account, and listing a pretty old application_
```
"jwt_configuration":{
            "lifetime_in_seconds":"36000" <----- this should be a number instead of a string.
         },
```
