### PR TITLE
Honor some editor env vars before falling back to notepad on Windows

### DIFF
--- a/internal/prompt/editor.go
+++ b/internal/prompt/editor.go
@@ -132,14 +132,14 @@ func (p *editorPrompt) captureInput(contents []byte, pattern string, infoFn func
 // getDefaultEditor is taken from https://github.com/cli/cli/blob/trunk/pkg/surveyext/editor_manual.go
 // and tries to infer the editor from different heuristics.
 func getDefaultEditor() string {
-	if runtime.GOOS == "windows" {
-		return "notepad"
-	} else if g := os.Getenv("GIT_EDITOR"); g != "" {
+	if g := os.Getenv("GIT_EDITOR"); g != "" {
 		return g
 	} else if v := os.Getenv("VISUAL"); v != "" {
 		return v
 	} else if e := os.Getenv("EDITOR"); e != "" {
 		return e
+	} else if runtime.GOOS == "windows" {
+		return "notepad"
 	}
 
 	return defaultEditor


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

If a Windows user has set `GIT_EDITOR`, `VISUAL`, or `EDITOR`, and they use `auth0` w/ some task that triggers an editor, their preferred editor will be opened.

### References

closes #454
https://github.com/cli/cli/issues/6102


### Testing

I have not tested this change.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
