### PR TITLE
Add homebrew docs for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ scoop install auth0
 
 ### Linux
 
+#### [Homebrew](https://brew.sh/)
+
+```bash
+ brew tap auth0/auth0-cli && brew install auth0
+```
+
 #### Manually
 
 1. Download the _Linux_ binary from the latest release: https://github.com/auth0/auth0-cli/releases/latest/


### PR DESCRIPTION
### Description

This PR adds instructions to the README to install the CLI using Homebrew on Linux, given that the formula is available for Linux installs as well: https://github.com/auth0/homebrew-auth0-cli/blob/main/auth0.rb#L38

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
