### PR TITLE
Add `branding emails show` and `branding emails update` [CLI-190]

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -33,6 +33,7 @@ var requiredScopes = []string{
 	"create:rules", "delete:rules", "read:rules", "update:rules",
 	"create:users", "delete:users", "read:users", "update:users",
 	"read:branding", "update:branding",
+	"read:email_templates", "update:email_templates",
 	"read:connections", "update:connections",
 	"read:client_keys", "read:logs", "read:tenant_settings", 
 	"read:custom_domains", "create:custom_domains", "update:custom_domains", "delete:custom_domains",

--- a/internal/auth0/auth0.go
+++ b/internal/auth0/auth0.go
@@ -14,6 +14,7 @@ type API struct {
 	Client         ClientAPI
 	Connection     ConnectionAPI
 	CustomDomain   CustomDomainAPI
+	EmailTemplate  EmailTemplateAPI
 	Log            LogAPI
 	LogStream      LogStreamAPI
 	ResourceServer ResourceServerAPI
@@ -30,6 +31,7 @@ func NewAPI(m *management.Management) *API {
 		Branding:       m.Branding,
 		Client:         m.Client,
 		CustomDomain:   m.CustomDomain,
+		EmailTemplate:  m.EmailTemplate,
 		Log:            m.Log,
 		LogStream:      m.LogStream,
 		ResourceServer: m.ResourceServer,

--- a/internal/auth0/email_template.go
+++ b/internal/auth0/email_template.go
@@ -1,0 +1,24 @@
+//go:generate mockgen -source=email_template.go -destination=email_template_mock.go -package=auth0
+
+package auth0
+
+import "gopkg.in/auth0.v5/management"
+
+type EmailTemplateAPI interface {
+	// Retrieve an email template by pre-defined name.
+	//
+	// These names are `verify_email`, `reset_email`, `welcome_email`,
+	// `blocked_account`, `stolen_credentials`, `enrollment_email`, and
+	// `mfa_oob_code`.
+	//
+	// The names `change_password`, and `password_reset` are also supported for
+	// legacy scenarios.
+	//
+	// See: https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
+	Read(template string, opts ...management.RequestOption) (e *management.EmailTemplate, err error)
+
+	// Modify an email template.
+	//
+	// See: https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
+	Update(template string, e *management.EmailTemplate, opts ...management.RequestOption) (err error)
+}

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -295,7 +295,7 @@ auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -s "API_K
 			if err := actionCode.EditorPromptU(
 				cmd,
 				&inputs.Code,
-				actionTemplate(inputs.Trigger),
+				current.GetCode(),
 				inputs.Name+".*.js",
 				cli.actionEditorHint,
 			); err != nil {

--- a/internal/cli/branding.go
+++ b/internal/cli/branding.go
@@ -84,6 +84,7 @@ func brandingCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(updateBrandingCmd(cli))
 	cmd.AddCommand(templateCmd(cli))
 	cmd.AddCommand(customDomainsCmd(cli))
+	cmd.AddCommand(emailTemplateCmd(cli))
 	return cmd
 }
 
@@ -99,6 +100,20 @@ func templateCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(updateBrandingTemplateCmd(cli))
 	return cmd
 }
+
+func emailTemplateCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "emails",
+		Short: "Manage custom email templates",
+		Long:  "Manage custom email templates. This requires a custom email provider to be configured for the tenant.",
+	}
+
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(showEmailTemplateCmd(cli))
+	cmd.AddCommand(updateEmailTemplateCmd(cli))
+	return cmd
+}
+
 
 func showBrandingCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
@@ -137,10 +152,10 @@ func updateBrandingCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "update",
-		Args:    cobra.NoArgs,
-		Short:   "Update the custom branding settings for Universal Login",
-		Long:    "Update the custom branding settings for Universal Login.",
+		Use:   "update",
+		Args:  cobra.NoArgs,
+		Short: "Update the custom branding settings for Universal Login",
+		Long:  "Update the custom branding settings for Universal Login.",
 		Example: `auth0 branding update
 auth0 branding update --accent '#B24592' --background '#F2DDEC' 
 auth0 branding update -a '#B24592' -b '#F2DDEC --logo 'https://example.com/logo.png`,

--- a/internal/cli/email_templates.go
+++ b/internal/cli/email_templates.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/spf13/cobra"
+	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/management"
+)
+
+const (
+	emailTemplateVerifyLink     = "verify-link"
+	emailTemplateVerifyCode     = "verify-code"
+	emailTemplateChangePassword = "change-password"
+	emailTemplateWelcome        = "welcome"
+	emailTemplateBlockedAccount = "blocked-account"
+	emailTemplatePasswordBreach = "password-breach"
+	emailTemplateMFAEnrollment  = "mfa-enrollment"
+	emailTemplateMFACode        = "mfa-code"
+	emailTemplateUserInvitation = "user-invitation"
+)
+
+var (
+	emailTemplateTemplate = Argument{
+		Name: "Template",
+		Help: fmt.Sprintf("Template name. Can be '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' or '%s'",
+			emailTemplateVerifyLink,
+			emailTemplateVerifyCode,
+			emailTemplateChangePassword,
+			emailTemplateWelcome,
+			emailTemplateBlockedAccount,
+			emailTemplatePasswordBreach,
+			emailTemplateMFAEnrollment,
+			emailTemplateMFACode,
+			emailTemplateUserInvitation),
+	}
+
+	emailTemplateBody = Flag{
+		Name:       "Body",
+		LongForm:   "body",
+		ShortForm:  "b",
+		Help:       "Body of the email template.",
+		IsRequired: true,
+	}
+
+	emailTemplateFrom = Flag{
+		Name:         "From",
+		LongForm:     "from",
+		ShortForm:    "f",
+		Help:         "Sender's 'from' email address.",
+		AlwaysPrompt: true,
+	}
+
+	emailTemplateSubject = Flag{
+		Name:         "Subject",
+		LongForm:     "subject",
+		ShortForm:    "s",
+		Help:         "Subject line of the email.",
+		AlwaysPrompt: true,
+	}
+
+	emailTemplateEnabled = Flag{
+		Name:         "Enabled",
+		LongForm:     "enabled",
+		ShortForm:    "e",
+		Help:         "Whether the template is enabled (true) or disabled (false).",
+		AlwaysPrompt: true,
+	}
+
+	emailTemplateURL = Flag{
+		Name:      "Result URL",
+		LongForm:  "url",
+		ShortForm: "u",
+		Help:      "URL to redirect the user to after a successful action.",
+	}
+
+	emailTemplateLifetime = Flag{
+		Name:      "Result URL Lifetime",
+		LongForm:  "lifetime",
+		ShortForm: "l",
+		Help:      "Lifetime in seconds that the link within the email will be valid for.",
+	}
+
+	emailTemplateOptions = pickerOptions{
+		{"Verification Email (using Link)", emailTemplateVerifyLink},
+		{"Verification Email (using Code)", emailTemplateVerifyCode},
+		{"Change Password", emailTemplateChangePassword},
+		{"Welcome Email", emailTemplateWelcome, },
+		{"Blocked Account Email", emailTemplateBlockedAccount},
+		{"Password Breach Alert", emailTemplatePasswordBreach},
+		{"Enroll in Multifactor Authentication", emailTemplateMFAEnrollment},
+		{"Verification Code for Email MFA", emailTemplateMFACode},
+		{"User Invitation", emailTemplateUserInvitation},
+	}
+)
+
+func showEmailTemplateCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Template string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Show an email template",
+		Long:  "Show an email template.",
+		Example: `auth0 branding emails show <template>
+auth0 branding emails show welcome`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := emailTemplateTemplate.Pick(cmd, &inputs.Template, cli.emailTemplatePickerOptions)
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.Template = args[0]
+			}
+
+			var email *management.EmailTemplate
+
+			if err := ansi.Waiting(func() error {
+				var err error
+				email, err = cli.api.EmailTemplate.Read(apiEmailTemplateFor(inputs.Template))
+				return err
+			}); err != nil {
+				return fmt.Errorf("Unable to get the email template '%s': %w", inputs.Template, err)
+			}
+
+			cli.renderer.EmailTemplateShow(email)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func updateEmailTemplateCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Template          string
+		Body              string
+		From              string
+		Subject           string
+		Enabled           bool
+		ResultURL         string
+		ResultURLLifetime int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Update an email template",
+		Long:  "Update an email template.",
+		Example: `auth0 branding emails update <template>
+auth0 branding emails update welcome`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				inputs.Template = args[0]
+			} else {
+				err := emailTemplateTemplate.Pick(cmd, &inputs.Template, cli.emailTemplatePickerOptions)
+				if err != nil {
+					return err
+				}
+			}
+
+			var current *management.EmailTemplate
+			err := ansi.Waiting(func() error {
+				var err error
+				current, err = cli.api.EmailTemplate.Read(apiEmailTemplateFor(inputs.Template))
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("Unable to get the email template '%s': %w", inputs.Template, err)
+			}
+
+			if err := emailTemplateFrom.AskU(cmd, &inputs.From, current.From); err != nil {
+				return err
+			}
+
+			if err := emailTemplateSubject.AskU(cmd, &inputs.Subject, current.Subject); err != nil {
+				return err
+			}
+
+			// TODO(cyx): we can re-think this once we have
+			// `--stdin` based commands. For now we don't have
+			// those yet, so keeping this simple.
+			if err := emailTemplateBody.EditorPromptU(
+				cmd,
+				&inputs.Body,
+				current.GetBody(),
+				inputs.Template+".*.liquid",
+				cli.emailTemplateEditorHint,
+			); err != nil {
+				return err
+			}
+			if err != nil {
+				return fmt.Errorf("Failed to capture input from the editor: %w", err)
+			}
+
+			if !ruleEnabled.IsSet(cmd) {
+				inputs.Enabled = auth0.BoolValue(current.Enabled)
+			}
+
+			if err := ruleEnabled.AskBoolU(cmd, &inputs.Enabled, current.Enabled); err != nil {
+				return err
+			}
+
+			if inputs.From == "" {
+				inputs.From = current.GetFrom()
+			}
+
+			if inputs.Subject == "" {
+				inputs.Subject = current.GetSubject()
+			}
+
+			template := apiEmailTemplateFor(inputs.Template)
+			// Prepare email template payload for update. This will also be
+			// re-hydrated by the SDK, which we'll use below during
+			// display.
+			emailTemplate := &management.EmailTemplate{
+				Template: &template,
+				Body: &inputs.Body,
+				From: &inputs.From,
+				Subject: &inputs.Subject,
+				Enabled: &inputs.Enabled,
+			}
+
+			if inputs.ResultURL == "" {
+				emailTemplate.ResultURL = current.ResultURL
+			} else {
+				emailTemplate.ResultURL = &inputs.ResultURL
+			}
+
+			if inputs.ResultURLLifetime == 0 {
+				emailTemplate.URLLifetimeInSecoonds = current.URLLifetimeInSecoonds
+			} else {
+				emailTemplate.URLLifetimeInSecoonds = &inputs.ResultURLLifetime
+			}
+
+			if err = ansi.Waiting(func() error {
+				return cli.api.EmailTemplate.Update(template, emailTemplate)
+			}); err != nil {
+				return err
+			}
+
+			cli.renderer.EmailTemplateUpdate(emailTemplate)
+			return nil
+		},
+	}
+
+	emailTemplateBody.RegisterStringU(cmd, &inputs.Body, "")
+	emailTemplateFrom.RegisterStringU(cmd, &inputs.From, "")
+	emailTemplateSubject.RegisterStringU(cmd, &inputs.Subject, "")
+	emailTemplateEnabled.RegisterBoolU(cmd, &inputs.Enabled, true)
+	emailTemplateURL.RegisterStringU(cmd, &inputs.ResultURL, "")
+	emailTemplateLifetime.RegisterIntU(cmd, &inputs.ResultURLLifetime, 0)
+
+	return cmd
+}
+
+func (c *cli) emailTemplateEditorHint() {
+	c.renderer.Infof("%s once you close the editor, the email template will be saved. To cancel, CTRL+C.", ansi.Faint("Hint:"))
+}
+
+func (c *cli) emailTemplatePickerOptions() (pickerOptions, error) {
+	return emailTemplateOptions, nil
+}
+
+func apiEmailTemplateFor(v string) string {
+	switch v {
+	case emailTemplateVerifyLink:
+		return "verify_email"
+	case emailTemplateVerifyCode:
+		return "verify_email_by_code"
+	case emailTemplateChangePassword:
+		return "reset_email"
+	case emailTemplateWelcome:
+		return "welcome_email"
+	case emailTemplateBlockedAccount:
+		return "blocked_account"
+	case emailTemplatePasswordBreach:
+		return "stolen_credentials"
+	case emailTemplateMFAEnrollment:
+		return "enrollment_email"
+	case emailTemplateMFACode:
+		return "mfa_oob_code"
+	case emailTemplateUserInvitation:
+		return "user_invitation"
+	default:
+		return v
+	}
+}

--- a/internal/display/email_templates.go
+++ b/internal/display/email_templates.go
@@ -1,0 +1,87 @@
+package display
+
+import (
+	"strconv"
+
+	"gopkg.in/auth0.v5/management"
+)
+
+type emailView struct {
+	Template          string
+	From              string
+	Subject           string
+	ResultURL         string
+	ResultURLLifetime string
+	Enabled           string
+	raw               interface{}
+}
+
+func (v *emailView) AsTableHeader() []string {
+	return []string{}
+}
+
+func (v *emailView) AsTableRow() []string {
+	return []string{}
+}
+
+func (v *emailView) KeyValues() [][]string {
+	return [][]string{
+		{"TEMPLATE", v.Template},
+		{"FROM", v.From},
+		{"SUBJECT", v.Subject},
+		{"RESULT URL", v.ResultURL},
+		{"RESULT URL LIFETIME", v.ResultURLLifetime},
+		{"ENABLED", v.Enabled},
+	}
+}
+
+func (v *emailView) Object() interface{} {
+	return v.raw
+}
+
+func (r *Renderer) EmailTemplateShow(email *management.EmailTemplate) {
+	r.Heading("email template")
+	r.Result(makeEmailTemplateView(email))
+}
+
+func (r *Renderer) EmailTemplateUpdate(email *management.EmailTemplate) {
+	r.Heading("email template updated")
+	r.Result(makeEmailTemplateView(email))
+}
+
+func makeEmailTemplateView(email *management.EmailTemplate) *emailView {
+	return &emailView{
+		Template:          emailTemplateFor(email.GetTemplate()),
+		From:              email.GetFrom(),
+		Subject:           email.GetSubject(),
+		ResultURL:         email.GetResultURL(),
+		ResultURLLifetime: strconv.Itoa(email.GetURLLifetimeInSecoonds()),
+		Enabled:           boolean(email.GetEnabled()),
+		raw:               email,
+	}
+}
+
+func emailTemplateFor(v string) string {
+	switch v {
+	case "verify_email":
+		return "Verification Email (using Link)"
+	case "verify_email_by_code":
+		return "Verification Email (using Code)"
+	case "change_password":
+		return "Change Password"
+	case "welcome_email":
+		return "Welcome Email"
+	case "blocked_account":
+		return "Blocked Account Email"
+	case "stolen_credentials":
+		return "Password Breach Alert"
+	case "enrollment_email":
+		return "Enroll in Multifactor Authentication"
+	case "mfa_oob_code":
+		return "Verification Code for Email MFA"
+	case "user_invitation":
+		return "User Invitation"
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
### Description

This PR adds the following commands:
- `auth0 branding emails show`
- `auth0 branding emails update`

<img width="388" alt="Screen Shot 2021-06-30 at 02 43 32" src="https://user-images.githubusercontent.com/5055789/123909776-e3a7c980-d94f-11eb-9a77-bdb3b430ef97.png">

<img width="603" alt="Screen Shot 2021-06-30 at 02 44 36" src="https://user-images.githubusercontent.com/5055789/123909795-ea364100-d94f-11eb-87c9-cad825beb520.png">

An issue with `actions update` was also fixed.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
