### PR TITLE
Add support for listing more than 50 roles

### DIFF
--- a/docs/auth0_roles_list.md
+++ b/docs/auth0_roles_list.md
@@ -19,6 +19,7 @@ auth0 roles list [flags]
 ```
 auth0 roles list
 auth0 roles ls
+auth0 roles ls -n 100
 ```
 
 ### Options

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/auth0/auth0-cli/internal/ansi"
-	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/auth0/go-auth0/management"
 	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
 // errNoRoles signifies no roles exist in a tenant
@@ -72,24 +73,29 @@ auth0 roles ls -n 100`,
 				cmd.Context(),
 				inputs.Number,
 				func(opts ...management.RequestOption) (result []interface{}, hasNext bool, err error) {
-					res, apiErr := cli.api.Role.List(opts...)
-					if apiErr != nil {
-						return nil, false, apiErr
+					roleList, err := cli.api.Role.List(opts...)
+					if err != nil {
+						return nil, false, err
 					}
-					var output []interface{}
-					for _, role := range res.Roles {
-						output = append(output, role)
+
+					for _, role := range roleList.Roles {
+						result = append(result, role)
 					}
-					return output, res.HasNext(), nil
-				})
+
+					return result, roleList.HasNext(), nil
+				},
+			)
 			if err != nil {
 				return fmt.Errorf("An unexpected error occurred: %w", err)
 			}
-			var typedList []*management.Role
+
+			var roles []*management.Role
 			for _, item := range list {
-				typedList = append(typedList, item.(*management.Role))
+				roles = append(roles, item.(*management.Role))
 			}
-			cli.renderer.RoleList(typedList)
+
+			cli.renderer.RoleList(roles)
+
 			return nil
 		},
 	}

--- a/internal/display/roles.go
+++ b/internal/display/roles.go
@@ -3,8 +3,9 @@ package display
 import (
 	"fmt"
 
-	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/go-auth0/management"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
 )
 
 type roleView struct {
@@ -41,7 +42,7 @@ func (v *roleView) Object() interface{} {
 func (r *Renderer) RoleList(roles []*management.Role) {
 	resource := "roles"
 
-	r.Heading(fmt.Sprintf("%s (%v)", resource, len(roles)))
+	r.Heading(fmt.Sprintf("%s (%d)", resource, len(roles)))
 
 	if len(roles) == 0 {
 		r.EmptyState(resource)

--- a/internal/display/roles.go
+++ b/internal/display/roles.go
@@ -1,6 +1,8 @@
 package display
 
 import (
+	"fmt"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/go-auth0/management"
 )
@@ -39,7 +41,7 @@ func (v *roleView) Object() interface{} {
 func (r *Renderer) RoleList(roles []*management.Role) {
 	resource := "roles"
 
-	r.Heading(resource)
+	r.Heading(fmt.Sprintf("%s (%v)", resource, len(roles)))
 
 	if len(roles) == 0 {
 		r.EmptyState(resource)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add support for listing more than 50 roles in a tenant by using pagination.

### References

Fixes #449 

### Testing

Manual testing against a tenant with more than 50 roles.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
