### PR TITLE
Add missing long command descriptions

### DIFF
--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -71,6 +71,7 @@ func usersCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users",
 		Short: "Manage resources for users",
+		Long: "Manage resources for users.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
@@ -448,7 +449,8 @@ auth0 users open "auth0|xxxxxxxxxx"`,
 func userBlocksCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "blocks",
-		Short: "Manage brute-force protection user blocks.",
+		Short: "Manage brute-force protection user blocks",
+		Long: "Manage brute-force protection user blocks.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())


### PR DESCRIPTION
### Description

This PR adds the missing `Long` description for the commands `users` and `users blocks`.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
