### PR TITLE
chore: run integration tests verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(GOBIN)/auth0-cli-config-generator:
 	go install ./pkg/auth0-cli-config-generator
 
 run-integration:
-	auth0-cli-config-generator && commander test commander.yaml
+	auth0-cli-config-generator && commander test commander.yaml --verbose
 .PHONY: run-integration
 
 # Delete all test apps created during integration testing


### PR DESCRIPTION
### Description

Runs integration tests w/ `verbose` so we can see if they hang. 

TODO in separate PR - split tests into their own step instead of running in `build`

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
