### PR TITLE
Replace client-id with filter in logs commands

### DIFF
--- a/docs/auth0_logs_list.md
+++ b/docs/auth0_logs_list.md
@@ -1,6 +1,6 @@
 ## auth0 logs list
 
-Show the tenant logs allowing to filter by Client Id.
+Show the tenant logs allowing to filter using Lucene query syntax.
 
 ```
 auth0 logs list [flags]
@@ -10,16 +10,21 @@ auth0 logs list [flags]
 
 ```
 auth0 logs list
-auth0 logs list --client-id <id>
+auth0 logs list --filter "client_id:<client-id>"
+auth0 logs list --filter "client_name:<client-name>"
+auth0 logs list --filter "user_id:<user-id>"
+auth0 logs list --filter "user_name:<user-name>"
+auth0 logs list --filter "ip:<ip>"
+auth0 logs list --filter "type:f" # See the full list of type codes at https://auth0.com/docs/logs/log-event-type-codes
 auth0 logs ls -n 100
 ```
 
 ### Flags
 
 ```
-  -c, --client-id string   Client Id of an Auth0 application to filter the logs.
-  -h, --help               help for list
-  -n, --number int         Number of log entries to show. (default 100)
+  -f, --filter string   Filter in Lucene query syntax. See https://auth0.com/docs/logs/log-search-query-syntax for more details.
+  -h, --help            help for list
+  -n, --number int      Number of log entries to show. (default 100)
 ```
 
 ### Flags inherited from parent commands

--- a/docs/auth0_logs_tail.md
+++ b/docs/auth0_logs_tail.md
@@ -1,6 +1,6 @@
 ## auth0 logs tail
 
-Tail the tenant logs allowing to filter by Client ID.
+Tail the tenant logs allowing to filter using Lucene query syntax.
 
 ```
 auth0 logs tail [flags]
@@ -10,16 +10,21 @@ auth0 logs tail [flags]
 
 ```
 auth0 logs tail
-auth0 logs tail --client-id <id>
+auth0 logs tail --filter "client_id:<client-id>"
+auth0 logs tail --filter "client_name:<client-name>"
+auth0 logs tail --filter "user_id:<user-id>"
+auth0 logs tail --filter "user_name:<user-name>"
+auth0 logs tail --filter "ip:<ip>"
+auth0 logs tail --filter "type:f" # See the full list of type codes at https://auth0.com/docs/logs/log-event-type-codes
 auth0 logs tail -n 100
 ```
 
 ### Flags
 
 ```
-  -c, --client-id string   Client Id of an Auth0 application to filter the logs.
-  -h, --help               help for tail
-  -n, --number int         Number of log entries to show. (default 100)
+  -f, --filter string   Filter in Lucene query syntax. See https://auth0.com/docs/logs/log-search-query-syntax for more details.
+  -h, --help            help for tail
+  -n, --number int      Number of log entries to show. (default 100)
 ```
 
 ### Flags inherited from parent commands

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -20,7 +20,7 @@ auth0 users search -q name -s "name:1"
 
 ```
   -h, --help           help for search
-  -q, --query string   Query in Lucene query string syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.
+  -q, --query string   Query in Lucene query syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.
   -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.
 ```
 

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -56,7 +56,7 @@ var (
 		Name:       "Query",
 		LongForm:   "query",
 		ShortForm:  "q",
-		Help:       "Query in Lucene query string syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.",
+		Help:       "Query in Lucene query syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.",
 		IsRequired: true,
 	}
 	userSort = Flag{

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -65,14 +65,14 @@ func (v *logView) AsTableRow() []string {
 
 	conn := v.getConnection()
 	if conn == notApplicable {
-		conn = ansi.Faint(truncate(conn, 25))
+		conn = ansi.Faint(truncate(conn, 20))
 	} else {
-		conn = truncate(conn, 25)
+		conn = truncate(conn, 20)
 	}
 
 	return []string{
 		typ,
-		truncate(desc, 50),
+		truncate(desc, 54),
 		ansi.Faint(truncate(timeAgo(v.GetDate()), 17)),
 		conn,
 		clientName,
@@ -118,7 +118,7 @@ func (v *logView) typeDesc() (typ, desc string) {
 		typ = "..."
 	}
 
-	typ = truncate(chunks[0], 22)
+	typ = truncate(chunks[0], 23)
 
 	if len(chunks) == 2 {
 		desc = strings.TrimSuffix(chunks[1], ")")


### PR DESCRIPTION
### Description

This PR replaces the `--client-id` filter with a single `--filter` flag that takes a Lucene query string, like `users search`.

E.g.

```sh
auth0 logs list --filter "client_id:<client-id>"
auth0 logs list --filter "client_name:<client-name>"
auth0 logs list --filter "user_id:<user-id>"
auth0 logs tail --filter "user_name:<user-name>"
auth0 logs tail --filter "ip:<ip>"
auth0 logs tail --filter "type:f"
```

⚠️  **THIS IS A BREAKING CHANGE**

The alternative, which would have been to add a flag per valid filter field, would have meant having a bunch of flags that are mutually exclusive.

<img width="942" alt="Screen Shot 2021-06-11 at 12 21 46" src="https://user-images.githubusercontent.com/5055789/121711819-635d1980-cab1-11eb-8286-72394560e64c.png">

<img width="963" alt="Screen Shot 2021-06-11 at 12 23 07" src="https://user-images.githubusercontent.com/5055789/121711823-6526dd00-cab1-11eb-9a55-a8f270c46ce3.png">

<img width="942" alt="Screen Shot 2021-06-11 at 12 19 27" src="https://user-images.githubusercontent.com/5055789/121711802-5e986580-cab1-11eb-8649-e026f2377348.png">

<img width="940" alt="Screen Shot 2021-06-11 at 12 20 41" src="https://user-images.githubusercontent.com/5055789/121711813-61935600-cab1-11eb-8bb2-621e529a4849.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
