### PR TITLE
Add support for M1 macs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
   - CGO_ENABLED=0
   goarch:
   - amd64
+  - arm64
   goos:
   - darwin
   - linux


### PR DESCRIPTION
### Description

This PR adds `arm64` to the `goarch` list in the Goreleaser config, to support M1 macs and arm Linux.

<img width="701" alt="Screen Shot 2021-04-30 at 15 15 49" src="https://user-images.githubusercontent.com/5055789/116737256-66032400-a9c7-11eb-8bc5-3a46fa08a4d1.png">

### References

Fixes #255

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
