### PR TITLE
chore: update brew homepage

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ brews:
       name: auth0
       email: support@auth0.com
     homepage: https://auth0.github.io/auth0-cli
-    description: Auth0 command-line tool to supercharge your developer workflow.
+    description: Auth0 command-line tool to supercharge your developer workflow
     license: MIT
     skip_upload: auto
     install: |
@@ -69,7 +69,7 @@ scoop:
       email: support@auth0.com
     commit_msg_template: "Scoop manifest update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: https://auth0.github.io/auth0-cli
-    description: Auth0 command-line tool to supercharge your developer workflow.
+    description: Auth0 command-line tool to supercharge your developer workflow
     license: MIT
     skip_upload: auto
     post_install: ["Write-Host 'Thanks for installing the Auth0 CLI'"]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ brews:
       name: auth0
       email: support@auth0.com
     homepage: https://auth0.github.io/auth0-cli
-    description: Supercharge your developer workflow.
+    description: Auth0 command-line tool to supercharge your developer workflow.
     license: MIT
     skip_upload: auto
     install: |
@@ -69,7 +69,7 @@ scoop:
       email: support@auth0.com
     commit_msg_template: "Scoop manifest update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: https://auth0.github.io/auth0-cli
-    description: Supercharge your developer workflow.
+    description: Auth0 command-line tool to supercharge your developer workflow.
     license: MIT
     skip_upload: auto
     post_install: ["Write-Host 'Thanks for installing the Auth0 CLI'"]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ brews:
     commit_author:
       name: auth0
       email: support@auth0.com
-    homepage: https://cli.auth0.com
+    homepage: https://auth0.github.io/auth0-cli
     description: Supercharge your developer workflow.
     license: MIT
     skip_upload: auto
@@ -68,7 +68,7 @@ scoop:
       name: auth0
       email: support@auth0.com
     commit_msg_template: "Scoop manifest update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: https://github.com/auth0/auth0-cli
+    homepage: https://auth0.github.io/auth0-cli
     description: Supercharge your developer workflow.
     license: MIT
     skip_upload: auto


### PR DESCRIPTION
Update brew and scoop homepage to point to https://auth0.github.io/auth0-cli.
and other minor fixed to satisfy core brew.