### PR TITLE
[DXCDT-19] Use GET instead of POST when downloading quickstarts

### DIFF
--- a/internal/cli/data/quickstarts.json
+++ b/internal/cli/data/quickstarts.json
@@ -41,7 +41,7 @@
       "branch": "master"
     },
     {
-      "name": "Go",
+      "name": "Go API",
       "path": "golang",
       "samples": [
         "01-Authorization-RS256"
@@ -73,7 +73,9 @@
     {
       "name": "PHP API",
       "path": "php",
-      "samples": ["app"],
+      "samples": [
+        "app"
+      ],
       "org": "auth0-samples",
       "repo": "auth0-php-api-samples",
       "branch": "main"
@@ -99,17 +101,7 @@
       "branch": "master"
     },
     {
-      "name": "Spring Security 4 Java API",
-      "path": "java-spring-security",
-      "samples": [
-        "01-Authorization"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-spring-security-api-sample",
-      "branch": "master"
-    },
-    {
-      "name": "Spring Security 5 Java API",
+      "name": "Spring Boot API",
       "path": "java-spring-security5",
       "samples": [
         "01-Authorization-MVC"
@@ -151,14 +143,34 @@
       "branch": "master"
     },
     {
-      "name": "Ionic 4",
-      "path": "ionic4",
+      "name": "Ionic & Capacitor (Angular)",
+      "path": "ionic-angular",
       "samples": [
-        "01-Login"
+        "angular"
       ],
       "org": "auth0-samples",
-      "repo": "auth0-ionic4-samples",
-      "branch": "master"
+      "repo": "auth0-ionic-samples",
+      "branch": "main"
+    },
+    {
+      "name": "Ionic & Capacitor (React)",
+      "path": "ionic-react",
+      "samples": [
+        "react"
+      ],
+      "org": "auth0-samples",
+      "repo": "auth0-ionic-samples",
+      "branch": "main"
+    },
+    {
+      "name": "iOS / macOS",
+      "path": "swift-beta",
+      "samples": [
+        "Sample-01"
+      ],
+      "org": "auth0-samples",
+      "repo": "auth0-ios-swift-sample",
+      "branch": "beta"
     },
     {
       "name": "iOS Swift",
@@ -217,7 +229,9 @@
       "org": "auth0-samples",
       "repo": "auth0-uwp-oidc-samples",
       "branch": "master"
-    },
+    }
+  ],
+  "spa": [
     {
       "name": "WPF / Winforms",
       "path": "wpf-winforms",
@@ -297,12 +311,10 @@
       "branch": "master"
     },
     {
-      "name": "ASP.NET Core",
+      "name": "ASP.NET Core MVC",
       "path": "aspnet-core",
       "samples": [
-        "Quickstart/01-Login",
-        "Quickstart/02-User-Profile",
-        "Quickstart/03-Authorization"
+        "Quickstart/Sample"
       ],
       "org": "auth0-samples",
       "repo": "auth0-aspnetcore-mvc-samples",
@@ -391,19 +403,11 @@
       "branch": "main"
     },
     {
-      "name": "Node.js",
-      "path": "nodejs",
-      "samples": [
-        "01-Login"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-nodejs-webapp-sample",
-      "branch": "master"
-    },
-    {
       "name": "PHP",
       "path": "php",
-      "samples": ["app"],
+      "samples": [
+        "app"
+      ],
       "org": "auth0-samples",
       "repo": "auth0-php-web-app",
       "branch": "main"


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

In this PR we are changing how we download the quickstarts sample by making a `GET` request instead of a `POST` and intentionally removing from the payload the following: `client_secret`, `tenant`, and `domain`.

We also update the `data/quickstarts.json` file with the latest sample structure and naming using the `quickstarts-json-generator` branch.

Unfortunately with the `GET` endpoint there doesn't seem to be any way for us to have the .env files replaced with the correct values as well. 

Sample output:

```shell
 ~/auth0/auth0-cli  patch/fix-download *3 !1  go run cmd/auth0/main.go quickstarts download                                                           ✔  18:16:08
 Client ID: SomeID
 Stack: Go
 WARNING: /Default-App already exists.
 Are you sure you want to proceed? Yes
 ▸    Quickstart sample sucessfully downloaded at /Default-App

   Auth0 + Go Web App Sample

  This sample demonstrates how to add authentication to a Go web app using
  Auth0.

  Check the Go Quickstart https://auth0.com/docs/quickstart/webapp/golang to
  better understand this sample.

  ## Running the App

  To run the app, make sure you have go installed.

  Rename the  .env.example  file to  .env  and provide your Auth0 credentials.

    # .env

    AUTH0_CLIENT_ID=YOUR_CLIENT_ID
    AUTH0_DOMAIN=YOUR_DOMAIN
    AUTH0_CLIENT_SECRET=YOUR_CLIENT_SECRET
    AUTH0_CALLBACK_URL=http://localhost:3000/callback

  Once you've set your Auth0 credentials in the  .env  file, run  go mod
  vendor  to download the Go dependencies.

  Run  go run main.go  to start the app and navigate to
  http://localhost:3000/.

  ## What is Auth0?

  Auth0 helps you to:

  • Add authentication with multiple authentication sources
  https://docs.auth0.com/identityproviders, either social like Google,
  Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce,
  amont others, or enterprise identity systems like Windows Azure AD, Google
  Apps, Active Directory, ADFS or any SAML Identity Provider.
  • Add authentication through more traditional username/password databases.
  • Add support for linking different user accounts with the same user.
  • Support for generating signed Json Web Tokens https://docs.auth0.com/jwt
  to call your APIs and flow the user identity securely.
  • Analytics of how, when and where users are logging in.
  • Pull data from other sources and add it to the user profile, through
  JavaScript rules https://docs.auth0.com/rules.

  ## Create a free Auth0 account

  1. Go to Auth0 https://auth0.com/signup and click Sign Up.
  2. Use Google, GitHub or Microsoft Account to login.

  ## Issue Reporting

  If you have found a bug or if you have a feature request, please report them
  at this repository issues section. Please do not report security
  vulnerabilities on the public GitHub issue tracker. The Responsible
  Disclosure Program https://auth0.com/whitehat details the procedure for
  disclosing security issues.

  ## Author

  Auth0 https://auth0.com

  ## License

  This project is licensed under the MIT license. See the LICENSE /LICENSE.txt
  file for more info.

 ▸    Hint: Start with 'cd Default-App/01-Login'
```


### References

- 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
