### PR TITLE
Add autogenerated docs [CLI-176]

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ auth0 [command]
 auth0 [command] --help
 ```
 
+* [auth0 apis](docs/auth0_apis.md)	 - Manage resources for APIs
+* [auth0 apps](docs/auth0_apps.md)	 - Manage resources for applications
+* [auth0 branding](docs/auth0_branding.md)	 - Manage branding options
+* [auth0 completion](docs/auth0_completion.md)	 - Setup autocomplete features for this CLI on your terminal
+* [auth0 ips](docs/auth0_ips.md)	 - Manage blocked IP addresses
+* [auth0 login](docs/auth0_login.md)	 - Authenticate the Auth0 CLI
+* [auth0 logout](docs/auth0_logout.md)	 - Log out of a tenant's session
+* [auth0 logs](docs/auth0_logs.md)	 - View tenant logs
+* [auth0 quickstarts](docs/auth0_quickstarts.md)	 - Quickstart support for getting bootstrapped
+* [auth0 roles](docs/auth0_roles.md)	 - Manage resources for roles
+* [auth0 rules](docs/auth0_rules.md)	 - Manage resources for rules
+* [auth0 tenants](docs/auth0_tenants.md)	 - Manage configured tenants
+* [auth0 test](docs/auth0_test.md)	 - Try your Universal Login box or get a token
+* [auth0 users](docs/auth0_users.md)	 - Manage resources for users
+
 ### Onboarding Journey
 
 Following these instructions will give you a sense of what's possible with the

--- a/docs/auth0.md
+++ b/docs/auth0.md
@@ -1,0 +1,38 @@
+## auth0
+
+Supercharge your development workflow.
+
+
+```
+auth0 [flags]
+```
+
+### Flags
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+  -h, --help            help for auth0
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+  -v, --version         version for auth0
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications
+* [auth0 branding](auth0_branding.md)	 - Manage branding options
+* [auth0 completion](auth0_completion.md)	 - Setup autocomplete features for this CLI on your terminal
+* [auth0 ips](auth0_ips.md)	 - Manage blocked IP addresses
+* [auth0 login](auth0_login.md)	 - Authenticate the Auth0 CLI
+* [auth0 logout](auth0_logout.md)	 - Log out of a tenant's session
+* [auth0 logs](auth0_logs.md)	 - View tenant logs
+* [auth0 quickstarts](auth0_quickstarts.md)	 - Quickstart support for getting bootstrapped
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules
+* [auth0 tenants](auth0_tenants.md)	 - Manage configured tenants
+* [auth0 test](auth0_test.md)	 - Try your Universal Login box or get a token
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_apis.md
+++ b/docs/auth0_apis.md
@@ -1,0 +1,31 @@
+## auth0 apis
+
+Manage resources for APIs.
+
+### Flags
+
+```
+  -h, --help   help for apis
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 apis create](auth0_apis_create.md)	 - Create a new API
+* [auth0 apis delete](auth0_apis_delete.md)	 - Delete an API
+* [auth0 apis list](auth0_apis_list.md)	 - List your APIs
+* [auth0 apis open](auth0_apis_open.md)	 - Open API settings page in Auth0 Manage
+* [auth0 apis scopes](auth0_apis_scopes.md)	 - Manage resources for API scopes
+* [auth0 apis show](auth0_apis_show.md)	 - Show an API
+* [auth0 apis update](auth0_apis_update.md)	 - Update an API

--- a/docs/auth0_apis_create.md
+++ b/docs/auth0_apis_create.md
@@ -1,0 +1,43 @@
+## auth0 apis create
+
+Create a new API.
+
+```
+auth0 apis create [flags]
+```
+
+### Examples
+
+```
+auth0 apis create 
+auth0 apis create --name myapi
+auth0 apis create -n myapi --identifier http://my-api
+auth0 apis create -n myapi --token-expiration 6100
+auth0 apis create -n myapi -e 6100 --offline-access=true
+```
+
+### Flags
+
+```
+  -h, --help                 help for create
+  -i, --identifier string    Identifier of the API. Cannot be changed once set.
+  -n, --name string          Name of the API.
+  -o, --offline-access       Whether Refresh Tokens can be issued for this API (true) or not (false).
+  -s, --scopes strings       Comma-separated list of scopes (permissions).
+  -l, --token-lifetime int   The amount of time in seconds that the token will be valid after being issued. Default value is 86400 seconds (1 day).
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apis_delete.md
+++ b/docs/auth0_apis_delete.md
@@ -1,0 +1,35 @@
+## auth0 apis delete
+
+Delete an API.
+
+```
+auth0 apis delete [flags]
+```
+
+### Examples
+
+```
+auth0 apis delete 
+auth0 apis delete <id|audience>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apis_list.md
+++ b/docs/auth0_apis_list.md
@@ -1,0 +1,36 @@
+## auth0 apis list
+
+List your existing APIs. To create one try:
+auth0 apis create
+
+```
+auth0 apis list [flags]
+```
+
+### Examples
+
+```
+auth0 apis list
+auth0 apis ls
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apis_open.md
+++ b/docs/auth0_apis_open.md
@@ -1,0 +1,35 @@
+## auth0 apis open
+
+Open API settings page in Auth0 Manage.
+
+```
+auth0 apis open [flags]
+```
+
+### Examples
+
+```
+auth0 apis open
+auth0 apis open <id|audience>
+```
+
+### Flags
+
+```
+  -h, --help   help for open
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apis_scopes.md
+++ b/docs/auth0_apis_scopes.md
@@ -1,0 +1,25 @@
+## auth0 apis scopes
+
+Manage resources for API scopes.
+
+### Flags
+
+```
+  -h, --help   help for scopes
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs
+* [auth0 apis scopes list](auth0_apis_scopes_list.md)	 - List the scopes of an API

--- a/docs/auth0_apis_scopes_list.md
+++ b/docs/auth0_apis_scopes_list.md
@@ -1,0 +1,35 @@
+## auth0 apis scopes list
+
+List the scopes of an API.
+
+```
+auth0 apis scopes list [flags]
+```
+
+### Examples
+
+```
+auth0 apis scopes list 
+auth0 apis scopes ls <id|audience>
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis scopes](auth0_apis_scopes.md)	 - Manage resources for API scopes

--- a/docs/auth0_apis_show.md
+++ b/docs/auth0_apis_show.md
@@ -1,0 +1,35 @@
+## auth0 apis show
+
+Show an API.
+
+```
+auth0 apis show [flags]
+```
+
+### Examples
+
+```
+auth0 apis show 
+auth0 apis show <id|audience>
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apis_update.md
+++ b/docs/auth0_apis_update.md
@@ -1,0 +1,42 @@
+## auth0 apis update
+
+Update an API.
+
+```
+auth0 apis update [flags]
+```
+
+### Examples
+
+```
+auth0 apis update 
+auth0 apis update <id|audience> 
+auth0 apis update <id|audience> --name myapi
+auth0 apis update -n myapi --token-expiration 6100
+auth0 apis update -n myapi -e 6100 --offline-access=true
+```
+
+### Flags
+
+```
+  -h, --help                 help for update
+  -n, --name string          Name of the API.
+  -o, --offline-access       Whether Refresh Tokens can be issued for this API (true) or not (false).
+  -s, --scopes strings       Comma-separated list of scopes (permissions).
+  -l, --token-lifetime int   The amount of time in seconds that the token will be valid after being issued. Default value is 86400 seconds (1 day).
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apis](auth0_apis.md)	 - Manage resources for APIs

--- a/docs/auth0_apps.md
+++ b/docs/auth0_apps.md
@@ -1,0 +1,31 @@
+## auth0 apps
+
+Manage resources for applications.
+
+### Flags
+
+```
+  -h, --help   help for apps
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 apps create](auth0_apps_create.md)	 - Create a new application
+* [auth0 apps delete](auth0_apps_delete.md)	 - Delete an application
+* [auth0 apps list](auth0_apps_list.md)	 - List your applications
+* [auth0 apps open](auth0_apps_open.md)	 - Open application settings page in Auth0 Manage
+* [auth0 apps show](auth0_apps_show.md)	 - Show an application
+* [auth0 apps update](auth0_apps_update.md)	 - Update an application
+* [auth0 apps use](auth0_apps_use.md)	 - Choose a default application for the Auth0 CLI

--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -1,0 +1,51 @@
+## auth0 apps create
+
+Create a new application.
+
+```
+auth0 apps create [flags]
+```
+
+### Examples
+
+```
+auth0 apps create 
+auth0 apps create --name myapp 
+auth0 apps create -n myapp --type [native|spa|regular|m2m]
+auth0 apps create -n myapp -t [native|spa|regular|m2m] --description <description>
+```
+
+### Flags
+
+```
+  -a, --auth-method string    Defines the requested authentication method for the token endpoint. Possible values are 'None' (public application without a client secret), 'Post' (application uses HTTP POST parameters) or 'Basic' (application uses HTTP Basic).
+  -c, --callbacks strings     After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
+  -d, --description string    Description of the application. Max character count is 140.
+  -g, --grants strings        List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
+  -h, --help                  help for create
+  -l, --logout-urls strings   Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.
+  -n, --name string           Name of the application.
+  -o, --origins strings       Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
+  -r, --reveal                Display the Client Secret as part of the command output.
+  -t, --type string           Type of application:
+                              - native: mobile, desktop, CLI and smart device apps running natively.
+                              - spa (single page application): a JavaScript front-end app that uses an API.
+                              - regular: Traditional web app using redirects.
+                              - m2m (machine to machine): CLIs, daemons or services running on your backend.
+  -w, --web-origins strings   Comma-separated list of allowed origins for use with Cross-Origin Authentication, Device Flow, and web message response mode.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_delete.md
+++ b/docs/auth0_apps_delete.md
@@ -1,0 +1,35 @@
+## auth0 apps delete
+
+Delete an application.
+
+```
+auth0 apps delete [flags]
+```
+
+### Examples
+
+```
+auth0 apps delete 
+auth0 apps delete <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_list.md
+++ b/docs/auth0_apps_list.md
@@ -1,0 +1,37 @@
+## auth0 apps list
+
+List your existing applications. To create one try:
+auth0 apps create
+
+```
+auth0 apps list [flags]
+```
+
+### Examples
+
+```
+auth0 apps list
+auth0 apps ls
+```
+
+### Flags
+
+```
+  -h, --help     help for list
+  -r, --reveal   Display the Client Secret as part of the command output.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_open.md
+++ b/docs/auth0_apps_open.md
@@ -1,0 +1,34 @@
+## auth0 apps open
+
+Open application settings page in Auth0 Manage.
+
+```
+auth0 apps open [flags]
+```
+
+### Examples
+
+```
+auth0 apps open <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for open
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_show.md
+++ b/docs/auth0_apps_show.md
@@ -1,0 +1,36 @@
+## auth0 apps show
+
+Show an application.
+
+```
+auth0 apps show [flags]
+```
+
+### Examples
+
+```
+auth0 apps show 
+auth0 apps show <id>
+```
+
+### Flags
+
+```
+  -h, --help     help for show
+  -r, --reveal   Display the Client Secret as part of the command output.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -1,0 +1,50 @@
+## auth0 apps update
+
+Update an application.
+
+```
+auth0 apps update [flags]
+```
+
+### Examples
+
+```
+auth0 apps update <id> 
+auth0 apps update <id> --name myapp 
+auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]
+```
+
+### Flags
+
+```
+  -a, --auth-method string    Defines the requested authentication method for the token endpoint. Possible values are 'None' (public application without a client secret), 'Post' (application uses HTTP POST parameters) or 'Basic' (application uses HTTP Basic).
+  -c, --callbacks strings     After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
+  -d, --description string    Description of the application. Max character count is 140.
+  -g, --grants strings        List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
+  -h, --help                  help for update
+  -l, --logout-urls strings   Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.
+  -n, --name string           Name of the application.
+  -o, --origins strings       Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
+  -r, --reveal                Display the Client Secret as part of the command output.
+  -t, --type string           Type of application:
+                              - native: mobile, desktop, CLI and smart device apps running natively.
+                              - spa (single page application): a JavaScript front-end app that uses an API.
+                              - regular: Traditional web app using redirects.
+                              - m2m (machine to machine): CLIs, daemons or services running on your backend.
+  -w, --web-origins strings   Comma-separated list of allowed origins for use with Cross-Origin Authentication, Device Flow, and web message response mode.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_apps_use.md
+++ b/docs/auth0_apps_use.md
@@ -1,0 +1,35 @@
+## auth0 apps use
+
+Specify your preferred application for interaction with the Auth0 CLI.
+
+```
+auth0 apps use [flags]
+```
+
+### Examples
+
+```
+auth0 apps use <client-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for use
+  -n, --none   Specify none of your apps.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 apps](auth0_apps.md)	 - Manage resources for applications

--- a/docs/auth0_branding.md
+++ b/docs/auth0_branding.md
@@ -1,0 +1,27 @@
+## auth0 branding
+
+Manage branding options.
+
+### Flags
+
+```
+  -h, --help   help for branding
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 branding show](auth0_branding_show.md)	 - Display the custom branding settings for Universal Login
+* [auth0 branding templates](auth0_branding_templates.md)	 - Manage custom page templates
+* [auth0 branding update](auth0_branding_update.md)	 - Update the custom branding settings for Universal Login

--- a/docs/auth0_branding_show.md
+++ b/docs/auth0_branding_show.md
@@ -1,0 +1,34 @@
+## auth0 branding show
+
+Display the custom branding settings for Universal Login.
+
+```
+auth0 branding show [flags]
+```
+
+### Examples
+
+```
+auth0 branding show
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 branding](auth0_branding.md)	 - Manage branding options

--- a/docs/auth0_branding_templates.md
+++ b/docs/auth0_branding_templates.md
@@ -1,0 +1,26 @@
+## auth0 branding templates
+
+Manage custom page templates. This requires at least one custom domain to be configured for the tenant.
+
+### Flags
+
+```
+  -h, --help   help for templates
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 branding](auth0_branding.md)	 - Manage branding options
+* [auth0 branding templates show](auth0_branding_templates_show.md)	 - Display the custom template for Universal Login
+* [auth0 branding templates update](auth0_branding_templates_update.md)	 - Update the custom template for Universal Login

--- a/docs/auth0_branding_templates_show.md
+++ b/docs/auth0_branding_templates_show.md
@@ -1,0 +1,34 @@
+## auth0 branding templates show
+
+Display the custom template for Universal Login.
+
+```
+auth0 branding templates show [flags]
+```
+
+### Examples
+
+```
+auth0 branding templates show
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 branding templates](auth0_branding_templates.md)	 - Manage custom page templates

--- a/docs/auth0_branding_templates_update.md
+++ b/docs/auth0_branding_templates_update.md
@@ -1,0 +1,34 @@
+## auth0 branding templates update
+
+Update the custom template for Universal Login.
+
+```
+auth0 branding templates update [flags]
+```
+
+### Examples
+
+```
+auth0 branding templates update
+```
+
+### Flags
+
+```
+  -h, --help   help for update
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 branding templates](auth0_branding_templates.md)	 - Manage custom page templates

--- a/docs/auth0_branding_update.md
+++ b/docs/auth0_branding_update.md
@@ -1,0 +1,41 @@
+## auth0 branding update
+
+Update the custom branding settings for Universal Login.
+
+```
+auth0 branding update [flags]
+```
+
+### Examples
+
+```
+auth0 branding update
+auth0 branding update --accent '#B24592' --background '#F2DDEC' 
+auth0 branding update -a '#B24592' -b '#F2DDEC --logo 'https://example.com/logo.png
+```
+
+### Flags
+
+```
+  -a, --accent string       Accent color.
+  -b, --background string   Page background color
+  -f, --favicon string      URL for the favicon. Must use HTTPS.
+  -c, --font string         URL for the custom font. The URL must point to a font file and not a stylesheet. Must use HTTPS.
+  -h, --help                help for update
+  -l, --logo string         URL for the logo. Must use HTTPS.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 branding](auth0_branding.md)	 - Manage branding options

--- a/docs/auth0_completion.md
+++ b/docs/auth0_completion.md
@@ -1,0 +1,68 @@
+## auth0 completion
+
+completion [bash|zsh|fish|powershell]
+
+To load completions:
+
+Bash:
+
+$ source <(auth0 completion bash)
+
+# To load completions for each session, execute once:
+Linux:
+  $ auth0 completion bash > /etc/bash_completion.d/auth0
+MacOS:
+  $ auth0 completion bash > /usr/local/etc/bash_completion.d/auth0
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ auth0 completion zsh > "${fpath[1]}/_auth0"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ auth0 completion fish | source
+
+# To load completions for each session, execute once:
+$ auth0 completion fish > ~/.config/fish/completions/auth0.fish
+
+Powershell:
+
+PS> auth0 completion powershell | Out-String | Invoke-Expression
+
+# To load completions for every new session, run:
+PS> auth0 completion powershell > auth0.ps1
+# and source this file from your powershell profile.
+
+
+```
+auth0 completion
+```
+
+### Flags
+
+```
+  -h, --help   help for completion
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.

--- a/docs/auth0_ips.md
+++ b/docs/auth0_ips.md
@@ -1,0 +1,26 @@
+## auth0 ips
+
+Manage blocked IP addresses.
+
+### Flags
+
+```
+  -h, --help   help for ips
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 ips check](auth0_ips_check.md)	 - Check IP address
+* [auth0 ips unblock](auth0_ips_unblock.md)	 - Unblock IP address

--- a/docs/auth0_ips_check.md
+++ b/docs/auth0_ips_check.md
@@ -1,0 +1,34 @@
+## auth0 ips check
+
+Check whether a given IP address is blocked.
+
+```
+auth0 ips check [flags]
+```
+
+### Examples
+
+```
+auth0 ips check <ip>
+```
+
+### Flags
+
+```
+  -h, --help   help for check
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 ips](auth0_ips.md)	 - Manage blocked IP addresses

--- a/docs/auth0_ips_unblock.md
+++ b/docs/auth0_ips_unblock.md
@@ -1,0 +1,34 @@
+## auth0 ips unblock
+
+Unblock an IP address which is currently blocked.
+
+```
+auth0 ips unblock [flags]
+```
+
+### Examples
+
+```
+auth0 ips unblock <ip>
+```
+
+### Flags
+
+```
+  -h, --help   help for unblock
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 ips](auth0_ips.md)	 - Manage blocked IP addresses

--- a/docs/auth0_login.md
+++ b/docs/auth0_login.md
@@ -1,0 +1,28 @@
+## auth0 login
+
+Sign in to your Auth0 account and authorize the CLI to access the Management API.
+
+```
+auth0 login [flags]
+```
+
+### Flags
+
+```
+  -h, --help   help for login
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.

--- a/docs/auth0_logout.md
+++ b/docs/auth0_logout.md
@@ -1,0 +1,34 @@
+## auth0 logout
+
+Log out of a tenant's session.
+
+```
+auth0 logout [flags]
+```
+
+### Examples
+
+```
+auth0 logout <tenant>
+```
+
+### Flags
+
+```
+  -h, --help   help for logout
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.

--- a/docs/auth0_logs.md
+++ b/docs/auth0_logs.md
@@ -1,0 +1,27 @@
+## auth0 logs
+
+View tenant logs.
+
+### Flags
+
+```
+  -h, --help   help for logs
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 logs list](auth0_logs_list.md)	 - Show the application logs
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams
+* [auth0 logs tail](auth0_logs_tail.md)	 - Tail the tenant logs

--- a/docs/auth0_logs_list.md
+++ b/docs/auth0_logs_list.md
@@ -1,0 +1,38 @@
+## auth0 logs list
+
+Show the tenant logs allowing to filter by Client Id.
+
+```
+auth0 logs list [flags]
+```
+
+### Examples
+
+```
+auth0 logs list
+auth0 logs list --client-id <id>
+auth0 logs ls -n 100
+```
+
+### Flags
+
+```
+  -c, --client-id string   Client Id of an Auth0 application to filter the logs.
+  -h, --help               help for list
+  -n, --number int         Number of log entries to show. (default 100)
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs](auth0_logs.md)	 - View tenant logs

--- a/docs/auth0_logs_streams.md
+++ b/docs/auth0_logs_streams.md
@@ -1,0 +1,30 @@
+## auth0 logs streams
+
+manage resources for log streams.
+
+### Flags
+
+```
+  -h, --help   help for streams
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs](auth0_logs.md)	 - View tenant logs
+* [auth0 logs streams create](auth0_logs_streams_create.md)	 - Create a new log stream
+* [auth0 logs streams delete](auth0_logs_streams_delete.md)	 - Delete a log stream
+* [auth0 logs streams list](auth0_logs_streams_list.md)	 - List all log streams
+* [auth0 logs streams open](auth0_logs_streams_open.md)	 - Open log stream settings page in Auth0 Manage
+* [auth0 logs streams show](auth0_logs_streams_show.md)	 - Show a log stream by Id
+* [auth0 logs streams update](auth0_logs_streams_update.md)	 - Update a log stream

--- a/docs/auth0_logs_streams_create.md
+++ b/docs/auth0_logs_streams_create.md
@@ -1,0 +1,57 @@
+## auth0 logs streams create
+
+Create a new log stream.
+
+```
+auth0 logs streams create [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams create
+auth0 logs streams create -n mylogstream -t http --http-type application/json --http-format JSONLINES --http-auth 1343434
+auth0 logs streams create -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
+auth0 logs streams create -n myeventbridge -t eventbridge --eventbridge-id 999999999999 --eventbridge-region us-east-1
+auth0 logs streams create -n test-splunk -t splunk --splunk-domain demo.splunk.com --splunk-token 12a34ab5-c6d7-8901-23ef-456b7c89d0c1 --splunk-port 8080 --splunk-secure=true
+```
+
+### Flags
+
+```
+      --datadog-id string           The region in which datadog dashboard is created.
+                                    if you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+      --datadog-key string          Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+      --eventbridge-id string       Id of the AWS account.
+      --eventbridge-region string   The region in which eventbridge will be created.
+      --eventgrid-group string      The name of the Azure resource group.
+      --eventgrid-id string         Id of the Azure subscription.
+      --eventgrid-region string     The region in which the Azure subscription is hosted.
+  -h, --help                        help for create
+      --http-auth string            HTTP Authorization header.
+      --http-endpoint string        HTTP endpoint.
+      --http-format string          HTTP Content-Format header. Possible values: JSONLINES, JSONARRAY, JSONOBJECT.
+      --http-type string            HTTP Content-Type header. Possible values: application/json.
+  -n, --name string                 Name of the log stream.
+      --splunk-domain string        The domain name of the splunk instance.
+      --splunk-port string          The port of the HTTP event collector.
+      --splunk-secure               This should be set to 'false' when using self-signed certificates.
+      --splunk-token string         Splunk event collector token.
+      --sumo-source string          Generated URL for your defined HTTP source in Sumo Logic.
+  -t, --type string                 Type of the log stream. Possible values: http, eventbridge, eventgrid, datadog, splunk, sumo.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_streams_delete.md
+++ b/docs/auth0_logs_streams_delete.md
@@ -1,0 +1,35 @@
+## auth0 logs streams delete
+
+Delete a log stream.
+
+```
+auth0 logs streams delete [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams delete
+auth0 logs streams delete <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_streams_list.md
+++ b/docs/auth0_logs_streams_list.md
@@ -1,0 +1,36 @@
+## auth0 logs streams list
+
+List your existing log streams. To create one try:
+auth0 logs streams create
+
+```
+auth0 logs streams list [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams list
+auth0 logs streams ls
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_streams_open.md
+++ b/docs/auth0_logs_streams_open.md
@@ -1,0 +1,34 @@
+## auth0 logs streams open
+
+Open log stream settings page in Auth0 Manage.
+
+```
+auth0 logs streams open [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams open <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for open
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_streams_show.md
+++ b/docs/auth0_logs_streams_show.md
@@ -1,0 +1,35 @@
+## auth0 logs streams show
+
+Show a log stream by Id.
+
+```
+auth0 logs streams show [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams show
+auth0 logs streams show <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_streams_update.md
+++ b/docs/auth0_logs_streams_update.md
@@ -1,0 +1,53 @@
+## auth0 logs streams update
+
+Update a log stream.
+
+```
+auth0 logs streams update [flags]
+```
+
+### Examples
+
+```
+auth0 logs streams update
+auth0 logs streams update <id> --name mylogstream
+auth0 logs streams update <id> -n mylogstream --type http
+auth0 logs streams update <id> -n mylogstream -t http --http-type application/json --http-format JSONLINES
+auth0 logs streams update <id> -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
+auth0 logs streams update <id> -n myeventbridge -t eventbridge
+```
+
+### Flags
+
+```
+      --datadog-id string      The region in which datadog dashboard is created.
+                               if you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+      --datadog-key string     Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+  -h, --help                   help for update
+      --http-auth string       HTTP Authorization header.
+      --http-endpoint string   HTTP endpoint.
+      --http-format string     HTTP Content-Format header. Possible values: JSONLINES, JSONARRAY, JSONOBJECT.
+      --http-type string       HTTP Content-Type header. Possible values: application/json.
+  -n, --name string            Name of the log stream.
+      --splunk-domain string   The domain name of the splunk instance.
+      --splunk-port string     The port of the HTTP event collector.
+      --splunk-secure          This should be set to 'false' when using self-signed certificates.
+      --splunk-token string    Splunk event collector token.
+      --sumo-source string     Generated URL for your defined HTTP source in Sumo Logic.
+  -t, --type string            Type of the log stream. Possible values: http, eventbridge, eventgrid, datadog, splunk, sumo.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs streams](auth0_logs_streams.md)	 - Manage resources for log streams

--- a/docs/auth0_logs_tail.md
+++ b/docs/auth0_logs_tail.md
@@ -1,0 +1,38 @@
+## auth0 logs tail
+
+Tail the tenant logs allowing to filter by Client ID.
+
+```
+auth0 logs tail [flags]
+```
+
+### Examples
+
+```
+auth0 logs tail
+auth0 logs tail --client-id <id>
+auth0 logs tail -n 100
+```
+
+### Flags
+
+```
+  -c, --client-id string   Client Id of an Auth0 application to filter the logs.
+  -h, --help               help for tail
+  -n, --number int         Number of log entries to show. (default 100)
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 logs](auth0_logs.md)	 - View tenant logs

--- a/docs/auth0_quickstarts.md
+++ b/docs/auth0_quickstarts.md
@@ -1,0 +1,26 @@
+## auth0 quickstarts
+
+Quickstart support for getting bootstrapped.
+
+### Flags
+
+```
+  -h, --help   help for quickstarts
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 quickstarts download](auth0_quickstarts_download.md)	 - Download a Quickstart sample app for a specific tech stack
+* [auth0 quickstarts list](auth0_quickstarts_list.md)	 - List the available Quickstarts

--- a/docs/auth0_quickstarts_download.md
+++ b/docs/auth0_quickstarts_download.md
@@ -1,0 +1,36 @@
+## auth0 quickstarts download
+
+Download a Quickstart sample app for a specific tech stack.
+
+```
+auth0 quickstarts download [flags]
+```
+
+### Examples
+
+```
+auth0 quickstarts download --stack <stack>
+auth0 qs download --stack <stack>
+```
+
+### Flags
+
+```
+  -h, --help           help for download
+  -s, --stack string   Tech/Language of the quickstart sample to download.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 quickstarts](auth0_quickstarts.md)	 - Quickstart support for getting bootstrapped

--- a/docs/auth0_quickstarts_list.md
+++ b/docs/auth0_quickstarts_list.md
@@ -1,0 +1,37 @@
+## auth0 quickstarts list
+
+List the available Quickstarts.
+
+```
+auth0 quickstarts list [flags]
+```
+
+### Examples
+
+```
+auth0 quickstarts list
+auth0 quickstarts ls
+auth0 qs list
+auth0 qs ls
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 quickstarts](auth0_quickstarts.md)	 - Quickstart support for getting bootstrapped

--- a/docs/auth0_roles.md
+++ b/docs/auth0_roles.md
@@ -1,0 +1,29 @@
+## auth0 roles
+
+Manage resources for roles.
+
+### Flags
+
+```
+  -h, --help   help for roles
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 roles create](auth0_roles_create.md)	 - Create a new role
+* [auth0 roles delete](auth0_roles_delete.md)	 - Delete a role
+* [auth0 roles list](auth0_roles_list.md)	 - List your roles
+* [auth0 roles show](auth0_roles_show.md)	 - Show a role
+* [auth0 roles update](auth0_roles_update.md)	 - Update a role

--- a/docs/auth0_roles_create.md
+++ b/docs/auth0_roles_create.md
@@ -1,0 +1,38 @@
+## auth0 roles create
+
+Create a new role.
+
+```
+auth0 roles create [flags]
+```
+
+### Examples
+
+```
+auth0 roles create
+auth0 roles create --name myrole
+auth0 roles create -n myrole --description "awesome role"
+```
+
+### Flags
+
+```
+  -d, --description string   Description of the role.
+  -h, --help                 help for create
+  -n, --name string          Name of the role.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles

--- a/docs/auth0_roles_delete.md
+++ b/docs/auth0_roles_delete.md
@@ -1,0 +1,35 @@
+## auth0 roles delete
+
+Delete a role.
+
+```
+auth0 roles delete [flags]
+```
+
+### Examples
+
+```
+auth0 roles delete
+auth0 roles delete <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles

--- a/docs/auth0_roles_list.md
+++ b/docs/auth0_roles_list.md
@@ -1,0 +1,36 @@
+## auth0 roles list
+
+List your existing roles. To create one try:
+auth0 roles create
+
+```
+auth0 roles list [flags]
+```
+
+### Examples
+
+```
+auth0 roles list
+auth0 roles ls
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles

--- a/docs/auth0_roles_show.md
+++ b/docs/auth0_roles_show.md
@@ -1,0 +1,35 @@
+## auth0 roles show
+
+Show a role.
+
+```
+auth0 roles show [flags]
+```
+
+### Examples
+
+```
+auth0 roles show
+auth0 roles show <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles

--- a/docs/auth0_roles_update.md
+++ b/docs/auth0_roles_update.md
@@ -1,0 +1,38 @@
+## auth0 roles update
+
+Update a role.
+
+```
+auth0 roles update [flags]
+```
+
+### Examples
+
+```
+auth0 roles update
+auth0 roles update <id> --name myrole
+auth0 roles update <id> -n myrole --description "awesome role"
+```
+
+### Flags
+
+```
+  -d, --description string   Description of the role.
+  -h, --help                 help for update
+  -n, --name string          Name of the role.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 roles](auth0_roles.md)	 - Manage resources for roles

--- a/docs/auth0_rules.md
+++ b/docs/auth0_rules.md
@@ -1,0 +1,31 @@
+## auth0 rules
+
+Manage resources for rules.
+
+### Flags
+
+```
+  -h, --help   help for rules
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 rules create](auth0_rules_create.md)	 - Create a new rule
+* [auth0 rules delete](auth0_rules_delete.md)	 - Delete a rule
+* [auth0 rules disable](auth0_rules_disable.md)	 - Disable a rule
+* [auth0 rules enable](auth0_rules_enable.md)	 - Enable a rule
+* [auth0 rules list](auth0_rules_list.md)	 - List your rules
+* [auth0 rules show](auth0_rules_show.md)	 - Show a rule
+* [auth0 rules update](auth0_rules_update.md)	 - Update a rule

--- a/docs/auth0_rules_create.md
+++ b/docs/auth0_rules_create.md
@@ -1,0 +1,40 @@
+## auth0 rules create
+
+Create a new rule.
+
+```
+auth0 rules create [flags]
+```
+
+### Examples
+
+```
+auth0 rules create
+auth0 rules create --name "My Rule"
+auth0 rules create -n "My Rule" --template "Empty rule"
+auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false
+```
+
+### Flags
+
+```
+  -e, --enabled           Enable (or disable) a rule. (default true)
+  -h, --help              help for create
+  -n, --name string       Name of the rule.
+  -t, --template string   Template to use for the rule.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_delete.md
+++ b/docs/auth0_rules_delete.md
@@ -1,0 +1,35 @@
+## auth0 rules delete
+
+Delete a rule.
+
+```
+auth0 rules delete [flags]
+```
+
+### Examples
+
+```
+auth0 rules delete 
+auth0 rules delete <rule-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_disable.md
+++ b/docs/auth0_rules_disable.md
@@ -1,0 +1,34 @@
+## auth0 rules disable
+
+Disable a rule.
+
+```
+auth0 rules disable [flags]
+```
+
+### Examples
+
+```
+auth0 rules disable <rule-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for disable
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_enable.md
+++ b/docs/auth0_rules_enable.md
@@ -1,0 +1,34 @@
+## auth0 rules enable
+
+Enable a rule.
+
+```
+auth0 rules enable [flags]
+```
+
+### Examples
+
+```
+auth0 rules enable <rule-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for enable
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_list.md
+++ b/docs/auth0_rules_list.md
@@ -1,0 +1,36 @@
+## auth0 rules list
+
+List your existing rules. To create one try:
+auth0 rules create
+
+```
+auth0 rules list [flags]
+```
+
+### Examples
+
+```
+auth0 rules list
+auth0 rules ls
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_show.md
+++ b/docs/auth0_rules_show.md
@@ -1,0 +1,35 @@
+## auth0 rules show
+
+Show a rule.
+
+```
+auth0 rules show [flags]
+```
+
+### Examples
+
+```
+auth0 rules show 
+auth0 rules show <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_rules_update.md
+++ b/docs/auth0_rules_update.md
@@ -1,0 +1,38 @@
+## auth0 rules update
+
+Update a rule.
+
+```
+auth0 rules update [flags]
+```
+
+### Examples
+
+```
+auth0 rules update <rule-id> 
+auth0 rules update <rule-id> --name "My Updated Rule"
+auth0 rules update <rule-id> -n "My Updated Rule" --enabled=false
+```
+
+### Flags
+
+```
+  -e, --enabled       Enable (or disable) a rule. (default true)
+  -h, --help          help for update
+  -n, --name string   Name of the rule.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 rules](auth0_rules.md)	 - Manage resources for rules

--- a/docs/auth0_tenants.md
+++ b/docs/auth0_tenants.md
@@ -1,0 +1,27 @@
+## auth0 tenants
+
+Manage configured tenants.
+
+### Flags
+
+```
+  -h, --help   help for tenants
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 tenants list](auth0_tenants_list.md)	 - List your tenants
+* [auth0 tenants open](auth0_tenants_open.md)	 - Open tenant settings page in Auth0 Manage
+* [auth0 tenants use](auth0_tenants_use.md)	 - Set the active tenant

--- a/docs/auth0_tenants_list.md
+++ b/docs/auth0_tenants_list.md
@@ -1,0 +1,34 @@
+## auth0 tenants list
+
+List your tenants.
+
+```
+auth0 tenants list [flags]
+```
+
+### Examples
+
+```
+auth0 tenants list
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 tenants](auth0_tenants.md)	 - Manage configured tenants

--- a/docs/auth0_tenants_open.md
+++ b/docs/auth0_tenants_open.md
@@ -1,0 +1,34 @@
+## auth0 tenants open
+
+Open tenant settings page in Auth0 Manage.
+
+```
+auth0 tenants open [flags]
+```
+
+### Examples
+
+```
+auth0 tenants open <tenant>
+```
+
+### Flags
+
+```
+  -h, --help   help for open
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 tenants](auth0_tenants.md)	 - Manage configured tenants

--- a/docs/auth0_tenants_use.md
+++ b/docs/auth0_tenants_use.md
@@ -1,0 +1,34 @@
+## auth0 tenants use
+
+Set the active tenant.
+
+```
+auth0 tenants use [flags]
+```
+
+### Examples
+
+```
+auth0 tenants use <tenant>
+```
+
+### Flags
+
+```
+  -h, --help   help for use
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 tenants](auth0_tenants.md)	 - Manage configured tenants

--- a/docs/auth0_test.md
+++ b/docs/auth0_test.md
@@ -1,0 +1,26 @@
+## auth0 test
+
+Try your Universal Login box or get a token.
+
+### Flags
+
+```
+  -h, --help   help for test
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 test login](auth0_test_login.md)	 - Try out your Universal Login box
+* [auth0 test token](auth0_test_token.md)	 - Fetch a token for the given application and API

--- a/docs/auth0_test_login.md
+++ b/docs/auth0_test_login.md
@@ -1,0 +1,40 @@
+## auth0 test login
+
+Launch a browser to try out your Universal Login box.
+
+```
+auth0 test login [flags]
+```
+
+### Examples
+
+```
+auth0 test login
+auth0 test login <client-id>
+auth0 test login <client-id> --connection <connection>
+```
+
+### Flags
+
+```
+  -a, --audience string     The unique identifier of the target API you want to access.
+      --connection string   Connection to test during login.
+  -d, --domain string       One of your custom domains.
+  -h, --help                help for login
+  -s, --scopes strings      The list of scopes you want to use. (default [openid,profile])
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 test](auth0_test.md)	 - Try your Universal Login box or get a token

--- a/docs/auth0_test_token.md
+++ b/docs/auth0_test_token.md
@@ -1,0 +1,40 @@
+## auth0 test token
+
+Fetch an access token for the given application.
+If --client-id is not provided, the default client "CLI Login Testing" will be used (and created if not exists).
+Specify the API you want this token for with --audience (API Identifer). Additionally, you can also specify the --scope to use.
+
+```
+auth0 test token [flags]
+```
+
+### Examples
+
+```
+auth0 test token
+auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>
+```
+
+### Flags
+
+```
+  -a, --audience string    The unique identifier of the target API you want to access.
+  -c, --client-id string   Client Id of an Auth0 application.
+  -h, --help               help for token
+  -s, --scopes strings     The list of scopes you want to use.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 test](auth0_test.md)	 - Try your Universal Login box or get a token

--- a/docs/auth0_users.md
+++ b/docs/auth0_users.md
@@ -1,0 +1,32 @@
+## auth0 users
+
+Manage resources for users.
+
+### Flags
+
+```
+  -h, --help   help for users
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0](auth0.md)	 - Supercharge your development workflow.
+* [auth0 users blocks](auth0_users_blocks.md)	 - Manage brute-force protection user blocks
+* [auth0 users create](auth0_users_create.md)	 - Create a new user
+* [auth0 users delete](auth0_users_delete.md)	 - Delete a user
+* [auth0 users open](auth0_users_open.md)	 - Open user details page in Auth0 Manage
+* [auth0 users search](auth0_users_search.md)	 - Search for users
+* [auth0 users show](auth0_users_show.md)	 - Show an existing user
+* [auth0 users unblock](auth0_users_unblock.md)	 - Remove brute-force protection blocks for a given user
+* [auth0 users update](auth0_users_update.md)	 - Update a user

--- a/docs/auth0_users_blocks.md
+++ b/docs/auth0_users_blocks.md
@@ -1,0 +1,25 @@
+## auth0 users blocks
+
+Manage brute-force protection user blocks.
+
+### Flags
+
+```
+  -h, --help   help for blocks
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users
+* [auth0 users blocks list](auth0_users_blocks_list.md)	 - List brute-force protection blocks for a given user

--- a/docs/auth0_users_blocks_list.md
+++ b/docs/auth0_users_blocks_list.md
@@ -1,0 +1,34 @@
+## auth0 users blocks list
+
+List brute-force protection blocks for a given user.
+
+```
+auth0 users blocks list [flags]
+```
+
+### Examples
+
+```
+auth0 users blocks list <user-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for list
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users blocks](auth0_users_blocks.md)	 - Manage brute-force protection user blocks

--- a/docs/auth0_users_create.md
+++ b/docs/auth0_users_create.md
@@ -1,0 +1,42 @@
+## auth0 users create
+
+Create a new user.
+
+```
+auth0 users create [flags]
+```
+
+### Examples
+
+```
+auth0 users create 
+auth0 users create --name "John Doe" 
+auth0 users create -n "John Doe" --email john@example.com
+auth0 users create -n "John Doe" --e john@example.com --connection "Username-Password-Authentication"
+```
+
+### Flags
+
+```
+  -c, --connection string   Name of the connection this user should be created in.
+  -e, --email string        The user's email.
+  -h, --help                help for create
+  -n, --name string         The user's full name.
+  -p, --password string     Initial password for this user (mandatory for non-SMS connections).
+  -u, --username string     The user's username. Only valid if the connection requires a username.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_delete.md
+++ b/docs/auth0_users_delete.md
@@ -1,0 +1,35 @@
+## auth0 users delete
+
+Delete a user.
+
+```
+auth0 users delete [flags]
+```
+
+### Examples
+
+```
+auth0 users delete 
+auth0 users delete <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for delete
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_open.md
+++ b/docs/auth0_users_open.md
@@ -1,0 +1,35 @@
+## auth0 users open
+
+Open user details page in Auth0 Manage.
+
+```
+auth0 users open [flags]
+```
+
+### Examples
+
+```
+auth0 users open <id>
+auth0 users open "auth0|xxxxxxxxxx"
+```
+
+### Flags
+
+```
+  -h, --help   help for open
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -1,0 +1,40 @@
+## auth0 users search
+
+Search for users. To create one try:
+auth0 users create
+
+```
+auth0 users search [flags]
+```
+
+### Examples
+
+```
+auth0 users search
+auth0 users search --query id
+auth0 users search -q name --sort "name:1"
+auth0 users search -q name -s "name:1"
+```
+
+### Flags
+
+```
+  -h, --help           help for search
+  -q, --query string   Query in Lucene query string syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.
+  -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_show.md
+++ b/docs/auth0_users_show.md
@@ -1,0 +1,35 @@
+## auth0 users show
+
+Show an existing user.
+
+```
+auth0 users show [flags]
+```
+
+### Examples
+
+```
+auth0 users show 
+auth0 users show <id>
+```
+
+### Flags
+
+```
+  -h, --help   help for show
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_unblock.md
+++ b/docs/auth0_users_unblock.md
@@ -1,0 +1,34 @@
+## auth0 users unblock
+
+Remove brute-force protection blocks for a given user.
+
+```
+auth0 users unblock [flags]
+```
+
+### Examples
+
+```
+auth0 users unblock <user-id>
+```
+
+### Flags
+
+```
+  -h, --help   help for unblock
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/docs/auth0_users_update.md
+++ b/docs/auth0_users_update.md
@@ -1,0 +1,41 @@
+## auth0 users update
+
+Update a user.
+
+```
+auth0 users update [flags]
+```
+
+### Examples
+
+```
+auth0 users update 
+auth0 users update <id> 
+auth0 users update <id> --name John Doe
+auth0 users update -n John Doe --email john.doe@example.com
+```
+
+### Flags
+
+```
+  -c, --connection string   Name of the connection this user should be created in.
+  -e, --email string        The user's email.
+  -h, --help                help for update
+  -n, --name string         The user's full name.
+  -p, --password string     Initial password for this user (mandatory for non-SMS connections).
+```
+
+### Flags inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 users](auth0_users.md)	 - Manage resources for users

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -246,8 +246,8 @@ func deleteRoleCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Args:  cobra.MaximumNArgs(1),
-		Short: "Delete an role",
-		Long:  "Delete an role.",
+		Short: "Delete a role",
+		Long:  "Delete a role.",
 		Example: `auth0 roles delete
 auth0 roles delete <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
### Description

This PR adds autogenerated docs for every command and links to the root ones from the README.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
