### PR TITLE
Add support for piped input to rules

### DIFF
--- a/internal/ansi/spinner.go
+++ b/internal/ansi/spinner.go
@@ -1,10 +1,10 @@
 package ansi
 
 import (
-	"os"
 	"time"
 
 	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/briandowns/spinner"
 )
 
@@ -34,11 +34,11 @@ func loading(initialMsg, doneMsg, failMsg string, fn func() error) error {
 	go func() {
 		defer close(done)
 
-		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(iostream.Messages))
 		s.Prefix = initialMsg
 		s.FinalMSG = doneMsg
 		s.HideCursor = true
-		s.Writer = os.Stderr
+		s.Writer = iostream.Messages
 
 		if err := s.Color(spinnerColor); err != nil {
 			panic(auth0.Error(err, "failed setting spinner color"))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/auth0/auth0-cli/internal/analytics"
-	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth"
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/buildinfo"
 	"github.com/auth0/auth0-cli/internal/display"
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/spf13/cobra"
@@ -516,11 +516,11 @@ func canPrompt(cmd *cobra.Command) bool {
 		return false
 	}
 
-	return ansi.IsTerminal() && !noInput
+	return iostream.IsInputTerminal() && iostream.IsOutputTerminal() && !noInput
 }
 
-func shouldPrompt(cmd *cobra.Command, flag string) bool {
-	return canPrompt(cmd) && !cmd.Flags().Changed(flag)
+func shouldPrompt(cmd *cobra.Command, flag *Flag) bool {
+	return canPrompt(cmd) && !flag.IsSet(cmd)
 }
 
 func shouldPromptWhenFlagless(cmd *cobra.Command, flag string) bool {
@@ -536,7 +536,7 @@ func shouldPromptWhenFlagless(cmd *cobra.Command, flag string) bool {
 }
 
 func prepareInteractivity(cmd *cobra.Command) {
-	if canPrompt(cmd) {
+	if canPrompt(cmd) || !iostream.IsInputTerminal() {
 		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 			_ = cmd.Flags().SetAnnotation(flag.Name, cobra.BashCompOneRequiredFlag, []string{"false"})
 		})

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,8 +1,7 @@
 package cli
 
 import (
-	"os"
-
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/spf13/cobra"
 )
 
@@ -57,22 +56,22 @@ PS> auth0 completion powershell > auth0.ps1
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":
-				err := cmd.Root().GenBashCompletion(os.Stdout)
+				err := cmd.Root().GenBashCompletion(iostream.Output)
 				if err != nil {
 					cli.renderer.Errorf("An unexpected error occurred while setting up completion: %v", err.Error())
 				}
 			case "zsh":
-				err := cmd.Root().GenZshCompletion(os.Stdout)
+				err := cmd.Root().GenZshCompletion(iostream.Output)
 				if err != nil {
 					cli.renderer.Errorf("An unexpected error occurred while setting up completion: %v", err.Error())
 				}
 			case "fish":
-				err := cmd.Root().GenFishCompletion(os.Stdout, true)
+				err := cmd.Root().GenFishCompletion(iostream.Output, true)
 				if err != nil {
 					cli.renderer.Errorf("An unexpected error occurred while setting up completion: %v", err.Error())
 				}
 			case "powershell":
-				err := cmd.Root().GenPowerShellCompletion(os.Stdout)
+				err := cmd.Root().GenPowerShellCompletion(iostream.Output)
 				if err != nil {
 					cli.renderer.Errorf("An unexpected error occurred while setting up completion: %v", err.Error())
 				}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -261,7 +261,7 @@ func shouldAsk(cmd *cobra.Command, f *Flag, isUpdate bool) bool {
 		return shouldPromptWhenFlagless(cmd, f.LongForm)
 	}
 
-	return shouldPrompt(cmd, f.LongForm)
+	return shouldPrompt(cmd, f)
 }
 
 func markFlagRequired(cmd *cobra.Command, f *Flag, isUpdate bool) error {

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -2,12 +2,12 @@ package display
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"golang.org/x/term"
 	"gopkg.in/auth0.v5/management"
 )
@@ -186,7 +186,7 @@ func getScopes(scopes []*management.ResourceServerScope) (string, bool) {
 	ellipsis := "..."
 	separator := " "
 	padding := 22 // the longest apiView key plus two spaces before and after in the label column
-	terminalWidth, _, err := term.GetSize(int(os.Stdin.Fd()))
+	terminalWidth, _, err := term.GetSize(int(iostream.Input.Fd()))
 	if err != nil {
 		terminalWidth = 80
 	}

--- a/internal/display/get_token.go
+++ b/internal/display/get_token.go
@@ -11,12 +11,6 @@ import (
 )
 
 func (r *Renderer) GetToken(c *management.Client, t *authutil.TokenResponse) {
-	// pass the access token to the pipe and exit
-	if isOutputPiped() {
-		fmt.Fprint(r.ResultWriter, t.AccessToken)
-		return
-	}
-
 	fmt.Fprint(r.ResultWriter, "\n")
 	r.Heading(fmt.Sprintf("token for %s", auth0.StringValue(c.Name)))
 

--- a/internal/display/organizations.go
+++ b/internal/display/organizations.go
@@ -104,7 +104,7 @@ func makeOrganizationView(organization *management.Organization, w io.Writer) *o
 		LogoURL:         organization.GetBranding().GetLogoUrl(),
 		AccentColor:     accentColor,
 		BackgroundColor: backgroundColor,
-		Metadata:        ansi.ColorizeJSON(metadata, false, w),
+		Metadata:        ansi.ColorizeJSON(metadata, false),
 		raw:             organization,
 	}
 }

--- a/internal/display/try_login.go
+++ b/internal/display/try_login.go
@@ -3,7 +3,6 @@ package display
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
@@ -39,6 +38,6 @@ func (r *Renderer) TryLogin(u *authutil.UserInfo, t *authutil.TokenResponse) {
 	case OutputFormatJSON:
 		fmt.Fprint(r.ResultWriter, jsonStr)
 	default:
-		fmt.Fprintln(r.ResultWriter, ansi.ColorizeJSON(jsonStr, false, os.Stdout))
+		fmt.Fprintln(r.ResultWriter, ansi.ColorizeJSON(jsonStr, false))
 	}
 }

--- a/internal/iostream/iostream.go
+++ b/internal/iostream/iostream.go
@@ -1,0 +1,45 @@
+package iostream
+
+import (
+	"bufio"
+	"io"
+	"os"
+
+	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/mattn/go-isatty"
+)
+
+var (
+	Input = os.Stdin
+	Output = os.Stdout
+	Messages = os.Stderr
+)
+
+func IsInputTerminal() bool {
+	return isatty.IsTerminal(Input.Fd())
+}
+
+func IsOutputTerminal() bool {
+	return isatty.IsTerminal(Output.Fd())
+}
+
+func PipedInput() []byte {
+	if !IsInputTerminal() {
+		reader := bufio.NewReader(Input)
+		var pipedInput []byte
+
+		for {
+			input, err := reader.ReadBytes('\n')
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				panic(auth0.Error(err, "unable to read from pipe"))
+			}
+			pipedInput = append(pipedInput, input...)
+		}
+
+		return pipedInput
+	}
+
+	return []byte{}
+}

--- a/internal/prompt/editor.go
+++ b/internal/prompt/editor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/kballard/go-shellquote"
 )
 
@@ -57,9 +58,9 @@ func (p *editorPrompt) openFile(filename string, infoFn func()) error {
 	}
 
 	cmd := exec.Command(editorExe, args[1:]...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdin = iostream.Input
+	cmd.Stdout = iostream.Output
+	cmd.Stderr = iostream.Messages
 
 	if !isCLIEditor && infoFn != nil {
 		infoFn()

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,12 +1,11 @@
 package prompt
 
 import (
-	"os"
-
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/auth0/auth0-cli/internal/iostream"
 )
 
-var stdErrWriter = survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+var stdErrWriter = survey.WithStdio(iostream.Input, iostream.Messages, iostream.Messages)
 
 var Icons = survey.WithIcons(func(icons *survey.IconSet) {
 	icons.Question.Text = ""


### PR DESCRIPTION
### Description

This PR adds support for piped input to the `rules create` and `rules update` commands. To do so, some i/o logic and identifiers have been moved to its own package (`iostream`).

<img width="570" alt="Screen Shot 2021-07-26 at 23 14 15" src="https://user-images.githubusercontent.com/5055789/127086928-5e281413-aa0f-4767-8958-b9d1c2676e57.png">

<img width="569" alt="Screen Shot 2021-07-26 at 23 26 42" src="https://user-images.githubusercontent.com/5055789/127086941-b6ed73f2-612d-454a-bbb2-8bcaf9f96f34.png">

### Testing

These changes have been tested manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
