### PR TITLE
Make API scopes non-required

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -37,7 +37,7 @@ var (
 		LongForm:   "scopes",
 		ShortForm:  "s",
 		Help:       "Comma-separated list of scopes (permissions).",
-		IsRequired: true,
+		AlwaysPrompt: true,
 	}
 	apiTokenLifetime = Flag{
 		Name:         "Token Lifetime",


### PR DESCRIPTION
### Description

This PR makes the `scope` flag non-required, as specified in the Management API docs.
https://auth0.com/docs/api/management/v2#!/Resource_Servers/post_resource_servers

<img width="495" alt="Screen Shot 2021-10-22 at 22 44 58" src="https://user-images.githubusercontent.com/5055789/138538087-f8f86776-c67b-4420-b4f6-8a6da5e3b2f0.png">

### References

Fixes https://github.com/auth0/auth0-cli/issues/365

### Testing

This change was tested manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
