### PR TITLE
import properly edited user template

### DIFF
--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -9,8 +9,8 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/auth0/auth0-cli/internal/users"
-	"github.com/spf13/cobra"
 	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -632,7 +632,7 @@ auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --up
 			}
 
 			// Convert json array to map
-			jsonstr := userImportOptions.getValue(inputs.Template)
+			jsonstr := inputs.TemplateBody
 			var jsonmap []map[string]interface{}
 			jsonErr := json.Unmarshal([]byte(jsonstr), &jsonmap)
 			if jsonErr != nil {


### PR DESCRIPTION
### Description

When using the `auth0 users import` command, after choosing a template, it will then open that template in an editor.
Instead of uploading the edited template, it will instead upload the default template, ignoring any changes made in the editor.

This pull request fixes this functionality to upload the correct template saved after the editor closes.

### Testing
1. Run auth0 users import
2. Choose a db connection.
3. Choose a template.
4. Make some changes to the template in the editor.
5. Import template
6. Check to make sure that the template being imported is the one saved from the editor.
