### PR TITLE
Forcing rebuild before running integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,9 @@ test-unit: ## Run unit tests
 	${call print, "Running unit tests"}
 	@go test -race ${GO_PACKAGES} -count 1
 
-test-integration: $(GO_BIN)/auth0 $(GO_BIN)/commander ## Run integration tests. To run a specific test pass the FILTER var. Usage: `make test-integration FILTER="attack-protection"`
+test-integration: $(GO_BIN)/commander ## Run integration tests. To run a specific test pass the FILTER var. Usage: `make test-integration FILTER="attack protection"`
 	${call print, "Running integration tests"}
+	@$(MAKE) install # ensure fresh install prior to running test
 	auth0 config init && commander test commander.yaml --filter "$(FILTER)"; \
 	exit_code=$$?; \
 	bash ./integration/test-cleanup.sh; \


### PR DESCRIPTION
### 🔧 Changes

This addition rebuilds the application code before each invocation of `make test-integration`. Doing so enables a more test-driven approach by allowing local changes to be immediately tested. 

Additionally, this corrects an example comment of the recently added `FILTER` argument that allows the targeting of specific integration tests.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
