### PR TITLE
feat: paginate apps list

### DIFF
--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -105,7 +105,7 @@ func (v *applicationView) Object() interface{} {
 func (r *Renderer) ApplicationList(clients []*management.Client, revealSecrets bool) {
 	resource := "applications"
 
-	r.Heading(resource)
+	r.Heading(fmt.Sprintf("%s (%v)", resource, len(clients)))
 
 	if len(clients) == 0 {
 		r.EmptyState(resource)


### PR DESCRIPTION
### Description

Add the `-n` (`--number`) flag to apps list command, to specifiy the number of results. This way we allow to get  fewer items than the default (50) or a large number of results paginating the API calls.


### References

https://github.com/auth0/auth0-cli/issues/346

### Testing

![image](https://user-images.githubusercontent.com/11925502/132905700-a56f2a6b-d0ee-4484-b9c4-7ec0fbd54770.png)


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
