### PR TITLE
Removed role alias

### DIFF
--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -39,7 +39,6 @@ func rolesCmd(cli *cli) *cobra.Command {
 		Use:     "roles",
 		Short:   "Manage resources for roles",
 		Long:    "Manage resources for roles.",
-		Aliases: []string{"role"},
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())


### PR DESCRIPTION
### Description

This PR removes the `role` alias from the `roles` command, as the `roles` command is already short enough and an alias with  1 character less is not justified, and does not follow from the other aliases:

<img width="536" alt="Screen Shot 2021-09-21 at 17 13 44" src="https://user-images.githubusercontent.com/5055789/134241054-ab5037a1-9fce-4ccd-9f11-7d77a2a5f33c.png">

**THIS IS A BREAKING CHANGE**.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
