### PR TITLE
feat: add a custom domain picker for `auth0 test login`

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -32,7 +32,7 @@ var requiredScopes = []string{
 	"create:rules", "delete:rules", "read:rules", "update:rules",
 	"read:users", "update:users",
 	"read:branding", "update:branding",
-	"read:client_keys", "read:logs", "read:tenant_settings",
+	"read:client_keys", "read:logs", "read:tenant_settings", "read:custom_domains",
 }
 
 // RequiredScopes returns the scopes used for login.

--- a/internal/auth0/auth0.go
+++ b/internal/auth0/auth0.go
@@ -14,6 +14,7 @@ type API struct {
 	ActionBinding   ActionBindingAPI
 	Branding        BrandingAPI
 	Client          ClientAPI
+	CustomDomain    CustomDomainAPI
 	Log             LogAPI
 	ResourceServer  ResourceServerAPI
 	Rule            RuleAPI
@@ -29,6 +30,7 @@ func NewAPI(m *management.Management) *API {
 		ActionBinding:   m.ActionBinding,
 		Branding:        m.Branding,
 		Client:          m.Client,
+		CustomDomain:    m.CustomDomain,
 		Log:             m.Log,
 		ResourceServer:  m.ResourceServer,
 		Rule:            m.Rule,

--- a/internal/auth0/custom_domain.go
+++ b/internal/auth0/custom_domain.go
@@ -1,0 +1,8 @@
+//go:generate mockgen -source=custom_domain.go -destination=custom_domain_mock.go -package=auth0
+package auth0
+
+import "gopkg.in/auth0.v5/management"
+
+type CustomDomainAPI interface {
+	List(opts ...management.RequestOption) (c []*management.CustomDomain, err error)
+}

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -108,7 +108,7 @@ func runLoginFlowPreflightChecks(cli *cli, c *management.Client) (abort bool) {
 
 // runLoginFlow initiates a full user-facing login flow, waits for a response
 // and returns the retrieved tokens to the caller when done.
-func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, prompt string, scopes []string) (*authutil.TokenResponse, error) {
+func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, prompt string, scopes []string, customDomain string) (*authutil.TokenResponse, error) {
 	var tokenResponse *authutil.TokenResponse
 
 	err := ansi.Spinner("Waiting for login flow to complete", func() error {
@@ -122,8 +122,13 @@ func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, 
 			return err
 		}
 
+		domain := t.Domain
+		if customDomain != "" {
+			domain = customDomain
+		}
+
 		// Build a login URL and initiate login in a browser window.
-		loginURL, err := authutil.BuildLoginURL(t.Domain, c.GetClientID(), cliLoginTestingCallbackURL, state, connName, audience, prompt, scopes)
+		loginURL, err := authutil.BuildLoginURL(domain, c.GetClientID(), cliLoginTestingCallbackURL, state, connName, audience, prompt, scopes)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR also adds a validation to the `auth0 branding template update` command to verify that at least one custom domain exists

![custom-domains](https://user-images.githubusercontent.com/1288192/116889187-a8647500-ac02-11eb-9395-f5d33407868f.gif)
