### PR TITLE
feat: [HACK22-14] Add value overrides for tenant config yaml

### DIFF
--- a/examples/import/config.json
+++ b/examples/import/config.json
@@ -4,7 +4,7 @@
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
     "EXAMPLE_API": "Example API",
     "EXAMPLE_CLIENT": "Example Client",
-    "EXAMPLE_CLIENT_BASE_URL": "http://localhost:3000/",
+    "EXAMPLE_CLIENT_BASE_URL": "http://localhost:3000",
     "ENV": "DEV"
   }
 }

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/auth0/auth0-cli/internal/cli/importcmd"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -62,8 +65,10 @@ func importCmd(cli *cli) *cobra.Command {
 			// Do: parse the YAML into a struct instance and perform the replacements, according to the config
 			// Return: YAML with replacements
 
-			importcmd.GetYAML(inputs.Input, config)
-			//fmt.Println(y)
+			yamlData := importcmd.ParseYAML(inputs.Input, config)
+
+			j, _ := yaml.Marshal(&yamlData)
+			fmt.Printf("yamlData is: \n%+v", string(j))
 
 			// Config file getConfig()
 			// Take: config file path

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/auth0/auth0-cli/internal/cli/importcmd"
 	"github.com/spf13/cobra"
 )
@@ -48,7 +46,7 @@ func importCmd(cli *cli) *cobra.Command {
 
 			// The command logic goes here
 
-			config, error := importcmd.GetConfig(inputs.Config)
+			config, _ := importcmd.GetConfig(inputs.Config)
 			// config, error := getConfig(inputs.Config)
 			// yaml, error := getYaml(inputs.Input, config)
 			// appChanges, error := processApps(cli, yaml, config)
@@ -64,15 +62,16 @@ func importCmd(cli *cli) *cobra.Command {
 			// Do: parse the YAML into a struct instance and perform the replacements, according to the config
 			// Return: YAML with replacements
 
-			//yaml := getYAML(&inputs.Input, &inputs.Config)
+			importcmd.GetYAML(inputs.Input, config)
+			//fmt.Println(y)
 
 			// Config file getConfig()
 			// Take: config file path
 			// Do: parse the JSON into a struct instance
 			// Return: config value
 
-			fmt.Printf("Config file: %s\n", inputs.Config)
-			fmt.Printf("Input file: %s\n", inputs.Input)
+			//fmt.Printf("Config file: %s\n", inputs.Config)
+			//fmt.Printf("Input file: %s\n", inputs.Input)
 
 			return nil
 		},

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -75,8 +75,8 @@ func importCmd(cli *cli) *cobra.Command {
 			// Do: parse the JSON into a struct instance
 			// Return: config value
 
-			//fmt.Printf("Config file: %s\n", inputs.Config)
-			//fmt.Printf("Input file: %s\n", inputs.Input)
+			fmt.Printf("Config file: %s\n", inputs.Config)
+			fmt.Printf("Input file: %s\n", inputs.Input)
 
 			return nil
 		},


### PR DESCRIPTION
### Description

Adds injection of config keyword replacements to the yaml config.

Returns the yaml config as a struct for use in handlers.

### References


### Testing

This was tested manually by running the below command:
```
$ go build . && ./auth0 import --config ../../examples/import/config.json --input ../../examples/import/tenant.yaml  
```
<details>

```
yamlData is: 
clients:
- name: Example Client (Backend)
  app_type: non_interactive
- name: Example Client (SPA)
  app_type: spa
  allowed_logout_urls:
  - http://localhost:3000
  - http://localhost:3000/logout
  callbacks:
  - http://localhost:3000
  - http://localhost:3000/callback
  web_origins:
  - http://localhost:3000
resourceServers:
- name: Example API (RS256)
  identifier: example-api-rs256
  allow_offline_access: true
  enforce_policies: false
  scopes:
  - value: example:scope1
    description: An example scope.
  signing_alg: RS256
  skip_consent_for_verifiable_first_party_clients: true
  token_dialect: access_token_authz
  token_lifetime: 86400
  token_lifetime_for_web: 7200
- name: Example API (HS256)
  identifier: example-api-hs256
  allow_offline_access: false
  enforce_policies: true
  scopes:
  - value: example:scope2
    description: Another example scope.
  signing_alg: HS256
  skip_consent_for_verifiable_first_party_clients: true
  token_dialect: access_token_authz
  token_lifetime: 86400
  token_lifetime_for_web: 7200
  signing_secret: siIfPACvAarnlebOyznrMKxWBUzATCfs
roles:
- name: Admin
  description: App Admin
  permissions:
  - permission_name: update:account
    resource_server_identifier: https://DEV.myapp.com/api/v1
  - permission_name: read:account
    resource_server_identifier: https://DEV.myapp.com/api/v1
- name: User
  description: App User
  permissions:
  - permission_name: read:account
    resource_server_identifier: https://DEV.myapp.com/api/v1
Config file: ../../examples/import/config.json
Input file: ../../examples/import/tenant.yaml

```
</details>

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
