### PR TITLE
Added documentation for changing the default text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The authenticator of the CLI defaults to the default Auth0 cloud `auth0.auth0.co
 	AUTH0_OAUTH_TOKEN_ENDPOINT - OAuth Token URL
 ```
 
-To change the text editor used for editing templates, set the environment variable `EDITOR`:
+To change the text editor used for editing templates, rules, and actions, set the environment variable `EDITOR`:
 
 `export EDITOR="code -w"`
 `export EDITOR="nano"`


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

There are no docs for how to change the default text editor when editing templates.

It forced me to use `vim` and I had to dig deep to find out how to change it.

This PR adds the `EDITOR` env variable to readme.


### References

### Testing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
