### PR TITLE
Add `actions deploy` command [DXCDT-13]

### DIFF
--- a/docs/auth0_actions.md
+++ b/docs/auth0_actions.md
@@ -31,6 +31,7 @@ Manage resources for actions.
 * [auth0](/auth0-cli/)	 - Supercharge your development workflow.
 * [auth0 actions create](auth0_actions_create.md)	 - Create a new action
 * [auth0 actions delete](auth0_actions_delete.md)	 - Delete an action
+* [auth0 actions deploy](auth0_actions_deploy.md)	 - Deploy an action
 * [auth0 actions list](auth0_actions_list.md)	 - List your actions
 * [auth0 actions open](auth0_actions_open.md)	 - Open action details page in the Auth0 Dashboard
 * [auth0 actions show](auth0_actions_show.md)	 - Show an action

--- a/docs/auth0_actions_deploy.md
+++ b/docs/auth0_actions_deploy.md
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+## auth0 actions deploy
+
+Deploy an action
+
+### Synopsis
+
+Deploy an action.
+
+```
+auth0 actions deploy [flags]
+```
+
+### Examples
+
+```
+auth0 actions deploy 
+auth0 actions deploy <id>
+```
+
+### Options
+
+```
+  -h, --help   help for deploy
+```
+
+### Options inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 actions](auth0_actions.md)	 - Manage resources for actions
+

--- a/docs/auth0_orgs.md
+++ b/docs/auth0_orgs.md
@@ -32,6 +32,7 @@ Manage resources for organizations.
 * [auth0 orgs create](auth0_orgs_create.md)	 - Create a new organization
 * [auth0 orgs delete](auth0_orgs_delete.md)	 - Delete an organization
 * [auth0 orgs list](auth0_orgs_list.md)	 - List your organizations
+* [auth0 orgs members](auth0_orgs_members.md)	 - Manage members of an organization
 * [auth0 orgs open](auth0_orgs_open.md)	 - Open organization settings page in the Auth0 Dashboard
 * [auth0 orgs show](auth0_orgs_show.md)	 - Show an organization
 * [auth0 orgs update](auth0_orgs_update.md)	 - Update an organization

--- a/docs/auth0_orgs_members.md
+++ b/docs/auth0_orgs_members.md
@@ -1,0 +1,33 @@
+---
+layout: default
+---
+## auth0 orgs members
+
+Manage members of an organization
+
+### Synopsis
+
+Manage members of an organization.
+
+### Options
+
+```
+  -h, --help   help for members
+```
+
+### Options inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 orgs](auth0_orgs.md)	 - Manage resources for organizations
+* [auth0 orgs members list](auth0_orgs_members_list.md)	 - List members of an organization
+

--- a/docs/auth0_orgs_members_list.md
+++ b/docs/auth0_orgs_members_list.md
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+## auth0 orgs members list
+
+List members of an organization
+
+### Synopsis
+
+List members of an organization.
+
+```
+auth0 orgs members list [flags]
+```
+
+### Examples
+
+```
+auth0 orgs members list
+auth0 orgs members ls <id>
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --debug           Enable debug mode.
+      --force           Skip confirmation.
+      --format string   Command output format. Options: json.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+### SEE ALSO
+
+* [auth0 orgs members](auth0_orgs_members.md)	 - Manage members of an organization
+

--- a/internal/auth0/action.go
+++ b/internal/auth0/action.go
@@ -32,4 +32,9 @@ type ActionAPI interface {
 	//
 	// https://auth0.com/docs/api/management/v2/#!/Actions/get_triggers
 	ListTriggers(opts ...management.RequestOption) (l *management.ActionTriggerList, err error)
+
+	// Deploy an action.
+	//
+	// See: https://auth0.com/docs/api/management/v2/#!/Actions/post_deploy_action
+	Deploy(id string, opts ...management.RequestOption) (v *management.ActionVersion, err error)
 }

--- a/internal/display/actions.go
+++ b/internal/display/actions.go
@@ -87,6 +87,11 @@ func (r *Renderer) ActionUpdate(action *management.Action) {
 	r.Result(makeActionView(action))
 }
 
+func (r *Renderer) ActionDeploy(action *management.Action) {
+	r.Heading("action deployed")
+	r.Result(makeActionView(action))
+}
+
 func makeActionView(action *management.Action) *actionView {
 	var triggers = make([]string, 0, len(action.SupportedTriggers))
 	for _, t := range action.SupportedTriggers {
@@ -98,9 +103,13 @@ func makeActionView(action *management.Action) *actionView {
 	lastDeployed := ""
 
 	if action.GetDeployedVersion() != nil {
-		isDeployed = action.GetDeployedVersion().Deployed
-		deployedVersionNumber = strconv.Itoa(action.GetDeployedVersion().Number)
-		lastDeployed = timeAgo(action.GetBuiltAt())
+		deployedVersion := action.GetDeployedVersion()
+		isDeployed = deployedVersion.Deployed
+		deployedVersionNumber = strconv.Itoa(deployedVersion.Number)
+
+		if deployedVersion.BuiltAt != nil {
+			lastDeployed = timeAgo(deployedVersion.GetBuiltAt())
+		}
 	}
 
 	return &actionView{


### PR DESCRIPTION
### Description

This PR adds support for deploying actions via the `auth0 actions deploy` command.

<img width="713" alt="Screen Shot 2022-01-20 at 22 02 38" src="https://user-images.githubusercontent.com/5055789/150448786-33266b59-cc6a-42f5-94df-9cbdc804982f.png">

### References

Closes #352 

### Testing

The changes were tested manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
