### PR TITLE
Make the `--no-color` flag global [CLI-143]

### DIFF
--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -88,6 +88,12 @@ func Red(text string) string {
 	return color.Sprintf(color.Red(text))
 }
 
+// BrightRed returns text colored bright red
+func BrightRed(text string) string {
+	color := Color(os.Stdout)
+	return color.Sprintf(color.BrightRed(text))
+}
+
 // Green returns text colored green
 func Green(text string) string {
 	color := Color(os.Stdout)
@@ -98,6 +104,12 @@ func Green(text string) string {
 func Yellow(text string) string {
 	color := Color(os.Stdout)
 	return color.Sprintf(color.Yellow(text))
+}
+
+// BrightYellow returns text colored bright yellow
+func BrightYellow(text string) string {
+	color := Color(os.Stdout)
+	return color.Sprintf(color.BrightYellow(text))
 }
 
 // Blue returns text colored blue

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -79,6 +79,7 @@ type cli struct {
 	format  string
 	force   bool
 	noInput bool
+	noColor bool
 
 	// config state management.
 	initOnce sync.Once

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -24,12 +24,6 @@ var (
 		ShortForm: "n",
 		Help:      "Number of log entries to show.",
 	}
-
-	logsNoColor = Flag{
-		Name:     "Disable Color",
-		LongForm: "no-color",
-		Help:     "Disable colored log output.",
-	}
 )
 
 func logsCmd(cli *cli) *cobra.Command {
@@ -50,7 +44,6 @@ func listLogsCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		ClientID string
 		Num      int
-		NoColor  bool
 	}
 
 	cmd := &cobra.Command{
@@ -88,14 +81,13 @@ auth0 logs ls -n 100`,
 				cli.api.ActionExecution, time.Second,
 			)
 
-			cli.renderer.LogList(list, logsCh, actionExecutionAPI, inputs.NoColor, !cli.debug)
+			cli.renderer.LogList(list, logsCh, actionExecutionAPI, !cli.debug)
 			return nil
 		},
 	}
 
 	logsClientID.RegisterString(cmd, &inputs.ClientID, "")
 	logsNum.RegisterInt(cmd, &inputs.Num, 100)
-	logsNoColor.RegisterBool(cmd, &inputs.NoColor, false)
 	return cmd
 }
 
@@ -103,7 +95,6 @@ func tailLogsCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		ClientID string
 		Num      int
-		NoColor  bool
 	}
 
 	cmd := &cobra.Command{
@@ -181,14 +172,13 @@ auth0 logs tail -n 100`,
 				cli.api.ActionExecution, time.Second,
 			)
 
-			cli.renderer.LogList(list, logsCh, actionExecutionAPI, inputs.NoColor, !cli.debug)
+			cli.renderer.LogList(list, logsCh, actionExecutionAPI, !cli.debug)
 			return nil
 		},
 	}
 
 	logsClientID.RegisterString(cmd, &inputs.ClientID, "")
 	logsNum.RegisterInt(cmd, &inputs.Num, 100)
-	logsNoColor.RegisterBool(cmd, &inputs.NoColor, false)
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,8 @@ func Execute() {
 				return nil
 			}
 
+			ansi.DisableColors = cli.noColor
+
 			// Initialize everything once. Later callers can then
 			// freely assume that config is fully primed and ready
 			// to go.
@@ -82,6 +84,8 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVar(&cli.noInput,
 		"no-input", false, "Disable interactivity.")
 
+	rootCmd.PersistentFlags().BoolVar(&cli.noColor,
+		"no-color", false, "Disable colors.")	
 	// order of the comamnds here matters
 	// so add new commands in a place that reflect its relevance or relation with other commands:
 	rootCmd.AddCommand(loginCmd(cli))

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/charmbracelet/glamour"
-	"github.com/logrusorgru/aurora"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -45,17 +44,17 @@ func (r *Renderer) Newline() {
 }
 
 func (r *Renderer) Infof(format string, a ...interface{}) {
-	fmt.Fprint(r.MessageWriter, aurora.Green(" ▸    "))
+	fmt.Fprint(r.MessageWriter, ansi.Green(" ▸    "))
 	fmt.Fprintf(r.MessageWriter, format+"\n", a...)
 }
 
 func (r *Renderer) Warnf(format string, a ...interface{}) {
-	fmt.Fprint(r.MessageWriter, aurora.Yellow(" ▸    "))
+	fmt.Fprint(r.MessageWriter, ansi.Yellow(" ▸    "))
 	fmt.Fprintf(r.MessageWriter, format+"\n", a...)
 }
 
 func (r *Renderer) Errorf(format string, a ...interface{}) {
-	fmt.Fprint(r.MessageWriter, aurora.BrightRed(" ▸    "))
+	fmt.Fprint(r.MessageWriter, ansi.BrightRed(" ▸    "))
 	fmt.Fprintf(r.MessageWriter, format+"\n", a...)
 }
 

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
-	"github.com/logrusorgru/aurora"
 
 	"gopkg.in/auth0.v5/management"
 	"gopkg.in/yaml.v2"
@@ -26,8 +25,7 @@ type logCategory int
 var _ View = &logView{}
 
 type logView struct {
-	silent  bool
-	noColor bool
+	silent bool
 	*management.Log
 
 	ActionExecutionAPI auth0.ActionExecutionAPI
@@ -130,23 +128,21 @@ func (v *logView) typeDesc() (typ, desc string) {
 
 	desc = fmt.Sprintf("%s %s", desc, auth0.StringValue(v.Description))
 
-	if !v.noColor {
-		switch v.category() {
-		case logCategorySuccess:
-			typ = aurora.Green(typ).String()
-		case logCategoryFailure:
-			typ = aurora.BrightRed(typ).String()
-		case logCategoryWarning:
-			typ = aurora.BrightYellow(typ).String()
-		default:
-			typ = ansi.Faint(typ)
-		}
+	switch v.category() {
+	case logCategorySuccess:
+		typ = ansi.Green(typ)
+	case logCategoryFailure:
+		typ = ansi.BrightRed(typ)
+	case logCategoryWarning:
+		typ = ansi.BrightYellow(typ)
+	default:
+		typ = ansi.Faint(typ)
 	}
 
 	return typ, desc
 }
 
-func (r *Renderer) LogList(logs []*management.Log, ch <-chan []*management.Log, api auth0.ActionExecutionAPI, noColor, silent bool) {
+func (r *Renderer) LogList(logs []*management.Log, ch <-chan []*management.Log, api auth0.ActionExecutionAPI, silent bool) {
 	resource := "logs"
 
 	r.Heading(resource)
@@ -159,7 +155,7 @@ func (r *Renderer) LogList(logs []*management.Log, ch <-chan []*management.Log, 
 
 	var res []View
 	for _, l := range logs {
-		res = append(res, &logView{Log: l, ActionExecutionAPI: api, silent: silent, noColor: noColor})
+		res = append(res, &logView{Log: l, ActionExecutionAPI: api, silent: silent})
 	}
 
 	var viewChan chan View
@@ -172,7 +168,7 @@ func (r *Renderer) LogList(logs []*management.Log, ch <-chan []*management.Log, 
 
 			for list := range ch {
 				for _, l := range list {
-					viewChan <- &logView{Log: l, ActionExecutionAPI: api, silent: silent, noColor: noColor}
+					viewChan <- &logView{Log: l, ActionExecutionAPI: api, silent: silent}
 				}
 			}
 		}()


### PR DESCRIPTION
### Description

This PR makes the `--no-color` flag global, as it was only previously defined for `logs` commands. The display logic was updated to take that value into account, and direct uses of the underlying `aurora` library have been fixed to use the wrapper `ansi` package instead.

<img width="452" alt="Screen Shot 2021-04-26 at 16 02 43" src="https://user-images.githubusercontent.com/5055789/116138008-ad796f80-a6aa-11eb-9d7c-4a768fffffd2.png">
<img width="979" alt="Screen Shot 2021-04-26 at 16 05 31" src="https://user-images.githubusercontent.com/5055789/116138015-b0746000-a6aa-11eb-8835-f5a25f63d3b4.png">


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
