### PR TITLE
Track all commands if the user is logged in [CLI-178]

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -76,7 +76,6 @@ type cli struct {
 	api      *auth0.API
 	renderer *display.Renderer
 	tracker  *analytics.Tracker
-	context  context.Context
 	// set of flags which are user specified.
 	debug   bool
 	tenant  string

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -21,6 +21,9 @@ func loginCmd(cli *cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			_, err := RunLogin(ctx, cli, false)
+			if err == nil {
+				cli.tracker.TrackCommandRun(cmd, cli.config.InstallID)
+			}
 			return err
 		},
 	}


### PR DESCRIPTION
### Description

Previously only the commands that required being logged in were tracked. This PR tracks all commands (even if they don't require being logged in) if the user is logged in.

<img width="393" alt="Screen Shot 2021-06-14 at 17 21 05" src="https://user-images.githubusercontent.com/5055789/121954343-05406880-cd35-11eb-9731-4a734b240de8.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
