### PR TITLE
feat: paginate orgs list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ integration-cleanup:
 	./integration/test-cleanup.sh
 .PHONY: integration-cleanup
 
-integration: build $(GOBIN)/commander 
+integration: build $(GOBIN)/commander
 	$(MAKE) run-integration; \
 	ret=$$?; \
 	$(MAKE) integration-cleanup; \
@@ -82,6 +82,6 @@ build-doc:
 
 # Start the doc site locally for testing purposes only
 # requires https://jekyllrb.com/docs/installation/
-start-doc: build-doc 
+start-doc: build-doc
 	@cd docs && bundle exec jekyll serve
 .PHONY: start-doc

--- a/internal/display/organizations.go
+++ b/internal/display/organizations.go
@@ -44,7 +44,7 @@ func (v *organizationView) Object() interface{} {
 	return v.raw
 }
 
-func (r *Renderer) OrganizationList(organizations []management.Organization) {
+func (r *Renderer) OrganizationList(organizations []*management.Organization) {
 	resource := "organizations"
 
 	r.Heading(resource)
@@ -57,7 +57,7 @@ func (r *Renderer) OrganizationList(organizations []management.Organization) {
 
 	var res []View
 	for _, o := range organizations {
-		res = append(res, makeOrganizationView(&o, r.MessageWriter))
+		res = append(res, makeOrganizationView(o, r.MessageWriter))
 	}
 
 	r.Results(res)

--- a/internal/display/organizations.go
+++ b/internal/display/organizations.go
@@ -44,7 +44,7 @@ func (v *organizationView) Object() interface{} {
 	return v.raw
 }
 
-func (r *Renderer) OrganizationList(organizations []*management.Organization) {
+func (r *Renderer) OrganizationList(organizations []management.Organization) {
 	resource := "organizations"
 
 	r.Heading(resource)
@@ -57,7 +57,7 @@ func (r *Renderer) OrganizationList(organizations []*management.Organization) {
 
 	var res []View
 	for _, o := range organizations {
-		res = append(res, makeOrganizationView(o, r.MessageWriter))
+		res = append(res, makeOrganizationView(&o, r.MessageWriter))
 	}
 
 	r.Results(res)


### PR DESCRIPTION
### Description

Adding support for pagination using optional parameter `-n` to organization list command: `auth0 orgs list -n 3` (limit to 3 items, defaults to 50)
Fixing `auth0 orgs members list` to allow `-n` as a parameter
Fixing `auth0 orgs roles list` to allow `-n` as a parameter
Fixing `auth0 orgs roles members list` to allow `-n` as a parameter

### References

Re-used the logic introduced by @sergeybykov in PRs #378 #386 #450

### Testing

Manual testing:
On `main` branch, run the following commands:
```
auth0 orgs list                     # => results are limited to 50 (defaul value, probably server-side)
auth0 orgs list -n 51               # => error: unknown shorthand flag: 'n' in -n
auth0 orgs members list -n 51       # => error: unknown shorthand flag: 'n' in -n
auth0 orgs roles list -n 51         # => error: unknown shorthand flag: 'n' in -n
auth0 orgs roles members list -n 51 # => error: unknown shorthand flag: 'n' in -n
```
On this PR's branch:
```
auth0 orgs list                     # => unchanged, results are still limited to 50 (default value set in CLI)
auth0 orgs list -n 51               # => returns up to 51 results
auth0 orgs members list -n 51       # => returns up to 51 results
auth0 orgs roles list -n 51         # => returns up to 51 results
auth0 orgs roles members list -n 51 # => returns up to 51 results
```

I did not write unit/integration tests, simply because none exists for most of the `internal/cli/*.go` files.
Developed on MacOS 12.4 (Monterey, Intel chip), golang 1.18.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
