### PR TITLE
Update paths for PHP QuickStarts

### DIFF
--- a/internal/cli/data/quickstarts.json
+++ b/internal/cli/data/quickstarts.json
@@ -73,7 +73,7 @@
     {
       "name": "PHP API",
       "path": "php",
-      "samples": [""],
+      "samples": ["app"],
       "org": "auth0-samples",
       "repo": "auth0-php-api-samples",
       "branch": "main"
@@ -403,7 +403,7 @@
     {
       "name": "PHP",
       "path": "php",
-      "samples": [""],
+      "samples": ["app"],
       "org": "auth0-samples",
       "repo": "auth0-php-web-app",
       "branch": "main"


### PR DESCRIPTION
An incoming change is in-flight with the PHP QuickStarts to restructure the GitHub repos to use a new subfolder; this change will break the CLI tooling without this change.