### PR TITLE
fix: Use single dash for single letter flags

### DIFF
--- a/docs/auth0_actions_create.md
+++ b/docs/auth0_actions_create.md
@@ -18,9 +18,9 @@ auth0 actions create [flags]
 ```
 auth0 actions create 
 auth0 actions create --name myaction
-auth0 actions create --n myaction --trigger post-login
-auth0 actions create --n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
-auth0 actions create --n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value
+auth0 actions create -n myaction --trigger post-login
+auth0 actions create -n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
+auth0 actions create -n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value
 ```
 
 ### Options

--- a/docs/auth0_actions_update.md
+++ b/docs/auth0_actions_update.md
@@ -18,9 +18,9 @@ auth0 actions update [flags]
 ```
 auth0 actions update <id> 
 auth0 actions update <id> --name myaction
-auth0 actions update <id> --n myaction --trigger post-login
-auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
-auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value
+auth0 actions update <id> -n myaction --trigger post-login
+auth0 actions update <id> -n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
+auth0 actions update <id> -n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value
 ```
 
 ### Options

--- a/docs/auth0_orgs_create.md
+++ b/docs/auth0_orgs_create.md
@@ -18,9 +18,9 @@ auth0 orgs create [flags]
 ```
 auth0 orgs create 
 auth0 orgs create --name myorganization
-auth0 orgs create --n myorganization --display "My Organization"
-auth0 orgs create --n myorganization -d "My Organization" -l "https://example.com/logo.png" -a "#635DFF" -b "#2A2E35"
-auth0 orgs create --n myorganization -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_value"
+auth0 orgs create -n myorganization --display "My Organization"
+auth0 orgs create -n myorganization -d "My Organization" -l "https://example.com/logo.png" -a "#635DFF" -b "#2A2E35"
+auth0 orgs create -n myorganization -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_value"
 ```
 
 ### Options

--- a/docs/auth0_users_create.md
+++ b/docs/auth0_users_create.md
@@ -19,7 +19,7 @@ auth0 users create [flags]
 auth0 users create 
 auth0 users create --name "John Doe" 
 auth0 users create -n "John Doe" --email john@example.com
-auth0 users create -n "John Doe" --e john@example.com --connection "Username-Password-Authentication"
+auth0 users create -n "John Doe" -e john@example.com --connection "Username-Password-Authentication"
 ```
 
 ### Options

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -170,9 +170,9 @@ func createActionCmd(cli *cli) *cobra.Command {
 		Long:  "Create a new action.",
 		Example: `auth0 actions create 
 auth0 actions create --name myaction
-auth0 actions create --n myaction --trigger post-login
-auth0 actions create --n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
-auth0 actions create --n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value`,
+auth0 actions create -n myaction --trigger post-login
+auth0 actions create -n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
+auth0 actions create -n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := actionName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -250,9 +250,9 @@ func updateActionCmd(cli *cli) *cobra.Command {
 		Long:  "Update an action.",
 		Example: `auth0 actions update <id> 
 auth0 actions update <id> --name myaction
-auth0 actions update <id> --n myaction --trigger post-login
-auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
-auth0 actions update <id> --n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value`,
+auth0 actions update <id> -n myaction --trigger post-login
+auth0 actions update <id> -n myaction -t post-login -d "lodash=4.0.0" -d "uuid=8.0.0"
+auth0 actions update <id> -n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=value" -s "SECRET=value`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.ID = args[0]

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -207,9 +207,9 @@ func createOrganizationCmd(cli *cli) *cobra.Command {
 		Long:  "Create a new organization.",
 		Example: `auth0 orgs create
 auth0 orgs create --name myorganization
-auth0 orgs create --n myorganization --display "My Organization"
-auth0 orgs create --n myorganization -d "My Organization" -l "https://example.com/logo.png" -a "#635DFF" -b "#2A2E35"
-auth0 orgs create --n myorganization -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_value"`,
+auth0 orgs create -n myorganization --display "My Organization"
+auth0 orgs create -n myorganization -d "My Organization" -l "https://example.com/logo.png" -a "#635DFF" -b "#2A2E35"
+auth0 orgs create -n myorganization -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_value"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := organizationName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -194,7 +194,7 @@ func createUserCmd(cli *cli) *cobra.Command {
 		Example: `auth0 users create 
 auth0 users create --name "John Doe" 
 auth0 users create -n "John Doe" --email john@example.com
-auth0 users create -n "John Doe" --e john@example.com --connection "Username-Password-Authentication"`,
+auth0 users create -n "John Doe" -e john@example.com --connection "Username-Password-Authentication"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Select from the available connection types
 			// Users API currently support  database connections


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Removes spurious `-` from short arg flags.

### References

Fixes #465 

### Testing

I have not tested this beyond confirming that the documentation as present in `main` w/o these changes does not work and that conceptually the changed text corresponds to the code and thus should work.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
