### PR TITLE
Add `branding show` and `branding update` [CLI-170]

### DIFF
--- a/internal/auth0/branding.go
+++ b/internal/auth0/branding.go
@@ -5,6 +5,7 @@ import "gopkg.in/auth0.v5/management"
 
 type BrandingAPI interface {
 	Read(opts ...management.RequestOption) (b *management.Branding, err error)
+	Update(t *management.Branding, opts ...management.RequestOption) (err error)
 	UniversalLogin(opts ...management.RequestOption) (ul *management.BrandingUniversalLogin, err error)
 	SetUniversalLogin(ul *management.BrandingUniversalLogin, opts ...management.RequestOption) (err error)
 	DeleteUniversalLogin(opts ...management.RequestOption) (err error)

--- a/internal/cli/branding.go
+++ b/internal/cli/branding.go
@@ -23,6 +23,46 @@ var (
 		IsRequired: true,
 	}
 
+	brandingAccent = Flag{
+		Name:         "Accent Color",
+		LongForm:     "accent",
+		ShortForm:    "a",
+		Help:         "Accent color.",
+		AlwaysPrompt: true,
+	}
+
+	brandingBackground = Flag{
+		Name:         "Background Color",
+		LongForm:     "background",
+		ShortForm:    "b",
+		Help:         "Page background color",
+		AlwaysPrompt: true,
+	}
+
+	brandingLogo = Flag{
+		Name:         "Logo URL",
+		LongForm:     "logo",
+		ShortForm:    "l",
+		Help:         "URL for the logo. Must use HTTPS.",
+		AlwaysPrompt: true,
+	}
+
+	brandingFavicon = Flag{
+		Name:         "Favicon URL",
+		LongForm:     "favicon",
+		ShortForm:    "f",
+		Help:         "URL for the favicon. Must use HTTPS.",
+		AlwaysPrompt: true,
+	}
+
+	brandingFont = Flag{
+		Name:         "Custom Font URL",
+		LongForm:     "font",
+		ShortForm:    "c",
+		Help:         "URL for the custom font. The URL must point to a font file and not a stylesheet. Must use HTTPS.",
+		AlwaysPrompt: true,
+	}
+
 	customTemplateOptions = pickerOptions{
 		{"Basic", branding.DefaultTemplate},
 		{"Login box + image", branding.ImageTemplate},
@@ -40,6 +80,7 @@ func brandingCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(showBrandingCmd(cli))
 	cmd.AddCommand(templateCmd(cli))
 	return cmd
 }
@@ -57,6 +98,33 @@ func templateCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
+func showBrandingCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "show",
+		Args:    cobra.NoArgs,
+		Short:   "Display the custom branding settings for Universal Login",
+		Long:    "Display the custom branding settings for Universal Login.",
+		Example: "auth0 branding show",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var branding *management.Branding // Load app by id
+
+			if err := ansi.Waiting(func() error {
+				var err error
+				branding, err = cli.api.Branding.Read()
+				return err
+			}); err != nil {
+				return fmt.Errorf("Unable to load branding settings due to an unexpected error: %w", err)
+			}
+
+			cli.renderer.BrandingShow(branding)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
 func showBrandingTemplateCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "show",
@@ -65,11 +133,17 @@ func showBrandingTemplateCmd(cli *cli) *cobra.Command {
 		Long:    "Display the custom template for Universal Login.",
 		Example: "auth0 branding templates show",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			template, err := cli.api.Branding.UniversalLogin()
-			if err != nil {
-				return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+			var template *management.BrandingUniversalLogin // Load app by id
+
+			if err := ansi.Waiting(func() error {
+				var err error
+				template, err = cli.api.Branding.UniversalLogin()
+				return err
+			}); err != nil {
+				return fmt.Errorf("Unable to load the Universal Login template due to an unexpected error: %w", err)
 			}
 
+			cli.renderer.Heading("template")
 			fmt.Println(*template.Body)
 
 			return nil

--- a/internal/cli/branding.go
+++ b/internal/cli/branding.go
@@ -222,8 +222,8 @@ auth0 branding update -a '#B24592' -b '#F2DDEC --logo 'https://example.com/logo.
 		},
 	}
 
-	brandingAccent.RegisterStringU(cmd, &inputs.AccentColor, "#0059d6")
-	brandingBackground.RegisterStringU(cmd, &inputs.BackgroundColor, "#000000")
+	brandingAccent.RegisterStringU(cmd, &inputs.AccentColor, "")
+	brandingBackground.RegisterStringU(cmd, &inputs.BackgroundColor, "")
 	brandingLogo.RegisterStringU(cmd, &inputs.LogoURL, "")
 	brandingFavicon.RegisterStringU(cmd, &inputs.FaviconURL, "")
 	brandingFont.RegisterStringU(cmd, &inputs.CustomFontURL, "")

--- a/internal/display/branding.go
+++ b/internal/display/branding.go
@@ -32,14 +32,20 @@ func (v *brandingView) KeyValues() [][]string {
 
 func (r *Renderer) BrandingShow(data *management.Branding) {
 	r.Heading("branding")
+	r.Result(makeBrandingView(data))
+}
 
-	branding := &brandingView{
+func (r *Renderer) BrandingUpdate(data *management.Branding) {
+	r.Heading("branding updated")
+	r.Result(makeBrandingView(data))
+}
+
+func makeBrandingView(data *management.Branding) *brandingView {
+	return &brandingView{
 		AccentColor: data.GetColors().GetPrimary(),
 		BackgroundColor: data.GetColors().GetPageBackground(),
 		LogoURL: data.GetLogoURL(),
 		FaviconURL: data.GetFaviconURL(),
 		CustomFontURL: data.GetFont().GetURL(),
 	}
-
-	r.Result(branding)
 }

--- a/internal/display/branding.go
+++ b/internal/display/branding.go
@@ -1,0 +1,45 @@
+package display
+
+import (
+	"gopkg.in/auth0.v5/management"
+)
+
+type brandingView struct {
+	AccentColor     string
+	BackgroundColor string
+	LogoURL         string
+	FaviconURL      string
+	CustomFontURL   string
+}
+
+func (v *brandingView) AsTableHeader() []string {
+	return []string{}
+}
+
+func (v *brandingView) AsTableRow() []string {
+	return []string{}
+}
+
+func (v *brandingView) KeyValues() [][]string {
+	return [][]string{
+		{"ACCENT COLOR", v.AccentColor},
+		{"BACKGROUND COLOR", v.BackgroundColor},
+		{"LOGO URL", v.LogoURL},
+		{"FAVICON URL", v.FaviconURL},
+		{"CUSTOM FONT URL", v.CustomFontURL},
+	}
+}
+
+func (r *Renderer) BrandingShow(data *management.Branding) {
+	r.Heading("branding")
+
+	branding := &brandingView{
+		AccentColor: data.GetColors().GetPrimary(),
+		BackgroundColor: data.GetColors().GetPageBackground(),
+		LogoURL: data.GetLogoURL(),
+		FaviconURL: data.GetFaviconURL(),
+		CustomFontURL: data.GetFont().GetURL(),
+	}
+
+	r.Result(branding)
+}


### PR DESCRIPTION
### Description

This PR adds the `branding show` and `branding update` commands.

<img width="1060" alt="Screen Shot 2021-05-29 at 00 35 15" src="https://user-images.githubusercontent.com/5055789/120057065-c0b78c00-c016-11eb-996c-a02f42ecfc3a.png">

### Testing

This was tested manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
