### PR TITLE
fix: app picker needs to also ignore lifetime in seconds

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -840,7 +840,7 @@ func interfaceToStringSlice(s []interface{}) []string {
 }
 
 func (c *cli) appPickerOptions() (pickerOptions, error) {
-	list, err := c.api.Client.List()
+	list, err := c.api.Client.List(management.ExcludeFields(clientExcludedList...))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Missed this in  #275.