### PR TITLE
Move configs to the top of the pre-run method

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,8 +31,10 @@ func Execute() {
 		Short:         "Supercharge your development workflow.",
 		Long:          "Supercharge your development workflow.\n" + getLogin(cli),
 		Version:       buildinfo.GetVersionWithCommit(),
-
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ansi.DisableColors = cli.noColor
+			prepareInteractivity(cmd)
+
 			// If the user is trying to login, no need to go
 			// through setup.
 			if cmd.Use == "login" && cmd.Parent().Use == "auth0" {
@@ -59,10 +61,6 @@ func Execute() {
 			if cmd.CalledAs() == "help" && cmd.Parent().Use == "auth0" {
 				return nil
 			}
-
-			ansi.DisableColors = cli.noColor
-
-			prepareInteractivity(cmd)
 
 			// Initialize everything once. Later callers can then
 			// freely assume that config is fully primed and ready


### PR DESCRIPTION
### Description

This PR moves some global config operations to the top of the root pre-run method, as there are (and could be more in the future) commands that could be allowed to run without being logged in, and would need the proper configurations to be in place. Currently, these are at the bottom, and will not run for commands that do not require authentication, because the pre-run method will return early.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
