### PR TITLE
Update PHP quickstarts.json data

### DIFF
--- a/internal/cli/data/quickstarts.json
+++ b/internal/cli/data/quickstarts.json
@@ -73,12 +73,10 @@
     {
       "name": "PHP API",
       "path": "php",
-      "samples": [
-        "01-Authenticate-RS256"
-      ],
+      "samples": [""],
       "org": "auth0-samples",
       "repo": "auth0-php-api-samples",
-      "branch": "master"
+      "branch": "main"
     },
     {
       "name": "Python API",
@@ -405,12 +403,10 @@
     {
       "name": "PHP",
       "path": "php",
-      "samples": [
-        "00-Starter-Seed"
-      ],
+      "samples": [""],
       "org": "auth0-samples",
       "repo": "auth0-php-web-app",
-      "branch": "master"
+      "branch": "main"
     },
     {
       "name": "PHP (Laravel)",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR fixes https://github.com/auth0/auth0-cli/issues/363 as our PHP backend and webapp samples have had their master branch renamed to main and the samples path changed. 

![image](https://user-images.githubusercontent.com/28300158/137786943-aab7a0c1-2605-456c-b41f-c5239c5b2641.png)


### References

PHP Backend QS: https://github.com/auth0-samples/auth0-php-web-app

PHP Webapp QS:  https://github.com/auth0-samples/auth0-php-api-samples

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
