### PR TITLE
Have the login command honor the `--no-input` flag [DXCDT-15]

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -8,8 +8,8 @@ import (
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth"
 	"github.com/auth0/auth0-cli/internal/prompt"
-	"github.com/spf13/cobra"
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
 )
 
 func loginCmd(cli *cli) *cobra.Command {
@@ -49,12 +49,17 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 	}
 
 	fmt.Printf("Your Device Confirmation code is: %s\n\n", ansi.Bold(state.UserCode))
-	cli.renderer.Infof("%s to open the browser to log in or %s to quit...", ansi.Green("Press Enter"), ansi.Red("^C"))
-	fmt.Scanln()
-	err = browser.OpenURL(state.VerificationURI)
 
-	if err != nil {
-		cli.renderer.Warnf("Couldn't open the URL, please do it manually: %s.", state.VerificationURI)
+	if cli.noInput {
+		cli.renderer.Infof("Open the following URL in a browser: %s\n", ansi.Green(state.VerificationURI))
+	} else {
+		cli.renderer.Infof("%s to open the browser to log in or %s to quit...", ansi.Green("Press Enter"), ansi.Red("^C"))
+		fmt.Scanln()
+		err = browser.OpenURL(state.VerificationURI)
+
+		if err != nil {
+			cli.renderer.Warnf("Couldn't open the URL, please do it manually: %s.", state.VerificationURI)
+		}
 	}
 
 	var res auth.Result


### PR DESCRIPTION
### Description

The `--no-input` flag is meant to disable interactivity. This PR has the `auth0 login` command honor this flag so as to not automatically open the login URL in the default browser, but print it instead. This allows the use of any browser for login.

<img width="680" alt="Screen Shot 2022-01-21 at 18 45 44" src="https://user-images.githubusercontent.com/5055789/150607417-7cf4e945-e025-4196-a2fc-7147e99e9957.png">

The regular, interactive login continues to work normally:

<img width="484" alt="Screen Shot 2022-01-21 at 18 38 01" src="https://user-images.githubusercontent.com/5055789/150607452-8c336ba1-20cc-4fe4-a814-e93434a6f978.png">

### References

Fixes #371

### Testing

The change was tested manually.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
