### PR TITLE
fix: remove doubled spa array key

### DIFF
--- a/internal/cli/data/quickstarts.json
+++ b/internal/cli/data/quickstarts.json
@@ -251,9 +251,7 @@
       "org": "auth0-samples",
       "repo": "auth0-xamarin-oidc-samples",
       "branch": "master"
-    }
-  ],
-  "spa": [
+    },
     {
       "name": "Angular",
       "path": "angular",

--- a/internal/cli/data/quickstarts.json
+++ b/internal/cli/data/quickstarts.json
@@ -54,7 +54,7 @@
       "name": "Laravel API",
       "path": "laravel",
       "samples": [
-        "01-Authorization-RS256"
+        "app"
       ],
       "org": "auth0-samples",
       "repo": "auth0-laravel-api-samples",
@@ -143,6 +143,16 @@
       "branch": "master"
     },
     {
+      "name": "Flutter",
+      "path": "flutter",
+      "samples": [
+        "sample"
+      ],
+      "org": "auth0-samples",
+      "repo": "auth0-flutter-samples",
+      "branch": "main"
+    },
+    {
       "name": "Ionic & Capacitor (Angular)",
       "path": "ionic-angular",
       "samples": [
@@ -164,50 +174,12 @@
     },
     {
       "name": "iOS / macOS",
-      "path": "swift-beta",
+      "path": "ios-swift",
       "samples": [
         "Sample-01"
       ],
       "org": "auth0-samples",
       "repo": "auth0-ios-swift-sample",
-      "branch": "beta"
-    },
-    {
-      "name": "iOS Swift",
-      "path": "ios-swift",
-      "samples": [
-        "00-Login",
-        "01-Embedded-Login",
-        "01-Login",
-        "02-Custom-Login-Form",
-        "03-User-Sessions",
-        "04-Calling-APIs",
-        "05-Authorization",
-        "07-Linking-Accounts",
-        "08-Credentials-TouchID"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-ios-swift-sample",
-      "branch": "master"
-    },
-    {
-      "name": "iOS Swift - Facebook Login",
-      "path": "ios-swift-facebook-login",
-      "samples": [
-        "00-login-facebook"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-ios-swift-native-social-samples",
-      "branch": "master"
-    },
-    {
-      "name": "iOS Swift - Sign In With Apple",
-      "path": "ios-swift-siwa",
-      "samples": [
-        "00-login-siwa"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-ios-swift-native-social-samples",
       "branch": "master"
     },
     {
@@ -229,9 +201,7 @@
       "org": "auth0-samples",
       "repo": "auth0-uwp-oidc-samples",
       "branch": "master"
-    }
-  ],
-  "spa": [
+    },
     {
       "name": "WPF / Winforms",
       "path": "wpf-winforms",
@@ -251,7 +221,9 @@
       "org": "auth0-samples",
       "repo": "auth0-xamarin-oidc-samples",
       "branch": "master"
-    },
+    }
+  ],
+  "spa": [
     {
       "name": "Angular",
       "path": "angular",
@@ -334,7 +306,8 @@
       "name": "Django",
       "path": "django",
       "samples": [
-        "01-Login"
+        "01-Login",
+        "Quickstart/Sample"
       ],
       "org": "auth0-samples",
       "repo": "auth0-django-web-app",
@@ -391,6 +364,16 @@
       "branch": "master"
     },
     {
+      "name": "Laravel",
+      "path": "laravel",
+      "samples": [
+        "app"
+      ],
+      "org": "auth0-samples",
+      "repo": "auth0-laravel-php-web-app",
+      "branch": "master"
+    },
+    {
       "name": "Next.js",
       "path": "nextjs",
       "samples": [
@@ -409,16 +392,6 @@
       "org": "auth0-samples",
       "repo": "auth0-php-web-app",
       "branch": "main"
-    },
-    {
-      "name": "PHP (Laravel)",
-      "path": "laravel",
-      "samples": [
-        "01-Login"
-      ],
-      "org": "auth0-samples",
-      "repo": "auth0-laravel-php-web-app",
-      "branch": "master"
     },
     {
       "name": "Python",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The quickstart.json file in `main` currently has invalid json.

### Testing

I opened the file in VSCode and it screamed. Once the duplicate key was removed, it stopped screaming.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
