### PR TITLE
Add scopes flag to `test login` [CLI-171]

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -49,7 +49,7 @@ var (
 		Name:      "Scopes",
 		LongForm:  "scopes",
 		ShortForm: "s",
-		Help:      "The list of scope you want to use to generate the token.",
+		Help:      "The list of scopes you want to use.",
 	}
 
 	testDomainArg = Argument{
@@ -85,6 +85,7 @@ func testLoginCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		ClientID       string
 		Audience       string
+		Scopes         []string
 		ConnectionName string
 		CustomDomain   string
 	}
@@ -157,7 +158,7 @@ auth0 test login <client-id> --connection <connection>`,
 				inputs.ConnectionName,
 				inputs.Audience, // audience is only supported for the test token command
 				"login",         // force a login page when using the test login command
-				cliLoginTestingScopes,
+				inputs.Scopes,
 				inputs.CustomDomain,
 			)
 			if err != nil {
@@ -195,6 +196,7 @@ auth0 test login <client-id> --connection <connection>`,
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
 	testAudience.RegisterString(cmd, &inputs.Audience, "")
+	testScopes.RegisterStringSlice(cmd, &inputs.Scopes, cliLoginTestingScopes)
 	testConnection.RegisterString(cmd, &inputs.ConnectionName, "")
 	testDomain.RegisterString(cmd, &inputs.CustomDomain, "")
 	return cmd


### PR DESCRIPTION
### Description

This PR adds the flag `--scopes` to `test login`. The addition makes the CLI more useful for troubleshooting login issues.

<img width="609" alt="Screen Shot 2021-05-28 at 22 42 37" src="https://user-images.githubusercontent.com/5055789/120054562-fbb1c380-c006-11eb-90e9-d3551e35a6a8.png">

<img width="469" alt="Screen Shot 2021-05-28 at 22 47 23" src="https://user-images.githubusercontent.com/5055789/120054564-feacb400-c006-11eb-90b9-5c25e5be6d10.png">

### Testing

This was tested manually by using a proxy to check the sent scopes.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
