### PR TITLE
fix: use updated token once after the renewal

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,9 +70,9 @@ var errUnauthenticated = errors.New("Not logged in. Try 'auth0 login'.")
 //
 type cli struct {
 	// core primitives exposed to command builders.
-	api      *auth0.API
-	renderer *display.Renderer
-
+	api          *auth0.API
+	renderer     *display.Renderer
+	activeTenant *tenant
 	// set of flags which are user specified.
 	debug   bool
 	tenant  string
@@ -123,21 +123,36 @@ func (c *cli) setup(ctx context.Context) error {
 		return err
 	}
 
-	t, err := c.getTenant()
+	t, err := c.prepareTenant(ctx)
 	if err != nil {
 		return err
 	}
 
-	if t.AccessToken == "" {
-		return errUnauthenticated
+	m, err := management.New(t.Domain,
+		management.WithStaticToken(t.AccessToken),
+		management.WithUserAgent(fmt.Sprintf("%v/%v", userAgent, strings.TrimPrefix(buildinfo.Version, "v"))))
+	if err != nil {
+		return err
 	}
 
-	if scopesChanged(t) {
-		// required scopes changed,
-		// a new token is required
-		err = RunLogin(ctx, c, true)
+	c.api = auth0.NewAPI(m)
+	return nil
+}
+
+// prepareTenant loads the tenant, refreshing its token if necessary.
+// The tenant access token needs a refresh if:
+// 1. the tenant scopes are different than the currently required scopes.
+// 2. the access token is expired.
+func (c *cli) prepareTenant(ctx context.Context) (tenant, error) {
+	t, err := c.getTenant()
+	if err != nil {
+		return tenant{}, err
+	}
+
+	if t.AccessToken == "" || scopesChanged(t) {
+		t, err = RunLogin(ctx, c, true)
 		if err != nil {
-			return err
+			return tenant{}, err
 		}
 	} else if isExpired(t.ExpiresAt, accessTokenExpThreshold) {
 		// check if the stored access token is expired:
@@ -151,9 +166,9 @@ func (c *cli) setup(ctx context.Context) error {
 		if err != nil {
 			// ask and guide the user through the login process:
 			c.renderer.Errorf("failed to renew access token, %s", err)
-			err = RunLogin(ctx, c, true)
+			t, err = RunLogin(ctx, c, true)
 			if err != nil {
-				return err
+				return tenant{}, err
 			}
 		} else {
 			// persist the updated tenant with renewed access token
@@ -164,24 +179,12 @@ func (c *cli) setup(ctx context.Context) error {
 
 			err = c.addTenant(t)
 			if err != nil {
-				return err
+				return tenant{}, err
 			}
 		}
 	}
 
-	// continue with the command setup:
-	if t.AccessToken != "" {
-		m, err := management.New(t.Domain,
-			management.WithStaticToken(t.AccessToken),
-			management.WithUserAgent(fmt.Sprintf("%v/%v", userAgent, strings.TrimPrefix(buildinfo.Version, "v"))))
-		if err != nil {
-			return err
-		}
-
-		c.api = auth0.NewAPI(m)
-	}
-
-	return err
+	return t, nil
 }
 
 // isExpired is true if now() + a threshold is after the given date

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,9 +70,8 @@ var errUnauthenticated = errors.New("Not logged in. Try 'auth0 login'.")
 //
 type cli struct {
 	// core primitives exposed to command builders.
-	api          *auth0.API
-	renderer     *display.Renderer
-	activeTenant *tenant
+	api      *auth0.API
+	renderer *display.Renderer
 	// set of flags which are user specified.
 	debug   bool
 	tenant  string

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -77,7 +77,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 		cli.renderer.Warnf("Could not store the refresh token locally, please expect to login again once your access token expired. See https://github.com/auth0/auth0-cli/blob/main/KNOWN-ISSUES.md.")
 	}
 
-	err = cli.addTenant(tenant{
+	t := tenant{
 		Name:        res.Tenant,
 		Domain:      res.Domain,
 		AccessToken: res.AccessToken,
@@ -85,7 +85,8 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 			time.Duration(res.ExpiresIn) * time.Second,
 		),
 		Scopes: auth.RequiredScopes(),
-	})
+	}
+	err = cli.addTenant(t)
 	if err != nil {
 		return tenant{}, fmt.Errorf("Unexpected error adding tenant to config: %w", err)
 	}
@@ -101,5 +102,5 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 		}
 	}
 
-	return tenant{}, nil
+	return t, nil
 }


### PR DESCRIPTION
Fix bug regarding old access token being used after the renewal process due to expiration or scopes changed.

_before_
![image](https://user-images.githubusercontent.com/11925502/118321905-ad63d700-b4d4-11eb-92ae-960d9395738f.png)

_after_
![image](https://user-images.githubusercontent.com/11925502/118321918-b3f24e80-b4d4-11eb-9eb2-ebeece787dd3.png)
