### PR TITLE
Limit user creation to database connections

### DIFF
--- a/docs/auth0_users_create.md
+++ b/docs/auth0_users_create.md
@@ -25,7 +25,7 @@ auth0 users create -n "John Doe" --e john@example.com --connection "Username-Pas
 ### Options
 
 ```
-  -c, --connection string   Name of the connection this user should be created in. Social connections are not supported.
+  -c, --connection string   Name of the database connection this user should be created in.
   -e, --email string        The user's email.
   -h, --help                help for create
   -n, --name string         The user's full name.

--- a/docs/auth0_users_update.md
+++ b/docs/auth0_users_update.md
@@ -25,7 +25,7 @@ auth0 users update -n John Doe --email john.doe@example.com
 ### Options
 
 ```
-  -c, --connection string   Name of the connection this user should be created in. Social connections are not supported.
+  -c, --connection string   Name of the database connection this user should be created in.
   -e, --email string        The user's email.
   -h, --help                help for update
   -n, --name string         The user's full name.

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -17,11 +17,12 @@ var (
 		Name: "User ID",
 		Help: "Id of the user.",
 	}
+
 	userConnection = Flag{
 		Name:       "Connection",
 		LongForm:   "connection",
 		ShortForm:  "c",
-		Help:       "Name of the connection this user should be created in. Social connections are not supported.",
+		Help:       "Name of the database connection this user should be created in.",
 		IsRequired: true,
 	}
 	userEmail = Flag{
@@ -548,7 +549,9 @@ func (c *cli) connectionPickerOptions() []string {
 		fmt.Println(err)
 	}
 	for _, conn := range list.Connections {
-		res = append(res, conn.GetName())
+		if conn.GetStrategy() == "auth0" {
+			res = append(res, conn.GetName())
+		}
 	}
 
 	return res


### PR DESCRIPTION

### Description

This PR limits the creation of users to database connections.

<img width="492" alt="Screen Shot 2021-07-14 at 19 13 08" src="https://user-images.githubusercontent.com/5055789/125701131-cdbc77a3-9b73-4efb-909c-b9af91be2e90.png">

The endpoint supports passwordless connections as well, but we do not yet support the input of phone numbers.

<img width="515" alt="Screen Shot 2021-07-14 at 19 28 06" src="https://user-images.githubusercontent.com/5055789/125701119-1d9bc945-2e5f-4221-b59d-41dd54c22023.png">

### References

Fixes https://github.com/auth0/auth0-cli/issues/334

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
