### PR TITLE
Add auth0.Error [CLI-156]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pierrec/lz4/v4 v4.1.3 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/internal/ansi/spinner.go
+++ b/internal/ansi/spinner.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/briandowns/spinner"
 )
 
@@ -40,7 +41,7 @@ func loading(initialMsg, doneMsg, failMsg string, fn func() error) error {
 		s.Writer = os.Stderr
 
 		if err := s.Color(spinnerColor); err != nil {
-			panic(err)
+			panic(auth0.Error(err, "failed setting spinner color"))
 		}
 
 		s.Start()

--- a/internal/auth0/error.go
+++ b/internal/auth0/error.go
@@ -1,0 +1,7 @@
+package auth0
+
+import "github.com/pkg/errors"
+
+func Error(e error, message string) error {
+	return errors.Wrap(e, message)
+}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -209,7 +210,7 @@ func registerString(cmd *cobra.Command, f *Flag, value *string, defaultValue str
 	cmd.Flags().StringVarP(value, f.LongForm, f.ShortForm, defaultValue, f.Help)
 
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
-		panic(unexpectedError(err)) // TODO: Handle
+		panic(auth0.Error(err, "failed to register string flag"))
 	}
 }
 
@@ -217,7 +218,7 @@ func registerStringSlice(cmd *cobra.Command, f *Flag, value *[]string, defaultVa
 	cmd.Flags().StringSliceVarP(value, f.LongForm, f.ShortForm, defaultValue, f.Help)
 
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
-		panic(unexpectedError(err)) // TODO: Handle
+		panic(auth0.Error(err, "failed to register string slice flag"))
 	}
 }
 
@@ -225,7 +226,7 @@ func registerInt(cmd *cobra.Command, f *Flag, value *int, defaultValue int, isUp
 	cmd.Flags().IntVarP(value, f.LongForm, f.ShortForm, defaultValue, f.Help)
 
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
-		panic(unexpectedError(err)) // TODO: Handle
+		panic(auth0.Error(err, "failed to register int flag"))
 	}
 }
 
@@ -233,7 +234,7 @@ func registerBool(cmd *cobra.Command, f *Flag, value *bool, defaultValue bool, i
 	cmd.Flags().BoolVarP(value, f.LongForm, f.ShortForm, defaultValue, f.Help)
 
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
-		panic(unexpectedError(err)) // TODO: Handle
+		panic(auth0.Error(err, "failed to register bool flag"))
 	}
 }
 

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -46,7 +46,7 @@ var (
 	qsBuf             []byte
 	quickstartsByType = func() (qs map[string][]auth0.Quickstart) {
 		if err := json.Unmarshal(qsBuf, &qs); err != nil {
-			panic(err)
+			panic(auth0.Error(err, "failed to unmarshal data/quickstarts.json"))
 		}
 		return
 	}()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,6 +205,7 @@ github.com/pierrec/lz4/v4/internal/lz4errors
 github.com/pierrec/lz4/v4/internal/lz4stream
 github.com/pierrec/lz4/v4/internal/xxh32
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
### Description

This PR adds a method that wraps every error passed to `panic` to decorate it with a stack trace, using the github.com/pkg/errors package.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
