### PR TITLE
Fix login cmd to raise issues encountered when fetching the device code

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ with the Device Code grant type enabled and set the following env variables:
 - `AUTH0_OAUTH_TOKEN_ENDPOINT` - OAuth Token URL, you can find this under **Advanced Settings -> Endpoints**.
 
 ```bash
-AUTH0_AUDIENCE="https://my_org.example.com/api/v2/" \
-AUTH0_DEVICE_CODE_ENDPOINT="https://my_org.example.com/oauth/device/code" \
-AUTH0_OAUTH_TOKEN_ENDPOINT="https://my_org.example.com/oauth/token" \
-AUTH0_CLIENT_ID="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+AUTH0_AUDIENCE="https://my-org.example.com/api/v2/" \
+AUTH0_DEVICE_CODE_ENDPOINT="https://my-org.example.com/oauth/device/code" \
+AUTH0_OAUTH_TOKEN_ENDPOINT="https://my-org.example.com/oauth/token" \
+AUTH0_CLIENT_ID="xxxxxxxxxxxxxxxx" \
 auth0 login
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Build, test, troubleshoot and manage your integration with **[Auth0](http://auth
 
 ![demo](./demo.gif)
 
+-------------------------------------
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Customization](#customization)
+- [Anonymous Analytics](#anonymous-analytics)
+- [Contributing](#contributing)
+- [Author](#author)
+
+-------------------------------------
+
 ## Features
 
 ### 🧪 Test the login flow at any time
@@ -98,6 +112,7 @@ auth0 [command] --help
 * [auth0 actions](https://auth0.github.io/auth0-cli/auth0_actions.html)	 - Manage resources for actions
 * [auth0 apis](https://auth0.github.io/auth0-cli/auth0_apis.html)	 - Manage resources for APIs
 * [auth0 apps](https://auth0.github.io/auth0-cli/auth0_apps.html)	 - Manage resources for applications
+* [auth0 attack-protection](https://auth0.github.io/auth0-cli/auth0_attack_protection.html)	 - Manage attack protection settings
 * [auth0 branding](https://auth0.github.io/auth0-cli/auth0_branding.html)	 - Manage branding options
 * [auth0 completion](https://auth0.github.io/auth0-cli/auth0_completion.html)	 - Setup autocomplete features for this CLI on your terminal
 * [auth0 ips](https://auth0.github.io/auth0-cli/auth0_ips.html)	 - Manage blocked IP addresses
@@ -115,11 +130,29 @@ auth0 [command] --help
 ### Onboarding Journey
 
 Following these instructions will give you a sense of what's possible with the
-Auth0 CLI. To start, you will have to login:
+Auth0 CLI. To start, you will have to log in:
 
 #### Login
 
+To log in to the Auth0 public cloud `auth0.auth0.com` simply run:
+
 ```bash
+auth0 login
+```
+
+To log in to an Auth0 private cloud please ensure you have a native application type created
+with the Device Code grant type enabled and set the following env variables:
+
+- `AUTH0_AUDIENCE` - The audience of the Auth0 Management API (System API) to use.
+- `AUTH0_CLIENT_ID` - Client ID of a native application configured with the **Device Code** grant type.
+- `AUTH0_DEVICE_CODE_ENDPOINT` - Device Authorization URL, you can find this under **Advanced Settings -> Endpoints**.
+- `AUTH0_OAUTH_TOKEN_ENDPOINT` - OAuth Token URL, you can find this under **Advanced Settings -> Endpoints**.
+
+```bash
+AUTH0_AUDIENCE="https://my_org.example.com/api/v2/" \
+AUTH0_DEVICE_CODE_ENDPOINT="https://my_org.example.com/oauth/device/code" \
+AUTH0_OAUTH_TOKEN_ENDPOINT="https://my_org.example.com/oauth/token" \
+AUTH0_CLIENT_ID="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
 auth0 login
 ```
 
@@ -230,16 +263,8 @@ Failed Login	hello	7 minutes ago	N/A	my awesome app
 
 ## Customization
 
-The authenticator of the CLI defaults to the default Auth0 cloud `auth0.auth0.com`. This can be customized for personalized cloud offerings by setting the following env variables:
-
-```
-	AUTH0_AUDIENCE - The audience of the Auth0 Management API (System API) to use.
-	AUTH0_CLIENT_ID - Client ID  of an application configured with the Device Code grant type.
-	AUTH0_DEVICE_CODE_ENDPOINT - Device Authorization URL
-	AUTH0_OAUTH_TOKEN_ENDPOINT - OAuth Token URL
-```
-
-To change the text editor used for editing templates, rules, and actions, set the environment variable `EDITOR`:
+To change the text editor used for editing templates, rules, and actions,
+set the environment variable `EDITOR` to your preferred editor:
 
 `export EDITOR="code -w"`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Supercharge your development workflow.
 * [auth0 actions](auth0_actions.md)	 - Manage resources for actions
 * [auth0 apis](auth0_apis.md)	 - Manage resources for APIs
 * [auth0 apps](auth0_apps.md)	 - Manage resources for applications
+* [auth0 attack-protection](auth0_attack_protection.md)	 - Manage attack protection settings
 * [auth0 branding](auth0_branding.md)	 - Manage branding options
 * [auth0 completion](auth0_completion.md)	 - Setup autocomplete features for this CLI on your terminal
 * [auth0 ips](auth0_ips.md)	 - Manage blocked IP addresses
@@ -35,4 +36,3 @@ Supercharge your development workflow.
 * [auth0 tenants](auth0_tenants.md)	 - Manage configured tenants
 * [auth0 test](auth0_test.md)	 - Try your Universal Login box or get a token
 * [auth0 users](auth0_users.md)	 - Manage resources for users
-

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -90,15 +90,16 @@ func (s *State) IntervalDuration() time.Duration {
 	return time.Duration(s.Interval+waitThresholdInSeconds) * time.Second
 }
 
-// Start kicks-off the device authentication flow
-// by requesting a device code from Auth0,
-// The returned state contains the URI for the next step of the flow.
+// Start kicks-off the device authentication flow by requesting
+// a device code from Auth0. The returned state contains the
+// URI for the next step of the flow.
 func (a *Authenticator) Start(ctx context.Context) (State, error) {
-	s, err := a.getDeviceCode(ctx)
+	state, err := a.getDeviceCode(ctx)
 	if err != nil {
 		return State{}, fmt.Errorf("cannot get device code: %w", err)
 	}
-	return s, nil
+
+	return state, nil
 }
 
 // Wait waits until the user is logged in on the browser.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/joeshaw/envdecode"
 )
 
 const (
@@ -41,11 +44,12 @@ var requiredScopes = []string{
 	"read:attack_protection", "update:attack_protection",
 }
 
+// Authenticator is used to facilitate the login process.
 type Authenticator struct {
-	Audience           string
-	ClientID           string
-	DeviceCodeEndpoint string
-	OauthTokenEndpoint string
+	Audience           string `env:"AUTH0_AUDIENCE,default=https://*.auth0.com/api/v2/"`
+	ClientID           string `env:"AUTH0_CLIENT_ID,default=2iZo3Uczt5LFHacKdM0zzgUO2eG2uDjT"`
+	DeviceCodeEndpoint string `env:"AUTH0_DEVICE_CODE_ENDPOINT,default=https://auth0.auth0.com/oauth/device/code"`
+	OauthTokenEndpoint string `env:"AUTH0_OAUTH_TOKEN_ENDPOINT,default=https://auth0.auth0.com/oauth/token"`
 }
 
 // SecretStore provides access to stored sensitive data.
@@ -73,11 +77,13 @@ type State struct {
 }
 
 // RequiredScopes returns the scopes used for login.
-func RequiredScopes() []string { return requiredScopes }
+func RequiredScopes() []string {
+	return requiredScopes
+}
 
 // RequiredScopesMin returns minimum scopes used for login in integration tests.
 func RequiredScopesMin() []string {
-	min := []string{}
+	var min []string
 	for _, s := range requiredScopes {
 		if s != "offline_access" && s != "openid" {
 			min = append(min, s)
@@ -90,13 +96,25 @@ func (s *State) IntervalDuration() time.Duration {
 	return time.Duration(s.Interval+waitThresholdInSeconds) * time.Second
 }
 
+// New returns a new instance of Authenticator
+// after decoding its parameters from env vars.
+func New() (*Authenticator, error) {
+	authenticator := Authenticator{}
+
+	if err := envdecode.StrictDecode(&authenticator); err != nil {
+		return nil, fmt.Errorf("failed to decode env vars for authenticator: %w", err)
+	}
+
+	return &authenticator, nil
+}
+
 // Start kicks-off the device authentication flow by requesting
 // a device code from Auth0. The returned state contains the
 // URI for the next step of the flow.
 func (a *Authenticator) Start(ctx context.Context) (State, error) {
 	state, err := a.getDeviceCode(ctx)
 	if err != nil {
-		return State{}, fmt.Errorf("cannot get device code: %w", err)
+		return State{}, fmt.Errorf("failed to get the device code: %w", err)
 	}
 
 	return state, nil
@@ -111,9 +129,9 @@ func (a *Authenticator) Wait(ctx context.Context, state State) (Result, error) {
 			return Result{}, ctx.Err()
 		case <-t.C:
 			data := url.Values{
-				"client_id":   {a.ClientID},
-				"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
-				"device_code": {state.DeviceCode},
+				"client_id":   []string{a.ClientID},
+				"grant_type":  []string{"urn:ietf:params:oauth:grant-type:device_code"},
+				"device_code": []string{state.DeviceCode},
 			}
 			r, err := http.PostForm(a.OauthTokenEndpoint, data)
 			if err != nil {
@@ -162,22 +180,48 @@ func (a *Authenticator) Wait(ctx context.Context, state State) (Result, error) {
 
 func (a *Authenticator) getDeviceCode(ctx context.Context) (State, error) {
 	data := url.Values{
-		"client_id": {a.ClientID},
-		"scope":     {strings.Join(requiredScopes, " ")},
-		"audience":  {a.Audience},
-	}
-	r, err := http.PostForm(a.DeviceCodeEndpoint, data)
-	if err != nil {
-		return State{}, fmt.Errorf("cannot get device code: %w", err)
-	}
-	defer r.Body.Close()
-	var res State
-	err = json.NewDecoder(r.Body).Decode(&res)
-	if err != nil {
-		return State{}, fmt.Errorf("cannot decode response: %w", err)
+		"client_id": []string{a.ClientID},
+		"scope":     []string{strings.Join(requiredScopes, " ")},
+		"audience":  []string{a.Audience},
 	}
 
-	return res, nil
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		a.DeviceCodeEndpoint,
+		strings.NewReader(data.Encode()),
+	)
+	if err != nil {
+		return State{}, fmt.Errorf("failed to create the request: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return State{}, fmt.Errorf("failed to send the request: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
+		bodyBytes, err := io.ReadAll(response.Body)
+		if err != nil {
+			return State{}, fmt.Errorf(
+				"received a %d response and failed to read the response",
+				response.StatusCode,
+			)
+		}
+
+		return State{}, fmt.Errorf("received a %d response: %s", response.StatusCode, bodyBytes)
+	}
+
+	var state State
+	err = json.NewDecoder(response.Body).Decode(&state)
+	if err != nil {
+		return State{}, fmt.Errorf("failed to decode the response: %w", err)
+	}
+
+	return state, nil
 }
 
 func parseTenant(accessToken string) (tenant, domain string, err error) {
@@ -189,7 +233,7 @@ func parseTenant(accessToken string) (tenant, domain string, err error) {
 	var payload struct {
 		AUDs []string `json:"aud"`
 	}
-	if err := json.Unmarshal([]byte(v), &payload); err != nil {
+	if err := json.Unmarshal(v, &payload); err != nil {
 		return "", "", err
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/auth0/auth0-cli/internal/display"
 	"github.com/google/go-cmp/cmp"
 	"github.com/olekukonko/tablewriter"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/auth0-cli/internal/display"
 )
 
 func TestIsExpired(t *testing.T) {
@@ -75,13 +76,13 @@ func expectTable(t testing.TB, got string, header []string, data [][]string) {
 func TestIsLoggedIn(t *testing.T) {
 	tests := []struct {
 		defaultTenant string
-		tenants       map[string]tenant
+		tenants       map[string]Tenant
 		want          bool
 		desc          string
 	}{
-		{"", map[string]tenant{}, false, "no tenants"},
-		{"t0", map[string]tenant{}, false, "tenant is set but no tenants map"},
-		{"t0", map[string]tenant{"t0": tenant{}}, false, "tenants map set but invalid token"},
+		{"", map[string]Tenant{}, false, "no tenants"},
+		{"t0", map[string]Tenant{}, false, "tenant is set but no tenants map"},
+		{"t0", map[string]Tenant{"t0": Tenant{}}, false, "tenants map set but invalid token"},
 	}
 
 	for _, test := range tests {
@@ -94,7 +95,7 @@ func TestIsLoggedIn(t *testing.T) {
 
 			type Config struct {
 				DefaultTenant string            `json:"default_tenant"`
-				Tenants       map[string]tenant `json:"tenants"`
+				Tenants       map[string]Tenant `json:"tenants"`
 			}
 
 			b, err := json.Marshal(&Config{test.defaultTenant, test.tenants})

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/auth0/auth0-cli/internal/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2/clientcredentials"
+
+	"github.com/auth0/auth0-cli/internal/auth"
 )
 
 var desiredInputs = `Config init is intended for non-interactive use, 
@@ -101,7 +102,7 @@ func initCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			t := tenant{
+			t := Tenant{
 				Name:        p.clientDomain,
 				Domain:      p.clientDomain,
 				AccessToken: token.AccessToken,

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -47,7 +47,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (Tenant, error) {
 	message := fmt.Sprintf(
 		"%s\n\n%s\n\n",
 		"✪ Welcome to the Auth0 CLI 🎊",
-		"If you don't have an account, please go to https://auth0.com/signup.",
+		"If you don't have an account, please create one here: https://auth0.com/signup.",
 	)
 
 	if expired {
@@ -59,7 +59,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (Tenant, error) {
 
 	state, err := cli.authenticator.Start(ctx)
 	if err != nil {
-		return Tenant{}, fmt.Errorf("Could not start the authentication process: %w.", err)
+		return Tenant{}, fmt.Errorf("Failed to start the authentication process: %w.", err)
 	}
 
 	message = fmt.Sprintf("Your device confirmation code is: %s\n\n", ansi.Bold(state.UserCode))

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -53,7 +53,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 
 	state, err := cli.authenticator.Start(ctx)
 	if err != nil {
-		return tenant{}, fmt.Errorf("Could not start the authentication process: %w.", err)
+		return Tenant{}, fmt.Errorf("Could not start the authentication process: %w.", err)
 	}
 
 	fmt.Printf("Your Device Confirmation code is: %s\n\n", ansi.Bold(state.UserCode))
@@ -77,7 +77,7 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (tenant, error) {
 	})
 
 	if err != nil {
-		return tenant{}, fmt.Errorf("login error: %w", err)
+		return Tenant{}, fmt.Errorf("login error: %w", err)
 	}
 
 	fmt.Print("\n")

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth"
 	"github.com/auth0/auth0-cli/internal/prompt"
-	"github.com/pkg/browser"
-	"github.com/spf13/cobra"
 )
 
 func loginCmd(cli *cli) *cobra.Command {
@@ -20,11 +21,13 @@ func loginCmd(cli *cli) *cobra.Command {
 		Long:  "Sign in to your Auth0 account and authorize the CLI to access the Management API.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			_, err := RunLogin(ctx, cli, false)
-			if err == nil {
-				cli.tracker.TrackCommandRun(cmd, cli.config.InstallID)
+			if _, err := RunLogin(ctx, cli, false); err != nil {
+				return err
 			}
-			return err
+
+			cli.tracker.TrackCommandRun(cmd, cli.config.InstallID)
+
+			return nil
 		},
 	}
 

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/auth0/auth0-cli/internal/prompt"
 	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
 var (
@@ -187,7 +188,7 @@ func addTenantCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			t := tenant{
+			t := Tenant{
 				Domain:       inputs.Domain,
 				ClientID:     inputs.ClientID,
 				ClientSecret: inputs.ClientSecret,

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -2,20 +2,20 @@ package cli
 
 import (
 	"crypto/rand"
-	"fmt"
-	"strings"
-
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/pkg/browser"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth/authutil"
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
-	"github.com/pkg/browser"
-	"github.com/auth0/go-auth0/management"
 )
 
 const (
@@ -55,7 +55,7 @@ func BuildOauthTokenParams(clientID, clientSecret, audience string) url.Values {
 }
 
 // runClientCredentialsFlow runs an M2M client credentials flow without opening a browser
-func runClientCredentialsFlow(cli *cli, c *management.Client, clientID string, audience string, tenant tenant) (*authutil.TokenResponse, error) {
+func runClientCredentialsFlow(cli *cli, c *management.Client, clientID string, audience string, tenant Tenant) (*authutil.TokenResponse, error) {
 
 	var tokenResponse *authutil.TokenResponse
 
@@ -111,7 +111,7 @@ func runLoginFlowPreflightChecks(cli *cli, c *management.Client) (abort bool) {
 
 // runLoginFlow initiates a full user-facing login flow, waits for a response
 // and returns the retrieved tokens to the caller when done.
-func runLoginFlow(cli *cli, t tenant, c *management.Client, connName, audience, prompt string, scopes []string, customDomain string) (*authutil.TokenResponse, error) {
+func runLoginFlow(cli *cli, t Tenant, c *management.Client, connName, audience, prompt string, scopes []string, customDomain string) (*authutil.TokenResponse, error) {
 	var tokenResponse *authutil.TokenResponse
 
 	err := ansi.Spinner("Waiting for login flow to complete", func() error {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When fetching a device code if we were getting a non 2XX response, we weren't stopping and alerting the user but kept going with an empty state, eventually trying to open a browser link that is empty due to the VerificationURI being an empty string.

We're now checking for non 2XX response code, alerting the user of the error and stopping the process.

### References



### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
