### PR TITLE
fix: better development ergonomics

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -86,7 +86,7 @@ func Execute() {
 		"no-input", false, "Disable interactivity.")
 
 	rootCmd.PersistentFlags().BoolVar(&cli.noColor,
-		"no-color", false, "Disable colors.")	
+		"no-color", false, "Disable colors.")
 	// order of the comamnds here matters
 	// so add new commands in a place that reflect its relevance or relation with other commands:
 	rootCmd.AddCommand(loginCmd(cli))
@@ -111,7 +111,15 @@ func Execute() {
 	defer func() {
 		if v := recover(); v != nil {
 			err := fmt.Errorf("panic: %v", v)
-			instrumentation.ReportException(err)
+
+			// If we're in development mode, we should throw the
+			// panic for so we have less surprises. For
+			// non-developers, we'll swallow the panics.
+			if instrumentation.ReportException(err) {
+				fmt.Println(panicMessage)
+			} else {
+				panic(v)
+			}
 		}
 	}()
 
@@ -143,3 +151,10 @@ func contextWithSignal(sigs ...os.Signal) context.Context {
 
 	return ctx
 }
+
+const panicMessage = `
+!!     Uh oh. Something went wrong.
+!!     If this problem keeps happening feel free to report an issue at
+!!
+!!     https://github.com/auth0/auth0-cli/issues/new/choose
+`

--- a/internal/instrumentation/instrumentation.go
+++ b/internal/instrumentation/instrumentation.go
@@ -11,13 +11,13 @@ var SentryDSN string
 
 // ReportException is designed to be called once as the CLI exits. We're
 // purposefully initializing a client all the time given this context.
-func ReportException(err error) {
+func ReportException(err error) bool {
 	if SentryDSN == "" {
-		return
+		return false
 	}
 
 	if err := sentry.Init(sentry.ClientOptions{Dsn: SentryDSN}); err != nil {
-		return
+		return false
 	}
 
 	// Flush buffered events before the program terminates.
@@ -25,4 +25,5 @@ func ReportException(err error) {
 
 	// Allow up to 2s to flush, otherwise quit.
 	sentry.Flush(2 * time.Second)
+	return true
 }


### PR DESCRIPTION
When we're developing, we woudn't want to swallow panics since that can
cause a lot of surprises.

For non-development cases, since we're reporting this, then swallowing
the panic and displaying a basic error message would be enough for the
user to know that something went wrong happened.


<img width="1291" alt="Screen Shot 2021-05-14 at 4 13 20 PM" src="https://user-images.githubusercontent.com/2257/118340026-68897180-b4cf-11eb-8969-608097f76588.png">
