### PR TITLE
feat: auth0 ips { check | unblock }

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -35,6 +35,7 @@ var requiredScopes = []string{
 	"read:branding", "update:branding",
 	"read:connections", "update:connections",
 	"read:client_keys", "read:logs", "read:tenant_settings", "read:custom_domains",
+	"read:anomaly_blocks", "delete:anomaly_blocks",
 }
 
 // RequiredScopes returns the scopes used for login.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -30,6 +30,7 @@ func TestRequiredScopes(t *testing.T) {
 			"read:connections", "update:connections",
 			"read:custom_domains",
 			"read:client_keys", "read:logs", "read:tenant_settings",
+			"read:anomaly_blocks", "delete:anomaly_blocks",
 		}
 
 		for _, v := range list {

--- a/internal/auth0/anomaly.go
+++ b/internal/auth0/anomaly.go
@@ -1,0 +1,17 @@
+package auth0
+
+import "gopkg.in/auth0.v5/management"
+
+type AnomalyAPI interface {
+	// Check if a given IP address is blocked via the multiple user accounts
+	// trigger due to multiple failed logins.
+	//
+	// See: https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id
+	CheckIP(ip string, opts ...management.RequestOption) (isBlocked bool, err error)
+
+	// Unblock an IP address currently blocked by the multiple user accounts
+	// trigger due to multiple failed logins.
+	//
+	// See: https://auth0.com/docs/api/management/v2#!/Anomaly/delete_ips_by_id
+	UnblockIP(ip string, opts ...management.RequestOption) (err error)
+}

--- a/internal/auth0/auth0.go
+++ b/internal/auth0/auth0.go
@@ -8,8 +8,10 @@ import (
 // API mimics `management.Management`s general interface, except it refers to
 // the interfaces instead of the concrete structs.
 type API struct {
+	Anomaly        AnomalyAPI
 	Branding       BrandingAPI
 	Client         ClientAPI
+	Connection     ConnectionAPI
 	CustomDomain   CustomDomainAPI
 	Log            LogAPI
 	ResourceServer ResourceServerAPI
@@ -17,11 +19,11 @@ type API struct {
 	Rule           RuleAPI
 	Tenant         TenantAPI
 	User           UserAPI
-	Connection     ConnectionAPI
 }
 
 func NewAPI(m *management.Management) *API {
 	return &API{
+		Anomaly:        m.Anomaly,
 		Branding:       m.Branding,
 		Client:         m.Client,
 		CustomDomain:   m.CustomDomain,

--- a/internal/cli/ips.go
+++ b/internal/cli/ips.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ipAddress = Argument{
+		Name: "IP",
+		Help: "IP address to check",
+	}
+)
+
+func ipsCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ips",
+		Short:   "Manage blocked IP addresses",
+		Long:    "Manage blocked IP addresses.",
+		Aliases: []string{"ip"},
+	}
+
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(checkIPCmd(cli))
+	cmd.AddCommand(unblockIPCmd(cli))
+
+	return cmd
+}
+
+func checkIPCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		IP string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "check",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Check IP address.",
+		Long:    "Check whether a given IP address is blocked.",
+		Example: "auth0 ips check <ip>",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				ipAddress.Ask(cmd, &inputs.IP)
+			} else {
+				inputs.IP = args[0]
+			}
+
+			var isBlocked bool
+
+			if err := ansi.Waiting(func() error {
+				var err error
+				isBlocked, err = cli.api.Anomaly.CheckIP(inputs.IP)
+				return err
+			}); err != nil {
+				return fmt.Errorf("An unexpected error occurred: %w", err)
+			}
+
+			if isBlocked {
+				cli.renderer.Infof("The IP %s is blocked", inputs.IP)
+			} else {
+				cli.renderer.Infof("The IP %s is not blocked", inputs.IP)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func unblockIPCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		IP string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "unblock",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Unblock IP address.",
+		Long:    "Unblock IP address which is currently blocked.",
+		Example: "auth0 ips unblock <ip>",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				ipAddress.Ask(cmd, &inputs.IP)
+			} else {
+				inputs.IP = args[0]
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.Anomaly.UnblockIP(inputs.IP)
+			}); err != nil {
+				return fmt.Errorf("An unexpected error occurred: %w", err)
+			}
+
+			cli.renderer.Infof("The IP %s was unblocked", inputs.IP)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/ips.go
+++ b/internal/cli/ips.go
@@ -41,7 +41,9 @@ func checkIPCmd(cli *cli) *cobra.Command {
 		Example: "auth0 ips check <ip>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				ipAddress.Ask(cmd, &inputs.IP)
+				if err := ipAddress.Ask(cmd, &inputs.IP); err != nil {
+					return err
+				}
 			} else {
 				inputs.IP = args[0]
 			}
@@ -84,7 +86,9 @@ func unblockIPCmd(cli *cli) *cobra.Command {
 		Example: "auth0 ips unblock <ip>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				ipAddress.Ask(cmd, &inputs.IP)
+				if err := ipAddress.Ask(cmd, &inputs.IP); err != nil {
+					return err
+				}
 			} else {
 				inputs.IP = args[0]
 			}

--- a/internal/cli/ips.go
+++ b/internal/cli/ips.go
@@ -10,16 +10,15 @@ import (
 var (
 	ipAddress = Argument{
 		Name: "IP",
-		Help: "IP address to check",
+		Help: "IP address to check.",
 	}
 )
 
 func ipsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ips",
-		Short:   "Manage blocked IP addresses",
-		Long:    "Manage blocked IP addresses.",
-		Aliases: []string{"ip"},
+		Use:   "ips",
+		Short: "Manage blocked IP addresses",
+		Long:  "Manage blocked IP addresses.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
@@ -37,7 +36,7 @@ func checkIPCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "check",
 		Args:    cobra.MaximumNArgs(1),
-		Short:   "Check IP address.",
+		Short:   "Check IP address",
 		Long:    "Check whether a given IP address is blocked.",
 		Example: "auth0 ips check <ip>",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,6 +55,8 @@ func checkIPCmd(cli *cli) *cobra.Command {
 			}); err != nil {
 				return fmt.Errorf("An unexpected error occurred: %w", err)
 			}
+
+			cli.renderer.Heading("IP")
 
 			if isBlocked {
 				cli.renderer.Infof("The IP %s is blocked", inputs.IP)
@@ -78,8 +79,8 @@ func unblockIPCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unblock",
 		Args:    cobra.MaximumNArgs(1),
-		Short:   "Unblock IP address.",
-		Long:    "Unblock IP address which is currently blocked.",
+		Short:   "Unblock IP address",
+		Long:    "Unblock an IP address which is currently blocked.",
 		Example: "auth0 ips unblock <ip>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -94,6 +95,7 @@ func unblockIPCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("An unexpected error occurred: %w", err)
 			}
 
+			cli.renderer.Heading("IP")
 			cli.renderer.Infof("The IP %s was unblocked", inputs.IP)
 			return nil
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,6 +101,7 @@ func Execute() {
 	rootCmd.AddCommand(logoutCmd(cli))
 	rootCmd.AddCommand(brandingCmd(cli))
 	rootCmd.AddCommand(rolesCmd(cli))
+	rootCmd.AddCommand(ipsCmd(cli))
 
 	// keep completion at the bottom:
 	rootCmd.AddCommand(completionCmd(cli))


### PR DESCRIPTION
This adds the `auth0 ips` command which supports two operations:

- auth0 ips check <ip>
- auth0 ips unblock <ip>

Quick demo shown below: 

[![asciicast](https://asciinema.org/a/XA2JqFei1stMeQZgNJI1pljCR.svg)](https://asciinema.org/a/XA2JqFei1stMeQZgNJI1pljCR)