### PR TITLE
Fix flag issues on `apps create` and `apps update` [CLI-146]

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -289,7 +289,7 @@ auth0 apis update -n myapi -e 6100 --offline-access=true`,
 				return err
 			}
 
-			if !cmd.Flags().Changed(apiOfflineAccess.LongForm) {
+			if !apiOfflineAccess.IsSet(cmd) {
 				inputs.AllowOfflineAccess = auth0.BoolValue(current.AllowOfflineAccess)
 			}
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -355,7 +355,7 @@ auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <descripti
 			appIsSPA := apiTypeFor(inputs.Type) == appTypeSPA
 
 			// Prompt for callback URLs if app is not m2m
-			if !appIsM2M {
+			if !appIsM2M && !appCallbacks.IsSet(cmd) {
 				var defaultValue string
 
 				if !appIsNative {
@@ -368,7 +368,7 @@ auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <descripti
 			}
 
 			// Prompt for logout URLs if app is not m2m
-			if !appIsM2M {
+			if !appIsM2M && !appLogoutURLs.IsSet(cmd) {
 				var defaultValue string
 
 				if !appIsNative {
@@ -381,7 +381,7 @@ auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <descripti
 			}
 
 			// Prompt for allowed origins URLs if app is SPA
-			if appIsSPA {
+			if appIsSPA && !appOrigins.IsSet(cmd) {
 				defaultValue := appDefaultURL
 
 				if err := appOrigins.AskMany(cmd, &inputs.AllowedOrigins, &defaultValue); err != nil {
@@ -390,7 +390,7 @@ auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <descripti
 			}
 
 			// Prompt for allowed web origins URLs if app is SPA
-			if appIsSPA {
+			if appIsSPA && !appWebOrigins.IsSet(cmd) {
 				defaultValue := appDefaultURL
 
 				if err := appWebOrigins.AskMany(cmd, &inputs.AllowedWebOrigins, &defaultValue); err != nil {
@@ -519,7 +519,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 			appIsSPA := apiTypeFor(inputs.Type) == appTypeSPA
 
 			// Prompt for callback URLs if app is not m2m
-			if !appIsM2M {
+			if !appIsM2M && !appCallbacks.IsSet(cmd) {
 				var defaultValue string
 
 				if !appIsNative {
@@ -536,7 +536,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 			}
 
 			// Prompt for logout URLs if app is not m2m
-			if !appIsM2M {
+			if !appIsM2M && !appLogoutURLs.IsSet(cmd) {
 				var defaultValue string
 
 				if !appIsNative {
@@ -553,7 +553,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 			}
 
 			// Prompt for allowed origins URLs if app is SPA
-			if appIsSPA {
+			if appIsSPA && !appOrigins.IsSet(cmd) {
 				defaultValue := appDefaultURL
 
 				if len(current.AllowedOrigins) > 0 {
@@ -566,7 +566,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 			}
 
 			// Prompt for allowed web origins URLs if app is SPA
-			if appIsSPA {
+			if appIsSPA && !appWebOrigins.IsSet(cmd) {
 				defaultValue := appDefaultURL
 
 				if len(current.WebOrigins) > 0 {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -33,6 +33,10 @@ func (f Flag) GetIsRequired() bool {
 	return f.IsRequired
 }
 
+func (f *Flag) IsSet(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed(f.LongForm)
+}
+
 func (f *Flag) Ask(cmd *cobra.Command, value interface{}, defaultValue *string) error {
 	return askFlag(cmd, f, value, defaultValue, false)
 }

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -313,7 +313,7 @@ auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
 				return err
 			}
 
-			if !cmd.Flags().Changed(ruleEnabled.LongForm) {
+			if !ruleEnabled.IsSet(cmd) {
 				inputs.Enabled = auth0.BoolValue(rule.Enabled)
 			}
 


### PR DESCRIPTION
### Description

This PR fixes a series of issues whereby the values of some flags passed to `apps create` and `apps update` would be lost. The flags affected were `--callbacks`, `--logout-urls`, `--origins` and `--web-origins`.

<img width="1025" alt="Screen Shot 2021-04-28 at 21 39 37" src="https://user-images.githubusercontent.com/5055789/116489322-1576b400-a86b-11eb-95a6-57b115ad08c3.png">

<img width="830" alt="Screen Shot 2021-04-28 at 21 40 11" src="https://user-images.githubusercontent.com/5055789/116489331-19a2d180-a86b-11eb-88ea-b294c167fee9.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
