### PR TITLE
Add ability to filter specific integration test in make test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,17 @@ check-vuln: $(GO_BIN)/govulncheck ## Check go vulnerabilities
 #-----------------------------------------------------------------------------------------------------------------------
 # Testing
 #-----------------------------------------------------------------------------------------------------------------------
-.PHONY: test-unit test-integration test-mocks
+.PHONY: test test-unit test-integration test-mocks
+
+test: test-unit test-integration ## Run all tests
 
 test-unit: ## Run unit tests
 	${call print, "Running unit tests"}
 	@go test -race ${GO_PACKAGES} -count 1
 
-test-integration: $(GO_BIN)/auth0 $(GO_BIN)/commander ## Run integration tests
+test-integration: $(GO_BIN)/auth0 $(GO_BIN)/commander ## Run integration tests. To run a specific test pass the FILTER var. Usage: `make test-integration FILTER="attack-protection"`
 	${call print, "Running integration tests"}
-	auth0 config init && commander test commander.yaml; \
+	auth0 config init && commander test commander.yaml --filter "$(FILTER)"; \
 	exit_code=$$?; \
 	bash ./integration/test-cleanup.sh; \
 	exit $$exit_code


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR adds the ability for us to only run a specific test or subset of tests based on the filter param that gets passed to the `make test-integration` command.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
