### PR TITLE
fix: auth0 tenants add: blank slate

### DIFF
--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/auth0/auth0-cli/internal/prompt"
@@ -166,7 +167,13 @@ func addTenantCmd(cli *cli) *cobra.Command {
 			if len(args) == 0 {
 				err := tenantDomain.Pick(cmd, &inputs.Domain, cli.tenantPickerOptions)
 				if err != nil {
-					return err
+					if !errors.Is(err, errUnauthenticated) {
+						return err
+					}
+
+					if err := tenantDomain.Ask(cmd, &inputs.Domain); err != nil {
+						return err
+					}
 				}
 			} else {
 				inputs.Domain = args[0]


### PR DESCRIPTION
### Description

For the blank slate case, we don't want it to error out if there are no
tenants since by definition we have no tenants configured.

### References

https://github.com/auth0/auth0-cli/issues/392

### Testing

1. Remove all your config e.g. `rm -rf ~/.config/auth0`
2. Try doing `auth0 tenants add`

You should be prompted, instead of seeing an error.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
