### PR TITLE
Refactor prepare interactivity [CLI-79]

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -129,9 +129,6 @@ func showApiCmd(cli *cli) *cobra.Command {
 		Long:  "Show an API.",
 		Example: `auth0 apis show 
 auth0 apis show <id|audience>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := apiID.Pick(cmd, &inputs.ID, cli.apiPickerOptions)
@@ -179,9 +176,6 @@ auth0 apis create --name myapi
 auth0 apis create -n myapi --identifier http://my-api
 auth0 apis create -n myapi --token-expiration 6100
 auth0 apis create -n myapi -e 6100 --offline-access=true`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := apiName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -253,9 +247,6 @@ auth0 apis update <id|audience>
 auth0 apis update <id|audience> --name myapi
 auth0 apis update -n myapi --token-expiration 6100
 auth0 apis update -n myapi -e 6100 --offline-access=true`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.ResourceServer
 
@@ -350,9 +341,6 @@ func deleteApiCmd(cli *cli) *cobra.Command {
 		Long:  "Delete an API.",
 		Example: `auth0 apis delete 
 auth0 apis delete <id|audience>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := apiID.Pick(cmd, &inputs.ID, cli.apiPickerOptions)
@@ -396,9 +384,6 @@ func openApiCmd(cli *cli) *cobra.Command {
 		Long:  "Open API settings page in Auth0 Manage.",
 		Example: `auth0 apis open
 auth0 apis open <id|audience>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := apiID.Pick(cmd, &inputs.ID, cli.apiPickerOptions)
@@ -449,9 +434,6 @@ func listScopesCmd(cli *cli) *cobra.Command {
 		Long:    "List the scopes of an API.",
 		Example: `auth0 apis scopes list 
 auth0 apis scopes ls <id|audience>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := apiID.Pick(cmd, &inputs.ID, cli.apiPickerOptions)

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -151,10 +151,6 @@ func useAppCmd(cli *cli) *cobra.Command {
 		Short:   "Choose a default application for the Auth0 CLI",
 		Long:    "Specify your preferred application for interaction with the Auth0 CLI.",
 		Example: "auth0 apps use <client-id>",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if inputs.None {
 				inputs.ID = ""
@@ -229,9 +225,6 @@ func showAppCmd(cli *cli) *cobra.Command {
 		Long:  "Show an application.",
 		Example: `auth0 apps show 
 auth0 apps show <id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := appID.Pick(cmd, &inputs.ID, cli.appPickerOptions)
@@ -273,9 +266,6 @@ func deleteAppCmd(cli *cli) *cobra.Command {
 		Long:  "Delete an application.",
 		Example: `auth0 apps delete 
 auth0 apps delete <id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := appID.Pick(cmd, &inputs.ID, cli.appPickerOptions)
@@ -331,9 +321,6 @@ func createAppCmd(cli *cli) *cobra.Command {
 auth0 apps create --name myapp 
 auth0 apps create -n myapp --type [native|spa|regular|m2m]
 auth0 apps create -n myapp -t [native|spa|regular|m2m] -- description <description>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prompt for app name
 			if err := appName.Ask(cmd, &inputs.Name, nil); err != nil {
@@ -480,9 +467,6 @@ func updateAppCmd(cli *cli) *cobra.Command {
 		Example: `auth0 apps update <id> 
 auth0 apps update <id> --name myapp 
 auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.Client
 
@@ -674,9 +658,6 @@ func openAppCmd(cli *cli) *cobra.Command {
 		Short:   "Open application settings page in Auth0 Manage",
 		Long:    "Open application settings page in Auth0 Manage.",
 		Example: "auth0 apps open <id>",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := appID.Pick(cmd, &inputs.ID, cli.appPickerOptions)

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -55,9 +55,6 @@ func listLogsCmd(cli *cli) *cobra.Command {
 		Example: `auth0 logs list
 auth0 logs list --client-id <id>
 auth0 logs ls -n 100`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			list, err := getLatestLogs(cli, inputs.Num, inputs.ClientID)
 			if err != nil {
@@ -105,9 +102,6 @@ func tailLogsCmd(cli *cli) *cobra.Command {
 		Example: `auth0 logs tail
 auth0 logs tail --client-id <id>
 auth0 logs tail -n 100`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			lastLogID := ""
 			list, err := getLatestLogs(cli, inputs.Num, inputs.ClientID)

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -112,9 +112,6 @@ func downloadQuickstartCmd(cli *cli) *cobra.Command {
 		Long:  "Download a Quickstart sample app for a specific tech stack.",
 		Example: `auth0 quickstarts download --stack <stack>
 auth0 qs download --stack <stack>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !canPrompt(cmd) {
 				return errors.New("This command can only be run on interactive mode")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -62,6 +62,8 @@ func Execute() {
 
 			ansi.DisableColors = cli.noColor
 
+			prepareInteractivity(cmd)
+
 			// Initialize everything once. Later callers can then
 			// freely assume that config is fully primed and ready
 			// to go.

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -127,9 +127,6 @@ func createRuleCmd(cli *cli) *cobra.Command {
 auth0 rules create --name "My Rule"
 auth0 rules create -n "My Rule" --template "Empty rule"
 auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ruleName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -191,9 +188,6 @@ func showRuleCmd(cli *cli) *cobra.Command {
 		Long:  "Show a rule.",
 		Example: `auth0 rules show 
 auth0 rules show <id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]
@@ -236,9 +230,6 @@ func deleteRuleCmd(cli *cli) *cobra.Command {
 		Long:  "Delete a rule.",
 		Example: `auth0 rules delete 
 auth0 rules delete <rule-id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]
@@ -286,9 +277,6 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 		Example: `auth0 rules update <rule-id> 
 auth0 rules update <rule-id> --name "My Updated Rule"
 auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]
@@ -380,9 +368,6 @@ func enableRuleCmd(cli *cli) *cobra.Command {
 		Short: "Enable a rule",
 		Long:  "Enable a rule.",
 		Example: `auth0 rules enable <rule-id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]
@@ -435,9 +420,6 @@ func disableRuleCmd(cli *cli) *cobra.Command {
 		Short: "Disable a rule",
 		Long:  "Disable a rule.",
 		Example: `auth0 rules disable <rule-id>`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -83,9 +83,6 @@ func updateBrandingTemplateCmd(cli *cli) *cobra.Command {
 		Short:   "Update the custom template for Universal Login",
 		Long:    "Update the custom template for Universal Login.",
 		Example: "auth0 branding templates update",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var templateData *branding.TemplateData
 			err := ansi.Waiting(func() error {

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -61,9 +61,6 @@ func useTenantCmd(cli *cli) *cobra.Command {
 		Short:   "Set the active tenant",
 		Long:    "Set the active tenant.",
 		Example: "auth0 tenants use <tenant>",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var selectedTenant string
 			if len(args) == 0 {
@@ -113,9 +110,6 @@ func openTenantCmd(cli *cli) *cobra.Command {
 		Short:   "Open tenant settings page in Auth0 Manage",
 		Long:    "Open tenant settings page in Auth0 Manage.",
 		Example: "auth0 tenants open <tenant>",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := tenantDomain.Pick(cmd, &inputs.Domain, cli.tenantPickerOptions)

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -87,7 +87,7 @@ func deleteUserBlocksCmd(cli *cli) *cobra.Command {
 		Use:     "unblock",
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Delete brute-force protection blocks for a given user",
-		Long:    "Delete brute-force protection blocks for a given user",
+		Long:    "Delete brute-force protection blocks for a given user.",
 		Example: "auth0 users unblock <user-id>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -44,16 +44,11 @@ func listUserBlocksCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List brute-force protection blocks for a given user",
-		Long: `List brute-force protection blocks for a given user:
-
-auth0 users blocks list <user-id>
-`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
+		Use:     "list",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List brute-force protection blocks for a given user",
+		Long:    "List brute-force protection blocks for a given user.",
+		Example: "auth0 users blocks list <user-id>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				if err := userID.Ask(cmd, &inputs.userID); err != nil {
@@ -89,16 +84,11 @@ func deleteUserBlocksCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "unblock",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Delete brute-force protection blocks for a given user",
-		Long: `Delete brute-force protection blocks for a given user:
-
-auth0 users unblock <user-id>
-`,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			prepareInteractivity(cmd)
-		},
+		Use:     "unblock",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Delete brute-force protection blocks for a given user",
+		Long:    "Delete brute-force protection blocks for a given user",
+		Example: "auth0 users unblock <user-id>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				if err := userID.Ask(cmd, &inputs.userID); err != nil {

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -86,8 +86,8 @@ func deleteUserBlocksCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unblock",
 		Args:    cobra.MaximumNArgs(1),
-		Short:   "Delete brute-force protection blocks for a given user",
-		Long:    "Delete brute-force protection blocks for a given user.",
+		Short:   "Remove brute-force protection blocks for a given user",
+		Long:    "Remove brute-force protection blocks for a given user.",
 		Example: "auth0 users unblock <user-id>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {


### PR DESCRIPTION
### Description

This PR removes every instance of `prepareInteractivity` (in individual commands' pre-run) and replaces it with a single call in the persistent pre-run of the root command.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
