### PR TITLE
Replace gopkg.in/auth0.v5 with github.com/auth0/go-auth0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.15
+	github.com/auth0/go-auth0 v0.6.0
 	github.com/briandowns/spinner v1.18.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/fsnotify/fsnotify v1.4.9
@@ -27,19 +28,15 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/pretty v1.2.0
 	github.com/zalando/go-keyring v0.1.1
-	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
-	gopkg.in/auth0.v5 v5.19.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace gopkg.in/auth0.v5 => github.com/go-auth0/auth0 v1.3.1-0.20211015053228-efc8aea5a7d7
-
 require (
 	github.com/andybalholm/brotli v1.0.1 // indirect
-	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/klauspost/compress v1.11.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/PuerkitoBio/rehttp v1.0.0 h1:aJ7A7YI2lIvOxcJVeUZY4P6R7kKZtLeONjgyKGwOIu8=
-github.com/PuerkitoBio/rehttp v1.0.0/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
+github.com/PuerkitoBio/rehttp v1.1.0 h1:JFZ7OeK+hbJpTxhNB0NDZT47AuXqCU0Smxfjtph7/Rs=
+github.com/PuerkitoBio/rehttp v1.1.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
@@ -64,12 +64,13 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/auth0/go-auth0 v0.6.0 h1:deJQmRe4QdjOnmzGWbwtzdzMfpbHa05338jMlJ/WN/o=
+github.com/auth0/go-auth0 v0.6.0/go.mod h1:9rEJrEWFALKlt1VVCx1zToCG6+uddn4MLEgtKSRhlEU=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
-github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -146,8 +147,6 @@ github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaU
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
-github.com/go-auth0/auth0 v1.3.1-0.20211015053228-efc8aea5a7d7 h1:wR6DxV3q/Fl+85QbXVVseLH5NG6iaed5KyAO3ZbJ3q4=
-github.com/go-auth0/auth0 v1.3.1-0.20211015053228-efc8aea5a7d7/go.mod h1:ZUc29HB1p9iYkA1ti2uz/kVL3I9vg+Hs+qFjHKub9SM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -293,8 +292,8 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd h1:nIzoSW6OhhppWLm4yqBwZsKJlAayUu5FGozhrF3ETSM=
 github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd/go.mod h1:MEQrHur0g8VplbLOv5vXmDzacSaH9Z7XhcgsSh1xciU=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -655,6 +654,7 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -669,8 +669,8 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
-golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/auth/mock/auth.go
+++ b/internal/auth/mock/auth.go
@@ -5,34 +5,49 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSecretStore is a mock of SecretStore interface
+// MockSecretStore is a mock of SecretStore interface.
 type MockSecretStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockSecretStoreMockRecorder
 }
 
-// MockSecretStoreMockRecorder is the mock recorder for MockSecretStore
+// MockSecretStoreMockRecorder is the mock recorder for MockSecretStore.
 type MockSecretStoreMockRecorder struct {
 	mock *MockSecretStore
 }
 
-// NewMockSecretStore creates a new mock instance
+// NewMockSecretStore creates a new mock instance.
 func NewMockSecretStore(ctrl *gomock.Controller) *MockSecretStore {
 	mock := &MockSecretStore{ctrl: ctrl}
 	mock.recorder = &MockSecretStoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSecretStore) EXPECT() *MockSecretStoreMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Delete mocks base method.
+func (m *MockSecretStore) Delete(namespace, key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", namespace, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockSecretStoreMockRecorder) Delete(namespace, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSecretStore)(nil).Delete), namespace, key)
+}
+
+// Get mocks base method.
 func (m *MockSecretStore) Get(namespace, key string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", namespace, key)
@@ -41,22 +56,8 @@ func (m *MockSecretStore) Get(namespace, key string) (string, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSecretStoreMockRecorder) Get(namespace, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSecretStore)(nil).Get), namespace, key)
-}
-
-// Delete mocks base method
-func (m *MockSecretStore) Delete(namespace, key string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", namespace, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockSecretStoreMockRecorder) Delete(namespace, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSecretStore)(nil).Delete), namespace, key)
 }

--- a/internal/auth0/action.go
+++ b/internal/auth0/action.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type ActionAPI interface {
 	// Create a new action.
@@ -8,7 +8,7 @@ type ActionAPI interface {
 	// See: https://auth0.com/docs/api/management/v2#!/Actions/post_action
 	Create(a *management.Action, opts ...management.RequestOption) error
 
-	// Retrieve action details.
+	// Read action details.
 	//
 	// See: https://auth0.com/docs/api/management/v2#!/Actions/get_action
 	Read(id string, opts ...management.RequestOption) (*management.Action, error)
@@ -28,10 +28,10 @@ type ActionAPI interface {
 	// See: https://auth0.com/docs/api/management/v2#!/Actions/get_actions
 	List(opts ...management.RequestOption) (c *management.ActionList, err error)
 
-	// ListTriggers available.
+	// Triggers available.
 	//
 	// https://auth0.com/docs/api/management/v2/#!/Actions/get_triggers
-	ListTriggers(opts ...management.RequestOption) (l *management.ActionTriggerList, err error)
+	Triggers(opts ...management.RequestOption) (l *management.ActionTriggerList, err error)
 
 	// Deploy an action.
 	//

--- a/internal/auth0/anomaly.go
+++ b/internal/auth0/anomaly.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type AnomalyAPI interface {
 	// Check if a given IP address is blocked via the multiple user accounts

--- a/internal/auth0/auth0.go
+++ b/internal/auth0/auth0.go
@@ -1,8 +1,8 @@
 package auth0
 
 import (
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 // API mimics `management.Management`s general interface, except it refers to

--- a/internal/auth0/branding.go
+++ b/internal/auth0/branding.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type BrandingAPI interface {
 	Read(opts ...management.RequestOption) (b *management.Branding, err error)

--- a/internal/auth0/branding_prompt.go
+++ b/internal/auth0/branding_prompt.go
@@ -2,7 +2,7 @@
 
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type PromptAPI interface {
 	// Read retrieves prompts settings.

--- a/internal/auth0/branding_prompt_mock.go
+++ b/internal/auth0/branding_prompt_mock.go
@@ -7,8 +7,8 @@ package auth0
 import (
 	reflect "reflect"
 
+	management "github.com/auth0/go-auth0/management"
 	gomock "github.com/golang/mock/gomock"
-	management "gopkg.in/auth0.v5/management"
 )
 
 // MockPromptAPI is a mock of PromptAPI interface.

--- a/internal/auth0/client.go
+++ b/internal/auth0/client.go
@@ -2,7 +2,7 @@
 
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type ClientAPI interface {
 	// Create a new client application.

--- a/internal/auth0/client_mock.go
+++ b/internal/auth0/client_mock.go
@@ -5,35 +5,36 @@
 package auth0
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	management "gopkg.in/auth0.v5/management"
 	reflect "reflect"
+
+	management "github.com/auth0/go-auth0/management"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClientAPI is a mock of ClientAPI interface
+// MockClientAPI is a mock of ClientAPI interface.
 type MockClientAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientAPIMockRecorder
 }
 
-// MockClientAPIMockRecorder is the mock recorder for MockClientAPI
+// MockClientAPIMockRecorder is the mock recorder for MockClientAPI.
 type MockClientAPIMockRecorder struct {
 	mock *MockClientAPI
 }
 
-// NewMockClientAPI creates a new mock instance
+// NewMockClientAPI creates a new mock instance.
 func NewMockClientAPI(ctrl *gomock.Controller) *MockClientAPI {
 	mock := &MockClientAPI{ctrl: ctrl}
 	mock.recorder = &MockClientAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClientAPI) EXPECT() *MockClientAPIMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockClientAPI) Create(c *management.Client, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{c}
@@ -45,34 +46,33 @@ func (m *MockClientAPI) Create(c *management.Client, opts ...management.RequestO
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockClientAPIMockRecorder) Create(c interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{c}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClientAPI)(nil).Create), varargs...)
 }
 
-// Read mocks base method
-func (m *MockClientAPI) Read(id string, opts ...management.RequestOption) (*management.Client, error) {
+// Delete mocks base method.
+func (m *MockClientAPI) Delete(id string, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{id}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "Read", varargs...)
-	ret0, _ := ret[0].(*management.Client)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// Read indicates an expected call of Read
-func (mr *MockClientAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
+// Delete indicates an expected call of Delete.
+func (mr *MockClientAPIMockRecorder) Delete(id interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{id}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockClientAPI)(nil).Read), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClientAPI)(nil).Delete), varargs...)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockClientAPI) List(opts ...management.RequestOption) (*management.ClientList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -85,32 +85,33 @@ func (m *MockClientAPI) List(opts ...management.RequestOption) (*management.Clie
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockClientAPIMockRecorder) List(opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClientAPI)(nil).List), opts...)
 }
 
-// Update mocks base method
-func (m *MockClientAPI) Update(id string, c *management.Client, opts ...management.RequestOption) error {
+// Read mocks base method.
+func (m *MockClientAPI) Read(id string, opts ...management.RequestOption) (*management.Client, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{id, c}
+	varargs := []interface{}{id}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "Update", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "Read", varargs...)
+	ret0, _ := ret[0].(*management.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Update indicates an expected call of Update
-func (mr *MockClientAPIMockRecorder) Update(id, c interface{}, opts ...interface{}) *gomock.Call {
+// Read indicates an expected call of Read.
+func (mr *MockClientAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id, c}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClientAPI)(nil).Update), varargs...)
+	varargs := append([]interface{}{id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockClientAPI)(nil).Read), varargs...)
 }
 
-// RotateSecret mocks base method
+// RotateSecret mocks base method.
 func (m *MockClientAPI) RotateSecret(id string, opts ...management.RequestOption) (*management.Client, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{id}
@@ -123,28 +124,28 @@ func (m *MockClientAPI) RotateSecret(id string, opts ...management.RequestOption
 	return ret0, ret1
 }
 
-// RotateSecret indicates an expected call of RotateSecret
+// RotateSecret indicates an expected call of RotateSecret.
 func (mr *MockClientAPIMockRecorder) RotateSecret(id interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{id}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockClientAPI)(nil).RotateSecret), varargs...)
 }
 
-// Delete mocks base method
-func (m *MockClientAPI) Delete(id string, opts ...management.RequestOption) error {
+// Update mocks base method.
+func (m *MockClientAPI) Update(id string, c *management.Client, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{id}
+	varargs := []interface{}{id, c}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret := m.ctrl.Call(m, "Update", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
-func (mr *MockClientAPIMockRecorder) Delete(id interface{}, opts ...interface{}) *gomock.Call {
+// Update indicates an expected call of Update.
+func (mr *MockClientAPIMockRecorder) Update(id, c interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClientAPI)(nil).Delete), varargs...)
+	varargs := append([]interface{}{id, c}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClientAPI)(nil).Update), varargs...)
 }

--- a/internal/auth0/connection.go
+++ b/internal/auth0/connection.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type ConnectionAPI interface {
 

--- a/internal/auth0/custom_domain.go
+++ b/internal/auth0/custom_domain.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type CustomDomainAPI interface {
 	// Create a new custom domain.

--- a/internal/auth0/email_template.go
+++ b/internal/auth0/email_template.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type EmailTemplateAPI interface {
 	// Retrieve an email template by pre-defined name.

--- a/internal/auth0/jobs.go
+++ b/internal/auth0/jobs.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type JobsAPI interface {
 	VerifyEmail(j *management.Job, opts ...management.RequestOption) (err error)

--- a/internal/auth0/log.go
+++ b/internal/auth0/log.go
@@ -2,7 +2,7 @@
 
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type LogAPI interface {
 	// Retrieves the data related to the log entry identified by id. This returns a

--- a/internal/auth0/log_mock.go
+++ b/internal/auth0/log_mock.go
@@ -5,55 +5,36 @@
 package auth0
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	management "gopkg.in/auth0.v5/management"
 	reflect "reflect"
+
+	management "github.com/auth0/go-auth0/management"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLogAPI is a mock of LogAPI interface
+// MockLogAPI is a mock of LogAPI interface.
 type MockLogAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockLogAPIMockRecorder
 }
 
-// MockLogAPIMockRecorder is the mock recorder for MockLogAPI
+// MockLogAPIMockRecorder is the mock recorder for MockLogAPI.
 type MockLogAPIMockRecorder struct {
 	mock *MockLogAPI
 }
 
-// NewMockLogAPI creates a new mock instance
+// NewMockLogAPI creates a new mock instance.
 func NewMockLogAPI(ctrl *gomock.Controller) *MockLogAPI {
 	mock := &MockLogAPI{ctrl: ctrl}
 	mock.recorder = &MockLogAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLogAPI) EXPECT() *MockLogAPIMockRecorder {
 	return m.recorder
 }
 
-// Read mocks base method
-func (m *MockLogAPI) Read(id string, opts ...management.RequestOption) (*management.Log, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{id}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Read", varargs...)
-	ret0, _ := ret[0].(*management.Log)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Read indicates an expected call of Read
-func (mr *MockLogAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockLogAPI)(nil).Read), varargs...)
-}
-
-// List mocks base method
+// List mocks base method.
 func (m *MockLogAPI) List(opts ...management.RequestOption) ([]*management.Log, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -66,13 +47,33 @@ func (m *MockLogAPI) List(opts ...management.RequestOption) ([]*management.Log, 
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockLogAPIMockRecorder) List(opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockLogAPI)(nil).List), opts...)
 }
 
-// Search mocks base method
+// Read mocks base method.
+func (m *MockLogAPI) Read(id string, opts ...management.RequestOption) (*management.Log, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{id}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
+	ret0, _ := ret[0].(*management.Log)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockLogAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockLogAPI)(nil).Read), varargs...)
+}
+
+// Search mocks base method.
 func (m *MockLogAPI) Search(opts ...management.RequestOption) ([]*management.Log, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -85,7 +86,7 @@ func (m *MockLogAPI) Search(opts ...management.RequestOption) ([]*management.Log
 	return ret0, ret1
 }
 
-// Search indicates an expected call of Search
+// Search indicates an expected call of Search.
 func (mr *MockLogAPIMockRecorder) Search(opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockLogAPI)(nil).Search), opts...)

--- a/internal/auth0/log_stream.go
+++ b/internal/auth0/log_stream.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type LogStreamAPI interface {
 	// Create a log stream.

--- a/internal/auth0/organization.go
+++ b/internal/auth0/organization.go
@@ -1,34 +1,34 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type OrganizationAPI interface {
-	// Create an Organization
+	// Create an Organization.
 	//
 	// See: https://auth0.com/docs/api/management/v2/#!/Organizations/post_organizations
 	Create(o *management.Organization, opts ...management.RequestOption) error
 
-	// Get a specific organization
+	// Read a specific organization.
 	//
 	// See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_organizations_by_id
 	Read(id string, opts ...management.RequestOption) (*management.Organization, error)
 
-	// Modify an organization
+	// Update an organization.
 	//
 	// See: https://auth0.com/docs/api/management/v2/#!/Organizations/patch_organizations_by_id
-	Update(o *management.Organization, opts ...management.RequestOption) error
+	Update(id string, o *management.Organization, opts ...management.RequestOption) error
 
-	// Delete a specific organization
+	// Delete a specific organization.
 	//
 	// See: https://auth0.com/docs/api/management/v2/#!/Organizations/delete_organizations_by_id
 	Delete(id string, opts ...management.RequestOption) error
 
-	// List available organizations
+	// List available organizations.
 	//
 	// See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_organizations
 	List(opts ...management.RequestOption) (c *management.OrganizationList, err error)
 
-	// List members of an organization
+	// Members lists members of an organization.
 	//
 	// See: https://auth0.com/docs/api/management/v2#!/Organizations/get_members
 	Members(id string, opts ...management.RequestOption) (o *management.OrganizationMemberList, err error)

--- a/internal/auth0/resource_server.go
+++ b/internal/auth0/resource_server.go
@@ -2,7 +2,7 @@
 
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type ResourceServerAPI interface {
 	// Create a resource server.

--- a/internal/auth0/resource_server_mock.go
+++ b/internal/auth0/resource_server_mock.go
@@ -5,35 +5,36 @@
 package auth0
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	management "gopkg.in/auth0.v5/management"
 	reflect "reflect"
+
+	management "github.com/auth0/go-auth0/management"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockResourceServerAPI is a mock of ResourceServerAPI interface
+// MockResourceServerAPI is a mock of ResourceServerAPI interface.
 type MockResourceServerAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceServerAPIMockRecorder
 }
 
-// MockResourceServerAPIMockRecorder is the mock recorder for MockResourceServerAPI
+// MockResourceServerAPIMockRecorder is the mock recorder for MockResourceServerAPI.
 type MockResourceServerAPIMockRecorder struct {
 	mock *MockResourceServerAPI
 }
 
-// NewMockResourceServerAPI creates a new mock instance
+// NewMockResourceServerAPI creates a new mock instance.
 func NewMockResourceServerAPI(ctrl *gomock.Controller) *MockResourceServerAPI {
 	mock := &MockResourceServerAPI{ctrl: ctrl}
 	mock.recorder = &MockResourceServerAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceServerAPI) EXPECT() *MockResourceServerAPIMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockResourceServerAPI) Create(rs *management.ResourceServer, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{rs}
@@ -45,53 +46,14 @@ func (m *MockResourceServerAPI) Create(rs *management.ResourceServer, opts ...ma
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockResourceServerAPIMockRecorder) Create(rs interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{rs}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockResourceServerAPI)(nil).Create), varargs...)
 }
 
-// Read mocks base method
-func (m *MockResourceServerAPI) Read(id string, opts ...management.RequestOption) (*management.ResourceServer, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{id}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Read", varargs...)
-	ret0, _ := ret[0].(*management.ResourceServer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Read indicates an expected call of Read
-func (mr *MockResourceServerAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockResourceServerAPI)(nil).Read), varargs...)
-}
-
-// Update mocks base method
-func (m *MockResourceServerAPI) Update(id string, rs *management.ResourceServer, opts ...management.RequestOption) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{id, rs}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Update", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update
-func (mr *MockResourceServerAPIMockRecorder) Update(id, rs interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id, rs}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceServerAPI)(nil).Update), varargs...)
-}
-
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockResourceServerAPI) Delete(id string, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{id}
@@ -103,14 +65,14 @@ func (m *MockResourceServerAPI) Delete(id string, opts ...management.RequestOpti
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockResourceServerAPIMockRecorder) Delete(id interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{id}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResourceServerAPI)(nil).Delete), varargs...)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockResourceServerAPI) List(opts ...management.RequestOption) (*management.ResourceServerList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -123,13 +85,33 @@ func (m *MockResourceServerAPI) List(opts ...management.RequestOption) (*managem
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockResourceServerAPIMockRecorder) List(opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockResourceServerAPI)(nil).List), opts...)
 }
 
-// Stream mocks base method
+// Read mocks base method.
+func (m *MockResourceServerAPI) Read(id string, opts ...management.RequestOption) (*management.ResourceServer, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{id}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
+	ret0, _ := ret[0].(*management.ResourceServer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockResourceServerAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockResourceServerAPI)(nil).Read), varargs...)
+}
+
+// Stream mocks base method.
 func (m *MockResourceServerAPI) Stream(fn func(*management.ResourceServer), opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{fn}
@@ -141,9 +123,28 @@ func (m *MockResourceServerAPI) Stream(fn func(*management.ResourceServer), opts
 	return ret0
 }
 
-// Stream indicates an expected call of Stream
+// Stream indicates an expected call of Stream.
 func (mr *MockResourceServerAPIMockRecorder) Stream(fn interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{fn}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockResourceServerAPI)(nil).Stream), varargs...)
+}
+
+// Update mocks base method.
+func (m *MockResourceServerAPI) Update(id string, rs *management.ResourceServer, opts ...management.RequestOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{id, rs}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Update", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockResourceServerAPIMockRecorder) Update(id, rs interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{id, rs}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockResourceServerAPI)(nil).Update), varargs...)
 }

--- a/internal/auth0/role.go
+++ b/internal/auth0/role.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type RoleAPI interface {
 	// Create a new role.

--- a/internal/auth0/rule.go
+++ b/internal/auth0/rule.go
@@ -2,7 +2,7 @@
 
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type RuleAPI interface {
 	// Create a new rule.

--- a/internal/auth0/rule_mock.go
+++ b/internal/auth0/rule_mock.go
@@ -5,35 +5,36 @@
 package auth0
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	management "gopkg.in/auth0.v5/management"
 	reflect "reflect"
+
+	management "github.com/auth0/go-auth0/management"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRuleAPI is a mock of RuleAPI interface
+// MockRuleAPI is a mock of RuleAPI interface.
 type MockRuleAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockRuleAPIMockRecorder
 }
 
-// MockRuleAPIMockRecorder is the mock recorder for MockRuleAPI
+// MockRuleAPIMockRecorder is the mock recorder for MockRuleAPI.
 type MockRuleAPIMockRecorder struct {
 	mock *MockRuleAPI
 }
 
-// NewMockRuleAPI creates a new mock instance
+// NewMockRuleAPI creates a new mock instance.
 func NewMockRuleAPI(ctrl *gomock.Controller) *MockRuleAPI {
 	mock := &MockRuleAPI{ctrl: ctrl}
 	mock.recorder = &MockRuleAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRuleAPI) EXPECT() *MockRuleAPIMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockRuleAPI) Create(r *management.Rule, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{r}
@@ -45,53 +46,14 @@ func (m *MockRuleAPI) Create(r *management.Rule, opts ...management.RequestOptio
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockRuleAPIMockRecorder) Create(r interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{r}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRuleAPI)(nil).Create), varargs...)
 }
 
-// Read mocks base method
-func (m *MockRuleAPI) Read(id string, opts ...management.RequestOption) (*management.Rule, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{id}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Read", varargs...)
-	ret0, _ := ret[0].(*management.Rule)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Read indicates an expected call of Read
-func (mr *MockRuleAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRuleAPI)(nil).Read), varargs...)
-}
-
-// Update mocks base method
-func (m *MockRuleAPI) Update(id string, r *management.Rule, opts ...management.RequestOption) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{id, r}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Update", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update
-func (mr *MockRuleAPIMockRecorder) Update(id, r interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{id, r}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockRuleAPI)(nil).Update), varargs...)
-}
-
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockRuleAPI) Delete(id string, opts ...management.RequestOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{id}
@@ -103,14 +65,14 @@ func (m *MockRuleAPI) Delete(id string, opts ...management.RequestOption) error 
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockRuleAPIMockRecorder) Delete(id interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{id}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRuleAPI)(nil).Delete), varargs...)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockRuleAPI) List(opts ...management.RequestOption) (*management.RuleList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -123,8 +85,47 @@ func (m *MockRuleAPI) List(opts ...management.RequestOption) (*management.RuleLi
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockRuleAPIMockRecorder) List(opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRuleAPI)(nil).List), opts...)
+}
+
+// Read mocks base method.
+func (m *MockRuleAPI) Read(id string, opts ...management.RequestOption) (*management.Rule, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{id}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
+	ret0, _ := ret[0].(*management.Rule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockRuleAPIMockRecorder) Read(id interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{id}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRuleAPI)(nil).Read), varargs...)
+}
+
+// Update mocks base method.
+func (m *MockRuleAPI) Update(id string, r *management.Rule, opts ...management.RequestOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{id, r}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Update", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockRuleAPIMockRecorder) Update(id, r interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{id, r}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockRuleAPI)(nil).Update), varargs...)
 }

--- a/internal/auth0/tenant.go
+++ b/internal/auth0/tenant.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type TenantAPI interface {
 	Read(opts ...management.RequestOption) (t *management.Tenant, err error)

--- a/internal/auth0/user.go
+++ b/internal/auth0/user.go
@@ -1,6 +1,6 @@
 package auth0
 
-import "gopkg.in/auth0.v5/management"
+import "github.com/auth0/go-auth0/management"
 
 type UserAPI interface {
 	// Retrieves a list of blocked IP addresses of a particular user.

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/prompt"
-	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
 )
 
 var (
@@ -201,7 +202,7 @@ auth0 actions create --n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=va
 
 			action := &management.Action{
 				Name: &inputs.Name,
-				SupportedTriggers: []management.ActionTrigger{
+				SupportedTriggers: []*management.ActionTrigger{
 					{
 						ID:      &inputs.Trigger,
 						Version: &version,
@@ -323,7 +324,7 @@ auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -s "API_K
 			// display.
 			action := &management.Action{
 				Name: &inputs.Name,
-				SupportedTriggers: []management.ActionTrigger{
+				SupportedTriggers: []*management.ActionTrigger{
 					{
 						ID:      &inputs.Trigger,
 						Version: &version,
@@ -535,7 +536,7 @@ func filterActionTriggersByVersion(list []*management.ActionTrigger, version str
 func latestActionTriggers(cli *cli) ([]string, string, error) {
 	var triggers []*management.ActionTrigger
 	if err := ansi.Waiting(func() error {
-		list, err := cli.api.Action.ListTriggers()
+		list, err := cli.api.Action.Triggers()
 		if err != nil {
 			return err
 		}
@@ -563,12 +564,12 @@ func actionTemplate(key string) string {
 	return actionTemplateEmpty
 }
 
-func apiActionDependenciesFor(dependencies map[string]string) []management.ActionDependency {
-	var res []management.ActionDependency
+func apiActionDependenciesFor(dependencies map[string]string) []*management.ActionDependency {
+	var res []*management.ActionDependency
 	for k, v := range dependencies {
 		key := k
 		value := v
-		res = append(res, management.ActionDependency{
+		res = append(res, &management.ActionDependency{
 			Name:    &key,
 			Version: &value,
 		})
@@ -576,12 +577,12 @@ func apiActionDependenciesFor(dependencies map[string]string) []management.Actio
 	return res
 }
 
-func apiActionSecretsFor(secrets map[string]string) []management.ActionSecret {
-	var res []management.ActionSecret
+func apiActionSecretsFor(secrets map[string]string) []*management.ActionSecret {
+	var res []*management.ActionSecret
 	for k, v := range secrets {
 		key := k
 		value := v
-		res = append(res, management.ActionSecret{
+		res = append(res, &management.ActionSecret{
 			Name:  &key,
 			Value: &value,
 		})

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -9,8 +9,8 @@ import (
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -33,10 +33,10 @@ var (
 		IsRequired: true,
 	}
 	apiScopes = Flag{
-		Name:       "Scopes",
-		LongForm:   "scopes",
-		ShortForm:  "s",
-		Help:       "Comma-separated list of scopes (permissions).",
+		Name:         "Scopes",
+		LongForm:     "scopes",
+		ShortForm:    "s",
+		Help:         "Comma-separated list of scopes (permissions).",
 		AlwaysPrompt: true,
 	}
 	apiTokenLifetime = Flag{

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -9,7 +9,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 // errNoApps signifies no applications exist in a tenant

--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/display"
 	"github.com/golang/mock/gomock"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 func TestAppsListCmd(t *testing.T) {

--- a/internal/cli/branding.go
+++ b/internal/cli/branding.go
@@ -10,8 +10,8 @@ import (
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -93,7 +93,7 @@ func templateCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "templates",
 		Short: "Manage custom page templates",
-		Long:  `Manage custom [page templates](https://auth0.com/docs/universal-login/new-experience/universal-login-page-templates). This requires a custom domain to be configured for the tenant.
+		Long: `Manage custom [page templates](https://auth0.com/docs/universal-login/new-experience/universal-login-page-templates). This requires a custom domain to be configured for the tenant.
 
 This command will open two windows:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,7 +25,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (

--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -8,7 +8,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (

--- a/internal/cli/email_templates.go
+++ b/internal/cli/email_templates.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (
@@ -86,7 +86,7 @@ var (
 		{"Verification Email (using Link)", emailTemplateVerifyLink},
 		{"Verification Email (using Code)", emailTemplateVerifyCode},
 		{"Change Password", emailTemplateChangePassword},
-		{"Welcome Email", emailTemplateWelcome, },
+		{"Welcome Email", emailTemplateWelcome},
 		{"Blocked Account Email", emailTemplateBlockedAccount},
 		{"Password Breach Alert", emailTemplatePasswordBreach},
 		{"Enroll in Multifactor Authentication", emailTemplateMFAEnrollment},
@@ -223,10 +223,10 @@ auth0 branding emails update welcome`,
 			// display.
 			emailTemplate := &management.EmailTemplate{
 				Template: &template,
-				Body: &inputs.Body,
-				From: &inputs.From,
-				Subject: &inputs.Subject,
-				Enabled: &inputs.Enabled,
+				Body:     &inputs.Body,
+				From:     &inputs.From,
+				Subject:  &inputs.Subject,
+				Enabled:  &inputs.Enabled,
 			}
 
 			if inputs.ResultURL == "" {

--- a/internal/cli/input.go
+++ b/internal/cli/input.go
@@ -7,7 +7,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5"
+	"github.com/auth0/go-auth0"
 )
 
 type commandInput interface {

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -9,7 +9,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -43,7 +43,7 @@ func logsCmd(cli *cli) *cobra.Command {
 func listLogsCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		Filter string
-		Num      int
+		Num    int
 	}
 
 	cmd := &cobra.Command{
@@ -80,7 +80,7 @@ auth0 logs ls -n 100`,
 func tailLogsCmd(cli *cli) *cobra.Command {
 	var inputs struct {
 		Filter string
-		Num      int
+		Num    int
 	}
 
 	cmd := &cobra.Command{

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -8,10 +8,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/prompt"
-	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
 )
 
 const (
@@ -212,11 +213,11 @@ auth0 orgs create --n myorganization -d "My Organization" -m "KEY=value" -m "OTH
 				o.Branding = &management.OrganizationBranding{}
 
 				if isLogoURLSet {
-					o.Branding.LogoUrl = &inputs.LogoURL
+					o.Branding.LogoURL = &inputs.LogoURL
 				}
 
 				if isAnyColorSet {
-					o.Branding.Colors = map[string]string{}
+					o.Branding.Colors = map[string]interface{}{}
 
 					if isAccentColorSet {
 						o.Branding.Colors[apiOrganizationColorPrimary] = inputs.AccentColor
@@ -315,23 +316,23 @@ auth0 orgs update <id> -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_v
 				o.Branding = &management.OrganizationBranding{}
 
 				if isLogoURLSet {
-					o.Branding.LogoUrl = &inputs.LogoURL
+					o.Branding.LogoURL = &inputs.LogoURL
 				} else if currentHasBranding {
-					o.Branding.LogoUrl = current.Branding.LogoUrl
+					o.Branding.LogoURL = current.Branding.LogoURL
 				}
 
 				if needToAddColors {
-					o.Branding.Colors = map[string]string{}
+					o.Branding.Colors = map[string]interface{}{}
 
 					if isAccentColorSet {
 						o.Branding.Colors[apiOrganizationColorPrimary] = inputs.AccentColor
-					} else if currentHasColors && len(current.Branding.Colors[apiOrganizationColorPrimary]) > 0 {
+					} else if currentHasColors && len(current.Branding.Colors[apiOrganizationColorPrimary].(string)) > 0 {
 						o.Branding.Colors[apiOrganizationColorPrimary] = current.Branding.Colors[apiOrganizationColorPrimary]
 					}
 
 					if isBackgroundColorSet {
 						o.Branding.Colors[apiOrganizationColorPageBackground] = inputs.BackgroundColor
-					} else if currentHasColors && len(current.Branding.Colors[apiOrganizationColorPageBackground]) > 0 {
+					} else if currentHasColors && len(current.Branding.Colors[apiOrganizationColorPageBackground].(string)) > 0 {
 						o.Branding.Colors[apiOrganizationColorPageBackground] = current.Branding.Colors[apiOrganizationColorPageBackground]
 					}
 				}
@@ -344,7 +345,7 @@ auth0 orgs update <id> -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_v
 			}
 
 			if err = ansi.Waiting(func() error {
-				return cli.api.Organization.Update(o)
+				return cli.api.Organization.Update(inputs.ID, o)
 			}); err != nil {
 				return err
 			}

--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -7,7 +7,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 // errNoRoles signifies no roles exist in a tenant
@@ -36,9 +36,9 @@ var (
 
 func rolesCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "roles",
-		Short:   "Manage resources for roles",
-		Long:    "Manage resources for roles.",
+		Use:   "roles",
+		Short: "Manage resources for roles",
+		Long:  "Manage resources for roles.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())

--- a/internal/cli/roles_permissions.go
+++ b/internal/cli/roles_permissions.go
@@ -7,8 +7,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -189,7 +189,7 @@ auth0 roles permissions rm`,
 			}
 
 			if len(inputs.Permissions) == 0 {
-				err := cli.pickRolePermissions( rs.Scopes, &inputs.Permissions)
+				err := cli.pickRolePermissions(rs.Scopes, &inputs.Permissions)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -10,7 +10,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -385,10 +385,10 @@ func enableRuleCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "enable",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Enable a rule",
-		Long:  "Enable a rule.",
+		Use:     "enable",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Enable a rule",
+		Long:    "Enable a rule.",
 		Example: `auth0 rules enable <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -437,10 +437,10 @@ func disableRuleCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "disable",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Disable a rule",
-		Long:  "Disable a rule.",
+		Use:     "disable",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Disable a rule",
+		Long:    "Disable a rule.",
 		Example: `auth0 rules disable <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -10,7 +10,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/auth0/auth0-cli/internal/users"
 	"github.com/spf13/cobra"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 var (
@@ -212,7 +212,7 @@ auth0 users create -n "John Doe" --e john@example.com --connection "Username-Pas
 				return err
 			}
 
-			////Prompt for user password
+			// //Prompt for user password
 			if err := userPassword.AskPassword(cmd, &inputs.Password, nil); err != nil {
 				return err
 			}
@@ -402,9 +402,9 @@ auth0 users update -n John Doe --email john.doe@example.com`,
 			}
 
 			// username cannot be updated for database connections
-			//if err := userUsername.AskU(cmd, &inputs.Username, current.Username); err != nil {
+			// if err := userUsername.AskU(cmd, &inputs.Username, current.Username); err != nil {
 			//	return err
-			//}
+			// }
 
 			user := &management.User{}
 

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -15,7 +15,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/pkg/browser"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (

--- a/internal/display/actions.go
+++ b/internal/display/actions.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type actionView struct {

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -9,7 +9,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/iostream"
 	"golang.org/x/term"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type apiView struct {

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 const (

--- a/internal/display/branding.go
+++ b/internal/display/branding.go
@@ -1,7 +1,7 @@
 package display
 
 import (
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type brandingView struct {

--- a/internal/display/custom_domain.go
+++ b/internal/display/custom_domain.go
@@ -2,7 +2,7 @@ package display
 
 import (
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type customDomainView struct {

--- a/internal/display/email_templates.go
+++ b/internal/display/email_templates.go
@@ -3,7 +3,7 @@ package display
 import (
 	"strconv"
 
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type emailView struct {

--- a/internal/display/get_token.go
+++ b/internal/display/get_token.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/auth/authutil"
 	"github.com/auth0/auth0-cli/internal/auth0"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 func (r *Renderer) GetToken(c *management.Client, t *authutil.TokenResponse) {

--- a/internal/display/log_streams.go
+++ b/internal/display/log_streams.go
@@ -2,7 +2,7 @@ package display
 
 import (
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type logStreamView struct {

--- a/internal/display/logs.go
+++ b/internal/display/logs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
 
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 	"gopkg.in/yaml.v2"
 )
 

--- a/internal/display/members.go
+++ b/internal/display/members.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type membersView struct {

--- a/internal/display/organizations.go
+++ b/internal/display/organizations.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/auth0/go-auth0/management"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
 )
 
 type organizationView struct {
@@ -82,12 +83,12 @@ func makeOrganizationView(organization *management.Organization, w io.Writer) *o
 	backgroundColor := ""
 
 	if organization.Branding != nil && organization.Branding.Colors != nil {
-		if len(organization.Branding.Colors["primary"]) > 0 {
-			accentColor = organization.Branding.Colors["primary"]
+		if len(organization.Branding.Colors["primary"].(string)) > 0 {
+			accentColor = organization.Branding.Colors["primary"].(string)
 		}
 
-		if len(organization.Branding.Colors["page_background"]) > 0 {
-			backgroundColor = organization.Branding.Colors["page_background"]
+		if len(organization.Branding.Colors["page_background"].(string)) > 0 {
+			backgroundColor = organization.Branding.Colors["page_background"].(string)
 		}
 	}
 
@@ -101,7 +102,7 @@ func makeOrganizationView(organization *management.Organization, w io.Writer) *o
 		ID:              organization.GetID(),
 		Name:            organization.GetName(),
 		DisplayName:     organization.GetDisplayName(),
-		LogoURL:         organization.GetBranding().GetLogoUrl(),
+		LogoURL:         organization.GetBranding().GetLogoURL(),
 		AccentColor:     accentColor,
 		BackgroundColor: backgroundColor,
 		Metadata:        ansi.ColorizeJSON(metadata, false),

--- a/internal/display/role_permissions.go
+++ b/internal/display/role_permissions.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type rolePermissionView struct {

--- a/internal/display/roles.go
+++ b/internal/display/roles.go
@@ -2,7 +2,7 @@ package display
 
 import (
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type roleView struct {

--- a/internal/display/rules.go
+++ b/internal/display/rules.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type ruleView struct {
@@ -54,7 +54,7 @@ func (r *Renderer) RulesList(rules []*management.Rule) {
 
 	var res []View
 
-	//@TODO Provide sort options via flags
+	// @TODO Provide sort options via flags
 	sort.Slice(rules, func(i, j int) bool {
 		return rules[i].GetOrder() < rules[j].GetOrder()
 	})

--- a/internal/display/user_blocks.go
+++ b/internal/display/user_blocks.go
@@ -1,7 +1,7 @@
 package display
 
 import (
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0/management"
 )
 
 type userBlockView struct {

--- a/internal/display/users.go
+++ b/internal/display/users.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"gopkg.in/auth0.v5"
-	"gopkg.in/auth0.v5/management"
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
 )
 
 type userView struct {


### PR DESCRIPTION
### Description

This PR replaces gopkg.in/auth0.v5 (github.com/go-auth0/auth0) with github.com/auth0/go-auth0 as we now have brought the SDK within the Auth0 org. 


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
