### PR TITLE
Add `branding domains update` [CLI-184]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,8 +42,10 @@ require (
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	golang.org/x/text v0.3.5 // indirect
-	gopkg.in/auth0.v5 v5.17.0
+	gopkg.in/auth0.v5 v5.18.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace gopkg.in/auth0.v5 => github.com/go-auth0/auth0 v1.3.1-0.20210615225247-8be98bbd9fc2

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaU
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/go-auth0/auth0 v1.3.1-0.20210615225247-8be98bbd9fc2 h1:/l2v4Rrnp0ACgi1pJIMuVXoBqBEcr7QAYtoJzQOz9EM=
+github.com/go-auth0/auth0 v1.3.1-0.20210615225247-8be98bbd9fc2/go.mod h1:ZUc29HB1p9iYkA1ti2uz/kVL3I9vg+Hs+qFjHKub9SM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -785,8 +787,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/auth0.v5 v5.17.0 h1:QBY9DJh/LNE1qEQc8r7Bg6edj+AyNb+r0UxZplx598g=
-gopkg.in/auth0.v5 v5.17.0/go.mod h1:ZUc29HB1p9iYkA1ti2uz/kVL3I9vg+Hs+qFjHKub9SM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -35,7 +35,7 @@ var requiredScopes = []string{
 	"read:branding", "update:branding",
 	"read:connections", "update:connections",
 	"read:client_keys", "read:logs", "read:tenant_settings", 
-	"read:custom_domains", "create:custom_domains", "delete:custom_domains",
+	"read:custom_domains", "create:custom_domains", "update:custom_domains", "delete:custom_domains",
 	"read:anomaly_blocks", "delete:anomaly_blocks",
 	"create:log_streams", "delete:log_streams", "read:log_streams", "update:log_streams",
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -29,7 +29,7 @@ func TestRequiredScopes(t *testing.T) {
 		list := []string{
 			"read:branding", "update:branding",
 			"read:connections", "update:connections",
-			"read:custom_domains", "create:custom_domains", "delete:custom_domains",
+			"read:custom_domains", "create:custom_domains", "update:custom_domains", "delete:custom_domains",
 			"read:client_keys", "read:logs", "read:tenant_settings",
 			"read:anomaly_blocks", "delete:anomaly_blocks",
 		}

--- a/internal/auth0/custom_domain.go
+++ b/internal/auth0/custom_domain.go
@@ -10,6 +10,9 @@ type CustomDomainAPI interface {
 	// Read retrieves a custom domain by its id.
 	Read(id string, opts ...management.RequestOption) (c *management.CustomDomain, err error)
 
+	// Update a custom domain.
+	Update(id string, c *management.CustomDomain, opts ...management.RequestOption) (err error)
+
 	// Delete a custom domain.
 	Delete(id string, opts ...management.RequestOption) (err error)
 

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -274,7 +274,7 @@ auth0 apis update -n myapi -e 6100 --offline-access=true`,
 				current, err = cli.api.ResourceServer.Read(url.PathEscape(inputs.ID))
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load API. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load API: %w", err)
 			}
 
 			if err := apiName.AskU(cmd, &inputs.Name, current.Name); err != nil {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -249,7 +249,7 @@ auth0 apps show <id>`,
 				a, err = cli.api.Client.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load application. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load application: %w", err)
 			}
 
 			cli.renderer.ApplicationShow(a, inputs.Reveal)
@@ -494,7 +494,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]`,
 				current, err = cli.api.Client.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load application. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load application: %w", err)
 			}
 
 			// Prompt for app name

--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -233,7 +233,7 @@ func updateCustomDomainCmd(cli *cli) *cobra.Command {
 		Long:  "Update a custom domain.",
 		Example: `auth0 branding domains update
 auth0 branding domains update <id> --policy compatible
-auth0 branding domains update <id> -p compatible --ip-header "X-Connecting-IP"`,
+auth0 branding domains update <id> -p compatible --ip-header "cf-connecting-ip"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.CustomDomain
 

--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -13,8 +13,10 @@ import (
 
 const (
 	customDomainProvisioningTypeAuth0 = "auth0_managed_certs"
-	customDomainProvisioningTypeSelf = "self_managed_certs"
+	customDomainProvisioningTypeSelf  = "self_managed_certs"
 	customDomainVerificationMethodTxt = "txt"
+	customDomainTLSPolicyRecommended  = "recommended"
+	customDomainTLSPolicyCompatible   = "compatible"
 )
 
 var (
@@ -32,10 +34,10 @@ var (
 	}
 
 	customDomainType = Flag{
-		Name:       "Provisioning Type",
-		LongForm:   "type",
-		ShortForm:  "t",
-		Help:       "Custom domain provisioning type. Must be 'auth0' for Auth0-managed certs or 'self' for self-managed certs.",
+		Name:      "Provisioning Type",
+		LongForm:  "type",
+		ShortForm: "t",
+		Help:      "Custom domain provisioning type. Must be 'auth0' for Auth0-managed certs or 'self' for self-managed certs.",
 	}
 
 	customDomainVerification = Flag{
@@ -43,6 +45,27 @@ var (
 		LongForm:  "verification",
 		ShortForm: "v",
 		Help:      "Custom domain verification method. Must be 'txt'.",
+	}
+
+	customDomainPolicy = Flag{
+		Name:         "TLS Policy",
+		LongForm:     "policy",
+		ShortForm:    "p",
+		Help:         "The TLS version policy. Can be either 'compatible' or 'recommended'.",
+		AlwaysPrompt: true,
+	}
+
+	customDomainIPHeader = Flag{
+		Name:         "Custom Client IP Header",
+		LongForm:     "ip-header",
+		ShortForm:    "i",
+		Help:         "The HTTP header to fetch the client's IP address.",
+		AlwaysPrompt: true,
+	}
+
+	customDomainPolicyOptions = []string{
+		customDomainTLSPolicyRecommended,
+		customDomainTLSPolicyCompatible,
 	}
 )
 
@@ -57,6 +80,7 @@ func customDomainsCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(listCustomDomainsCmd(cli))
 	cmd.AddCommand(showCustomDomainCmd(cli))
 	cmd.AddCommand(createCustomDomainCmd(cli))
+	cmd.AddCommand(updateCustomDomainCmd(cli))
 	cmd.AddCommand(deleteCustomDomainCmd(cli))
 	cmd.AddCommand(verifyCustomDomainCmd(cli))
 
@@ -134,9 +158,11 @@ auth0 branding domains show <id>`,
 
 func createCustomDomainCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Domain             string
-		Type               string
-		VerificationMethod string
+		Domain               string
+		Type                 string
+		VerificationMethod   string
+		TLSPolicy            string
+		CustomClientIPHeader string
 	}
 
 	cmd := &cobra.Command{
@@ -155,14 +181,22 @@ auth0 branding domains create <id>`,
 				Domain: &inputs.Domain,
 			}
 
-			if len(inputs.Type) > 0 {
+			if inputs.Type != "" {
 				customDomain.Type = apiProvisioningTypeFor(inputs.Type)
 			} else {
 				customDomain.Type = auth0.String(customDomainProvisioningTypeAuth0)
 			}
 
-			if len(inputs.VerificationMethod) > 0 {
+			if inputs.VerificationMethod != "" {
 				customDomain.VerificationMethod = apiVerificationMethodFor(inputs.VerificationMethod)
+			}
+
+			if inputs.TLSPolicy != "" {
+				customDomain.TLSPolicy = apiTLSPolicyFor(inputs.TLSPolicy)
+			}
+
+			if inputs.CustomClientIPHeader != "" {
+				customDomain.CustomClientIPHeader = &inputs.CustomClientIPHeader
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -176,9 +210,89 @@ auth0 branding domains create <id>`,
 		},
 	}
 
-	customDomainDomain.RegisterStringU(cmd, &inputs.Domain, "")
-	customDomainType.RegisterStringU(cmd, &inputs.Type, "")
-	customDomainVerification.RegisterStringU(cmd, &inputs.VerificationMethod, "")
+	customDomainDomain.RegisterString(cmd, &inputs.Domain, "")
+	customDomainType.RegisterString(cmd, &inputs.Type, "")
+	customDomainVerification.RegisterString(cmd, &inputs.VerificationMethod, "")
+	customDomainPolicy.RegisterString(cmd, &inputs.TLSPolicy, "")
+	customDomainIPHeader.RegisterString(cmd, &inputs.CustomClientIPHeader, "")
+
+	return cmd
+}
+
+func updateCustomDomainCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID                   string
+		TLSPolicy            string
+		CustomClientIPHeader string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Update a custom domain",
+		Long:  "Update a custom domain.",
+		Example: `auth0 branding domains update
+auth0 branding domains update <id> --policy compatible
+auth0 branding domains update <id> -p compatible --ip-header "X-Connecting-IP"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var current *management.CustomDomain
+
+			if len(args) == 0 {
+				err := customDomainID.Pick(cmd, &inputs.ID, cli.customDomainsPickerOptions)
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			// Load custom domain by id
+			if err := ansi.Waiting(func() error {
+				var err error
+				current, err = cli.api.CustomDomain.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("Unable to load custom domain: %w", err)
+			}
+
+			// Prompt for TLS policy
+			if err := customDomainPolicy.SelectU(cmd, &inputs.TLSPolicy, customDomainPolicyOptions, current.TLSPolicy); err != nil {
+				return err
+			}
+
+			// Prompt for custom domain custom client IP header
+			if err := customDomainIPHeader.AskU(cmd, &inputs.CustomClientIPHeader, current.CustomClientIPHeader); err != nil {
+				return err
+			}
+
+			// Start with an empty custom domain object. We'll conditionally
+			// hydrate it based on the provided parameters since
+			// we'll do PATCH semantics.
+			c := &management.CustomDomain{}
+
+			if inputs.TLSPolicy != "" {
+				c.TLSPolicy = apiTLSPolicyFor(inputs.TLSPolicy)
+			}
+
+			if inputs.CustomClientIPHeader != "" {
+				c.CustomClientIPHeader = &inputs.CustomClientIPHeader
+			}
+
+			// Update custom domain
+			if err := ansi.Waiting(func() error {
+				return cli.api.CustomDomain.Update(inputs.ID, c)
+			}); err != nil {
+				return fmt.Errorf("Unable to update custom domain: %v", err)
+			}
+
+			// Render custom domain update specific view
+			cli.renderer.CustomDomainUpdate(c)
+			return nil
+		},
+	}
+
+	customDomainPolicy.RegisterStringU(cmd, &inputs.TLSPolicy, "")
+	customDomainIPHeader.RegisterStringU(cmd, &inputs.CustomClientIPHeader, "")
 
 	return cmd
 }
@@ -281,6 +395,17 @@ func apiVerificationMethodFor(v string) *string {
 	switch v {
 	case "txt":
 		return auth0.String(customDomainVerificationMethodTxt)
+	default:
+		return auth0.String(v)
+	}
+}
+
+func apiTLSPolicyFor(v string) *string {
+	switch v {
+	case "recommended":
+		return auth0.String(customDomainTLSPolicyRecommended)
+	case "compatible":
+		return auth0.String(customDomainTLSPolicyCompatible)
 	default:
 		return auth0.String(v)
 	}

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -222,7 +222,7 @@ auth0 logs streams show <id>`,
 				a, err = cli.api.LogStream.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load log stream. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load log stream: %w", err)
 			}
 			cli.renderer.LogStreamShow(a)
 			return nil
@@ -487,7 +487,7 @@ auth0 logs streams update <id> -n myeventbridge -t eventbridge`,
 				current, err = cli.api.LogStream.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load logstream. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load logstream: %w", err)
 			}
 
 			// Prompt for log stream name

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -110,7 +110,7 @@ auth0 roles show <id>`,
 				r, err = cli.api.Role.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load role. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load role: %w", err)
 			}
 
 			cli.renderer.RoleShow(r)

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -207,7 +207,7 @@ auth0 rules show <id>`,
 			})
 
 			if err != nil {
-				return fmt.Errorf("Unable to load rule. The ID %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load rule: %w", err)
 			}
 
 			cli.renderer.RuleShow(rule)

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -250,7 +250,7 @@ auth0 users show <id>`,
 				a, err = cli.api.User.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load user. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load user: %w", err)
 			}
 
 			// get the current connection
@@ -345,7 +345,7 @@ auth0 users update -n John Doe --email john.doe@example.com`,
 				current, err = cli.api.User.Read(inputs.ID)
 				return err
 			}); err != nil {
-				return fmt.Errorf("Unable to load user. The Id %v specified doesn't exist", inputs.ID)
+				return fmt.Errorf("Unable to load user: %w", err)
 			}
 			// using getUserConnection to get connection name from user Identities
 			// just using current.connection will return empty

--- a/internal/display/custom_domain.go
+++ b/internal/display/custom_domain.go
@@ -8,12 +8,14 @@ import (
 )
 
 type customDomainView struct {
-	ID                 string
-	Domain             string
-	Status             string
-	Primary            bool
-	ProvisioningType   string
-	VerificationMethod string
+	ID                   string
+	Domain               string
+	Status               string
+	Primary              bool
+	ProvisioningType     string
+	VerificationMethod   string
+	TLSPolicy            string
+	CustomClientIPHeader string
 }
 
 func (v *customDomainView) AsTableHeader() []string {
@@ -36,6 +38,8 @@ func (v *customDomainView) KeyValues() [][]string {
 		{"PRIMARY", strconv.FormatBool(v.Primary)},
 		{"PROVISIONING TYPE", v.ProvisioningType},
 		{"VERIFICATION METHOD", v.VerificationMethod},
+		{"TLS POLICY", v.TLSPolicy},
+		{"CUSTOM CLIENT IP HEADER", v.CustomClientIPHeader},
 	}
 }
 
@@ -72,19 +76,26 @@ func (r *Renderer) CustomDomainCreate(customDomain *management.CustomDomain) {
 	r.customDomainResult(customDomain)
 }
 
+func (r *Renderer) CustomDomainUpdate(customDomain *management.CustomDomain) {
+	r.Heading("custom domain updated")
+	r.customDomainResult(customDomain)
+}
+
 func (r *Renderer) customDomainResult(customDomain *management.CustomDomain) {
 	r.Result(&customDomainView{
-		ID:                 ansi.Faint(customDomain.GetID()),
-		Domain:             customDomain.GetDomain(),
-		Status:             customDomainStatusColor(customDomain.GetStatus()),
-		Primary:            customDomain.GetPrimary(),
-		ProvisioningType:   customDomain.GetType(),
-		VerificationMethod: customDomain.GetVerificationMethod(),
+		ID:                   ansi.Faint(customDomain.GetID()),
+		Domain:               customDomain.GetDomain(),
+		Status:               customDomainStatusColor(customDomain.GetStatus()),
+		Primary:              customDomain.GetPrimary(),
+		ProvisioningType:     customDomain.GetType(),
+		VerificationMethod:   customDomain.GetVerificationMethod(),
+		TLSPolicy:            customDomain.GetTLSPolicy(),
+		CustomClientIPHeader: customDomain.GetCustomClientIPHeader(),
 	})
 }
 
 func customDomainStatusColor(v string) string {
-	switch(v) {
+	switch v {
 	case "disabled":
 		return ansi.Red(v)
 	case "pending", "pending_verification":

--- a/vendor/gopkg.in/auth0.v5/CHANGELOG.md
+++ b/vendor/gopkg.in/auth0.v5/CHANGELOG.md
@@ -1,7 +1,17 @@
+# v5.18.0
+
+* `management.Actions`: Support for Auth0 ([Actions](https://auth0.com/docs/actions)) ([#219](https://github.com/go-auth0/auth0/pull/219))
+
+## v5.17.0
+
+* `management.AnomalyManager`: Support for `CheckIP` and `UnblockIP` ([#214](https://github.com/go-auth0/auth0/pull/214))
+
 ## v5.16.0
+
 * `management.Connection`: Add support for Google Apps enterprise connection ([#212](https://github.com/go-auth0/auth0/pull/212))
 
 ## v5.15.0
+
 * `management.Guardian`: Fixed minor bug when unmarshalling Policy string array ([#211](https://github.com/go-auth0/auth0/pull/211))
 
 NOTES:
@@ -9,9 +19,11 @@ NOTES:
 * Added support for .env config file support ([#210](https://github.com/go-auth0/auth0/pull/210))
 
 ## v5.14.1
+
 * `management.Connection`: Add support for Auth0 SAML connection entityId option ([#209](https://github.com/go-auth0/auth0/pull/209))
 
 ## v5.14.0
+
 * `management.SigningKey`: Add support for listing, reading, rotating and revoking an Auth0 Tenant's signing key ([#191](https://github.com/go-auth0/auth0/pull/191))
 * `management.Grant`: Support pagination response when listing Grants ([#205](https://github.com/go-auth0/auth0/pull/205))
 * `management.Guardian`: Support to create a MFA enrollment ticket ([#207](https://github.com/go-auth0/auth0/pull/207))
@@ -19,9 +31,11 @@ NOTES:
 * `management.Connection`: Support deny list (non persistent attributes) of attributes Auth0 stores per connection object ([#203](https://github.com/go-auth0/auth0/pull/203))
 
 ## v5.13.0
+
 * `management.ConnectionOptionsOIDC`: Add `SetUserAttributes` to OIDC Strategy
 
 ## v5.12.0
+
 * `management.Connection`: Change Metadata property to be string map ([#160](https://github.com/go-auth0/auth0/pull/160))
 * `management.Connection`: Add Auth0 managed `ProvisioningTicketUrl to root connection object ([#201](https://github.com/go-auth0/auth0/pull/201))
 * `management.ConnectionOptions`: Adds missing AzureAD connection `TrustEmailVerified` option ([#198](https://github.com/go-auth0/auth0/pull/198))
@@ -34,12 +48,15 @@ NOTES:
 * `management.UserIdentity`: Add MFA Enrollments for a User ([#157](https://github.com/go-auth0/auth0/pull/157))
 
 ## v5.11.0
+
 * `management.ConnectionOptions`: Adds SetUserAttributes to ConnectionOptions to connections ([#194](https://github.com/go-auth0/auth0/pull/194))
 
 ## v5.10.0
+
 * `management.ConnectionOptions`: Adds set_user_root_attributes to more connections ([#192](https://github.com/go-auth0/auth0/pull/192))
 
 ## v5.9.0 
+
 * `management.ConnectionManager`: Return nil when ConnectionManager.ReadByName() name field is empty ([#186](https://github.com/go-auth0/auth0/pull/186))
 
 ## v5.8.0

--- a/vendor/gopkg.in/auth0.v5/README.md
+++ b/vendor/gopkg.in/auth0.v5/README.md
@@ -77,7 +77,7 @@ The following Auth0 resources are supported:
 - [x] [Jobs](https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id)
 - [x] [Stats](https://auth0.com/docs/api/management/v2#!/Stats/get_active_users)
 - [x] [Tenants](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings)
-- [ ] [Anomaly](https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id)
+- [X] [Anomaly](https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id)
 - [x] [Tickets](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification)
 - [x] [Signing Keys](https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys)
 

--- a/vendor/gopkg.in/auth0.v5/management/actions.go
+++ b/vendor/gopkg.in/auth0.v5/management/actions.go
@@ -1,0 +1,279 @@
+package management
+
+import (
+	"net/http"
+	"time"
+)
+
+const (
+	ActionTriggerPostLogin         string = "post-login"
+	ActionTriggerClientCredentials string = "client-credentials"
+)
+
+type ActionTrigger struct {
+	ID      *string `json:"id"`
+	Version *string `json:"version"`
+	Status  *string `json:"status,omitempty"`
+}
+
+type ActionTriggerList struct {
+	Triggers []*ActionTrigger `json:"triggers"`
+}
+
+type ActionDependency struct {
+	Name        *string `json:"name"`
+	Version     *string `json:"version,omitempty"`
+	RegistryURL *string `json:"registry_url,omitempty"`
+}
+
+type ActionSecret struct {
+	Name      *string    `json:"name"`
+	Value     *string    `json:"value,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type ActionVersionError struct {
+	ID      *string `json:"id"`
+	Message *string `json:"msg"`
+	Url     *string `json:"url"`
+}
+
+const (
+	ActionStatusPending  string = "pending"
+	ActionStatusBuilding string = "building"
+	ActionStatusPackaged string = "packaged"
+	ActionStatusBuilt    string = "built"
+	ActionStatusRetrying string = "retrying"
+	ActionStatusFailed   string = "failed"
+)
+
+type Action struct {
+	ID   *string `json:"id,omitempty"`
+	Name *string `json:"name"`
+	Code *string `json:"code,omitempty"` // nil in embedded Action in ActionVersion
+
+	SupportedTriggers []ActionTrigger    `json:"supported_triggers"`
+	Dependencies      []ActionDependency `json:"dependencies,omitempty"`
+	Secrets           []ActionSecret     `json:"secrets,omitempty"`
+
+	DeployedVersion    *ActionVersion `json:"deployed_version,omitempty"`
+	Status             *string        `json:"status,omitempty"`
+	AllChangesDeployed bool           `json:"all_changes_deployed,omitempty"`
+
+	BuiltAt   *time.Time `json:"built_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type ActionList struct {
+	List
+	Actions []*Action `json:"actions"`
+}
+
+type ActionVersion struct {
+	ID           *string            `json:"id,omitempty"`
+	Code         *string            `json:"code"`
+	Dependencies []ActionDependency `json:"dependencies,omitempty"`
+	Deployed     bool               `json:"deployed"`
+	Status       *string            `json:"status,omitempty"`
+	Number       int                `json:"number,omitempty"`
+
+	Errors []ActionVersionError `json:"errors,omitempty"`
+	Action *Action              `json:"action,omitempty"`
+
+	BuiltAt   *time.Time `json:"built_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type ActionVersionList struct {
+	List
+	Versions []*ActionVersion `json:"versions"`
+}
+
+const (
+	ActionBindingReferenceByName string = "action_name"
+	ActionBindingReferenceById   string = "action_id"
+)
+
+type ActionBindingReference struct {
+	Type  *string `json:"type"`
+	Value *string `json:"value"`
+}
+
+type ActionBinding struct {
+	ID          *string `json:"id,omitempty"`
+	TriggerID   *string `json:"trigger_id,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+
+	Ref     *ActionBindingReference `json:"ref,omitempty"`
+	Action  *Action                 `json:"action,omitempty"`
+	Secrets []ActionSecret          `json:"secrets,omitempty"`
+
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type ActionBindingList struct {
+	List
+	Bindings []*ActionBinding `json:"bindings"`
+}
+
+type actionBindingsPerTrigger struct {
+	Bindings []*ActionBinding `json:"bindings"`
+}
+
+type ActionTestPayload map[string]interface{}
+
+type ActionTestRequest struct {
+	Payload *ActionTestPayload `json:"payload"`
+}
+
+type ActionExecutionResult struct {
+	ActionName *string            `json:"action_name,omitempty"`
+	Error      *map[string]string `json:"error,omitempty"`
+
+	StartedAt *time.Time `json:"started_at,omitempty"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+}
+
+type ActionExecution struct {
+	ID        *string                  `json:"id"`
+	TriggerID *string                  `json:"trigger_id"`
+	Status    *string                  `json:"status"`
+	Results   []*ActionExecutionResult `json:"results"`
+
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type ActionManager struct {
+	*Management
+}
+
+func newActionManager(m *Management) *ActionManager {
+	return &ActionManager{m}
+}
+
+func applyActionsListDefaults(options []RequestOption) RequestOption {
+	return newRequestOption(func(r *http.Request) {
+		PerPage(50).apply(r)
+		for _, option := range options {
+			option.apply(r)
+		}
+	})
+}
+
+// ListTriggers available.
+//
+// https://auth0.com/docs/api/management/v2/#!/Actions/get_triggers
+func (m *ActionManager) ListTriggers(opts ...RequestOption) (l *ActionTriggerList, err error) {
+	err = m.Request("GET", m.URI("actions", "triggers"), &l, opts...)
+	return
+}
+
+// Create a new action.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Actions/post_action
+func (m *ActionManager) Create(a *Action, opts ...RequestOption) error {
+	return m.Request("POST", m.URI("actions", "actions"), a, opts...)
+}
+
+// Retrieve action details.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Actions/get_action
+func (m *ActionManager) Read(id string, opts ...RequestOption) (a *Action, err error) {
+	err = m.Request("GET", m.URI("actions", "actions", id), &a, opts...)
+	return
+}
+
+// Update an existing action.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Actions/patch_action
+func (m *ActionManager) Update(id string, a *Action, opts ...RequestOption) error {
+	return m.Request("PATCH", m.URI("actions", "actions", id), &a, opts...)
+}
+
+// Delete an action
+//
+// See: https://auth0.com/docs/api/management/v2#!/Actions/delete_action
+func (m *ActionManager) Delete(id string, opts ...RequestOption) error {
+	return m.Request("DELETE", m.URI("actions", "actions", id), nil, opts...)
+}
+
+// List all actions.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Actions/get_actions
+func (m *ActionManager) List(opts ...RequestOption) (l *ActionList, err error) {
+	err = m.Request("GET", m.URI("actions", "actions"), &l, applyActionsListDefaults(opts))
+	return
+}
+
+// ReadVersion of an action.
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/get_action_version
+func (m *ActionManager) ReadVersion(id string, versionId string, opts ...RequestOption) (v *ActionVersion, err error) {
+	err = m.Request("GET", m.URI("actions", "actions", id, "versions", versionId), &v, opts...)
+	return
+}
+
+// ListVersions of an action.
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/get_action_versions
+func (m *ActionManager) ListVersions(id string, opts ...RequestOption) (c *ActionVersionList, err error) {
+	err = m.Request("GET", m.URI("actions", "actions", id, "versions"), &c, applyActionsListDefaults(opts))
+	return
+}
+
+// UpdateBindings of a trigger
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/patch_bindings
+func (m *ActionManager) UpdateBindings(triggerID string, b []*ActionBinding, opts ...RequestOption) error {
+	bl := &actionBindingsPerTrigger{
+		Bindings: b,
+	}
+	return m.Request("PATCH", m.URI("actions", "triggers", triggerID, "bindings"), &bl, opts...)
+}
+
+// ListBindings of a trigger
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/get_bindings
+func (m *ActionManager) ListBindings(triggerID string, opts ...RequestOption) (bl *ActionBindingList, err error) {
+	err = m.Request("GET", m.URI("actions", "triggers", triggerID, "bindings"), &bl, applyActionsListDefaults(opts))
+	return
+}
+
+// Deploy an action
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/post_deploy_action
+func (m *ActionManager) Deploy(id string, opts ...RequestOption) (v *ActionVersion, err error) {
+	err = m.Request("POST", m.URI("actions", "actions", id, "deploy"), &v, opts...)
+	return
+}
+
+// DeployVersion of an action
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/post_deploy_draft_version
+func (m *ActionManager) DeployVersion(id string, versionId string, opts ...RequestOption) (v *ActionVersion, err error) {
+	err = m.Request("POST", m.URI("actions", "actions", id, "versions", versionId, "deploy"), &v, opts...)
+	return
+}
+
+// Test an action
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/post_test_action
+func (m *ActionManager) Test(id string, payload *ActionTestPayload, opts ...RequestOption) (err error) {
+	r := &ActionTestRequest{
+		Payload: payload,
+	}
+	err = m.Request("POST", m.URI("actions", "actions", id, "test"), &r, opts...)
+	return
+}
+
+// ReadExecution of an action
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/get_execution
+func (m *ActionManager) ReadExecution(executionId string, opts ...RequestOption) (v *ActionExecution, err error) {
+	err = m.Request("GET", m.URI("actions", "executions", executionId), &v, opts...)
+	return
+}

--- a/vendor/gopkg.in/auth0.v5/management/custom_domain.go
+++ b/vendor/gopkg.in/auth0.v5/management/custom_domain.go
@@ -24,6 +24,12 @@ type CustomDomain struct {
 	VerificationMethod *string `json:"verification_method,omitempty"`
 
 	Verification *CustomDomainVerification `json:"verification,omitempty"`
+
+	// The TLS version policy. Can be either "compatible" or "recommended".
+	TLSPolicy *string `json:"tls_policy,omitempty"`
+
+	// The HTTP header to fetch the client's IP address
+	CustomClientIPHeader *string `json:"custom_client_ip_header,omitempty"`
 }
 
 type CustomDomainVerification struct {
@@ -48,6 +54,13 @@ func newCustomDomainManager(m *Management) *CustomDomainManager {
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/post_custom_domains
 func (m *CustomDomainManager) Create(c *CustomDomain, opts ...RequestOption) (err error) {
 	return m.Request("POST", m.URI("custom-domains"), c, opts...)
+}
+
+// Update a custom domain.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/patch_custom_domains_by_id
+func (m *CustomDomainManager) Update(id string, c *CustomDomain, opts ...RequestOption) (err error) {
+	return m.Request("PATCH", m.URI("custom-domains", id), c, opts...)
 }
 
 // Retrieve a custom domain configuration and status.

--- a/vendor/gopkg.in/auth0.v5/management/management.gen.go
+++ b/vendor/gopkg.in/auth0.v5/management/management.gen.go
@@ -6,6 +6,449 @@ import (
 	"time"
 )
 
+// GetBuiltAt returns the BuiltAt field if it's non-nil, zero value otherwise.
+func (a *Action) GetBuiltAt() time.Time {
+	if a == nil || a.BuiltAt == nil {
+		return time.Time{}
+	}
+	return *a.BuiltAt
+}
+
+// GetCode returns the Code field if it's non-nil, zero value otherwise.
+func (a *Action) GetCode() string {
+	if a == nil || a.Code == nil {
+		return ""
+	}
+	return *a.Code
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *Action) GetCreatedAt() time.Time {
+	if a == nil || a.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *a.CreatedAt
+}
+
+// GetDeployedVersion returns the DeployedVersion field.
+func (a *Action) GetDeployedVersion() *ActionVersion {
+	if a == nil {
+		return nil
+	}
+	return a.DeployedVersion
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *Action) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *Action) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (a *Action) GetStatus() string {
+	if a == nil || a.Status == nil {
+		return ""
+	}
+	return *a.Status
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *Action) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// String returns a string representation of Action.
+func (a *Action) String() string {
+	return Stringify(a)
+}
+
+// GetAction returns the Action field.
+func (a *ActionBinding) GetAction() *Action {
+	if a == nil {
+		return nil
+	}
+	return a.Action
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetCreatedAt() time.Time {
+	if a == nil || a.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *a.CreatedAt
+}
+
+// GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetDisplayName() string {
+	if a == nil || a.DisplayName == nil {
+		return ""
+	}
+	return *a.DisplayName
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetRef returns the Ref field.
+func (a *ActionBinding) GetRef() *ActionBindingReference {
+	if a == nil {
+		return nil
+	}
+	return a.Ref
+}
+
+// GetTriggerID returns the TriggerID field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetTriggerID() string {
+	if a == nil || a.TriggerID == nil {
+		return ""
+	}
+	return *a.TriggerID
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// String returns a string representation of ActionBinding.
+func (a *ActionBinding) String() string {
+	return Stringify(a)
+}
+
+// String returns a string representation of ActionBindingList.
+func (a *ActionBindingList) String() string {
+	return Stringify(a)
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (a *ActionBindingReference) GetType() string {
+	if a == nil || a.Type == nil {
+		return ""
+	}
+	return *a.Type
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (a *ActionBindingReference) GetValue() string {
+	if a == nil || a.Value == nil {
+		return ""
+	}
+	return *a.Value
+}
+
+// String returns a string representation of ActionBindingReference.
+func (a *ActionBindingReference) String() string {
+	return Stringify(a)
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *ActionDependency) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetRegistryURL returns the RegistryURL field if it's non-nil, zero value otherwise.
+func (a *ActionDependency) GetRegistryURL() string {
+	if a == nil || a.RegistryURL == nil {
+		return ""
+	}
+	return *a.RegistryURL
+}
+
+// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+func (a *ActionDependency) GetVersion() string {
+	if a == nil || a.Version == nil {
+		return ""
+	}
+	return *a.Version
+}
+
+// String returns a string representation of ActionDependency.
+func (a *ActionDependency) String() string {
+	return Stringify(a)
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetCreatedAt() time.Time {
+	if a == nil || a.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *a.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetStatus() string {
+	if a == nil || a.Status == nil {
+		return ""
+	}
+	return *a.Status
+}
+
+// GetTriggerID returns the TriggerID field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetTriggerID() string {
+	if a == nil || a.TriggerID == nil {
+		return ""
+	}
+	return *a.TriggerID
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// String returns a string representation of ActionExecution.
+func (a *ActionExecution) String() string {
+	return Stringify(a)
+}
+
+// GetActionName returns the ActionName field if it's non-nil, zero value otherwise.
+func (a *ActionExecutionResult) GetActionName() string {
+	if a == nil || a.ActionName == nil {
+		return ""
+	}
+	return *a.ActionName
+}
+
+// GetEndedAt returns the EndedAt field if it's non-nil, zero value otherwise.
+func (a *ActionExecutionResult) GetEndedAt() time.Time {
+	if a == nil || a.EndedAt == nil {
+		return time.Time{}
+	}
+	return *a.EndedAt
+}
+
+// GetError returns the Error field if it's non-nil, zero value otherwise.
+func (a *ActionExecutionResult) GetError() map[string]string {
+	if a == nil || a.Error == nil {
+		return map[string]string{}
+	}
+	return *a.Error
+}
+
+// GetStartedAt returns the StartedAt field if it's non-nil, zero value otherwise.
+func (a *ActionExecutionResult) GetStartedAt() time.Time {
+	if a == nil || a.StartedAt == nil {
+		return time.Time{}
+	}
+	return *a.StartedAt
+}
+
+// String returns a string representation of ActionExecutionResult.
+func (a *ActionExecutionResult) String() string {
+	return Stringify(a)
+}
+
+// String returns a string representation of ActionList.
+func (a *ActionList) String() string {
+	return Stringify(a)
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *ActionSecret) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionSecret) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// GetValue returns the Value field if it's non-nil, zero value otherwise.
+func (a *ActionSecret) GetValue() string {
+	if a == nil || a.Value == nil {
+		return ""
+	}
+	return *a.Value
+}
+
+// String returns a string representation of ActionSecret.
+func (a *ActionSecret) String() string {
+	return Stringify(a)
+}
+
+// GetPayload returns the Payload field.
+func (a *ActionTestRequest) GetPayload() *ActionTestPayload {
+	if a == nil {
+		return nil
+	}
+	return a.Payload
+}
+
+// String returns a string representation of ActionTestRequest.
+func (a *ActionTestRequest) String() string {
+	return Stringify(a)
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ActionTrigger) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (a *ActionTrigger) GetStatus() string {
+	if a == nil || a.Status == nil {
+		return ""
+	}
+	return *a.Status
+}
+
+// GetVersion returns the Version field if it's non-nil, zero value otherwise.
+func (a *ActionTrigger) GetVersion() string {
+	if a == nil || a.Version == nil {
+		return ""
+	}
+	return *a.Version
+}
+
+// String returns a string representation of ActionTrigger.
+func (a *ActionTrigger) String() string {
+	return Stringify(a)
+}
+
+// String returns a string representation of ActionTriggerList.
+func (a *ActionTriggerList) String() string {
+	return Stringify(a)
+}
+
+// GetAction returns the Action field.
+func (a *ActionVersion) GetAction() *Action {
+	if a == nil {
+		return nil
+	}
+	return a.Action
+}
+
+// GetBuiltAt returns the BuiltAt field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetBuiltAt() time.Time {
+	if a == nil || a.BuiltAt == nil {
+		return time.Time{}
+	}
+	return *a.BuiltAt
+}
+
+// GetCode returns the Code field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetCode() string {
+	if a == nil || a.Code == nil {
+		return ""
+	}
+	return *a.Code
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetCreatedAt() time.Time {
+	if a == nil || a.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *a.CreatedAt
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetStatus() string {
+	if a == nil || a.Status == nil {
+		return ""
+	}
+	return *a.Status
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// String returns a string representation of ActionVersion.
+func (a *ActionVersion) String() string {
+	return Stringify(a)
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ActionVersionError) GetID() string {
+	if a == nil || a.ID == nil {
+		return ""
+	}
+	return *a.ID
+}
+
+// GetMessage returns the Message field if it's non-nil, zero value otherwise.
+func (a *ActionVersionError) GetMessage() string {
+	if a == nil || a.Message == nil {
+		return ""
+	}
+	return *a.Message
+}
+
+// GetUrl returns the Url field if it's non-nil, zero value otherwise.
+func (a *ActionVersionError) GetUrl() string {
+	if a == nil || a.Url == nil {
+		return ""
+	}
+	return *a.Url
+}
+
+// String returns a string representation of ActionVersionError.
+func (a *ActionVersionError) String() string {
+	return Stringify(a)
+}
+
+// String returns a string representation of ActionVersionList.
+func (a *ActionVersionList) String() string {
+	return Stringify(a)
+}
+
 // String returns a string representation of BlacklistToken.
 func (b *BlacklistToken) String() string {
 	return Stringify(b)
@@ -2898,6 +3341,14 @@ func (c *CreateEnrollmentTicket) String() string {
 	return Stringify(c)
 }
 
+// GetCustomClientIPHeader returns the CustomClientIPHeader field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetCustomClientIPHeader() string {
+	if c == nil || c.CustomClientIPHeader == nil {
+		return ""
+	}
+	return *c.CustomClientIPHeader
+}
+
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
 func (c *CustomDomain) GetDomain() string {
 	if c == nil || c.Domain == nil {
@@ -2928,6 +3379,14 @@ func (c *CustomDomain) GetStatus() string {
 		return ""
 	}
 	return *c.Status
+}
+
+// GetTLSPolicy returns the TLSPolicy field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetTLSPolicy() string {
+	if c == nil || c.TLSPolicy == nil {
+		return ""
+	}
+	return *c.TLSPolicy
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.

--- a/vendor/gopkg.in/auth0.v5/management/management.go
+++ b/vendor/gopkg.in/auth0.v5/management/management.go
@@ -159,6 +159,9 @@ type Management struct {
 	// Anomaly manages the IP blocks
 	Anomaly *AnomalyManager
 
+	// Actions manages Actions extensibility
+	Action *ActionManager
+
 	url         *url.URL
 	basePath    string
 	userAgent   string
@@ -227,6 +230,7 @@ func New(domain string, options ...ManagementOption) (*Management, error) {
 	m.Blacklist = newBlacklistManager(m)
 	m.SigningKey = newSigningKeyManager(m)
 	m.Anomaly = newAnomalyManager(m)
+	m.Action = newActionManager(m)
 
 	return m, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,7 +350,7 @@ google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
 google.golang.org/protobuf/runtime/protoimpl
-# gopkg.in/auth0.v5 v5.17.0
+# gopkg.in/auth0.v5 v5.18.0 => github.com/go-auth0/auth0 v1.3.1-0.20210615225247-8be98bbd9fc2
 ## explicit
 gopkg.in/auth0.v5
 gopkg.in/auth0.v5/internal/client
@@ -366,3 +366,4 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 ## explicit
 gopkg.in/yaml.v3
+# gopkg.in/auth0.v5 => github.com/go-auth0/auth0 v1.3.1-0.20210615225247-8be98bbd9fc2


### PR DESCRIPTION
### Description

Previously, the `update` command for custom domains could not be added, because the Go SDK did not support that method. Now that [it has been added](https://github.com/go-auth0/auth0/pull/222) to the Go SDK, this PR updates the Go SDK to the latest commit and adds the `branding domains update` command.

<img width="567" alt="Screen Shot 2021-06-15 at 16 21 05" src="https://user-images.githubusercontent.com/5055789/122135358-b8cd5980-ce16-11eb-8695-6073249e01e3.png">

### Testing

This change has been tested manually with a proxy, to check that the modified values are correctly included in the request.

<img width="198" alt="Screen Shot 2021-06-15 at 20 22 47" src="https://user-images.githubusercontent.com/5055789/122135753-78baa680-ce17-11eb-94d4-a2cdc47fa68a.png">

<img width="458" alt="Screen Shot 2021-06-15 at 20 20 26" src="https://user-images.githubusercontent.com/5055789/122135706-5fb1f580-ce17-11eb-9c99-fc27753b638c.png">

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
