### PR TITLE
DXCDT-287: Remove format flag in favor of json flag

### DIFF
--- a/docs/auth0_actions.md
+++ b/docs/auth0_actions.md
@@ -20,7 +20,7 @@ Manage resources for actions.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_create.md
+++ b/docs/auth0_actions_create.md
@@ -39,7 +39,7 @@ auth0 actions create -n myaction -t post-login -d "lodash=4.0.0" -s "API_KEY=val
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_delete.md
+++ b/docs/auth0_actions_delete.md
@@ -31,7 +31,7 @@ auth0 actions delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_deploy.md
+++ b/docs/auth0_actions_deploy.md
@@ -31,7 +31,7 @@ auth0 actions deploy <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_list.md
+++ b/docs/auth0_actions_list.md
@@ -32,7 +32,7 @@ auth0 actions ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_open.md
+++ b/docs/auth0_actions_open.md
@@ -30,7 +30,7 @@ auth0 actions open <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_show.md
+++ b/docs/auth0_actions_show.md
@@ -31,7 +31,7 @@ auth0 actions show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_actions_update.md
+++ b/docs/auth0_actions_update.md
@@ -39,7 +39,7 @@ auth0 actions update <id> -n myaction -t post-login -d "lodash=4.0.0" -s "API_KE
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_api.md
+++ b/docs/auth0_api.md
@@ -43,7 +43,7 @@ cat data.json | auth0 api post clients
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis.md
+++ b/docs/auth0_apis.md
@@ -20,7 +20,7 @@ Manage resources for APIs.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_create.md
+++ b/docs/auth0_apis_create.md
@@ -39,7 +39,7 @@ auth0 apis create -n myapi -e 6100 --offline-access=true
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_delete.md
+++ b/docs/auth0_apis_delete.md
@@ -31,7 +31,7 @@ auth0 apis delete <id|audience>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_list.md
+++ b/docs/auth0_apis_list.md
@@ -34,7 +34,7 @@ auth0 apis ls -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_open.md
+++ b/docs/auth0_apis_open.md
@@ -31,7 +31,7 @@ auth0 apis open <id|audience>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_scopes.md
+++ b/docs/auth0_apis_scopes.md
@@ -20,7 +20,7 @@ Manage resources for API scopes.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_scopes_list.md
+++ b/docs/auth0_apis_scopes_list.md
@@ -31,7 +31,7 @@ auth0 apis scopes ls <id|audience>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_show.md
+++ b/docs/auth0_apis_show.md
@@ -31,7 +31,7 @@ auth0 apis show <id|audience>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apis_update.md
+++ b/docs/auth0_apis_update.md
@@ -38,7 +38,7 @@ auth0 apis update -n myapi -e 6100 --offline-access=true
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps.md
+++ b/docs/auth0_apps.md
@@ -20,7 +20,7 @@ Manage resources for applications.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -47,7 +47,7 @@ auth0 apps create -n myapp -t [native|spa|regular|m2m] --description <descriptio
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_delete.md
+++ b/docs/auth0_apps_delete.md
@@ -31,7 +31,7 @@ auth0 apps delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_list.md
+++ b/docs/auth0_apps_list.md
@@ -35,7 +35,7 @@ auth0 apps ls -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_open.md
+++ b/docs/auth0_apps_open.md
@@ -30,7 +30,7 @@ auth0 apps open <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_show.md
+++ b/docs/auth0_apps_show.md
@@ -32,7 +32,7 @@ auth0 apps show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -46,7 +46,7 @@ auth0 apps update <id> -n myapp --type [native|spa|regular|m2m]
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_apps_use.md
+++ b/docs/auth0_apps_use.md
@@ -31,7 +31,7 @@ auth0 apps use <client-id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding.md
+++ b/docs/auth0_branding.md
@@ -20,7 +20,7 @@ Manage branding options.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains.md
+++ b/docs/auth0_branding_domains.md
@@ -20,7 +20,7 @@ Manage custom domains.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_create.md
+++ b/docs/auth0_branding_domains_create.md
@@ -36,7 +36,7 @@ auth0 branding domains create <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_delete.md
+++ b/docs/auth0_branding_domains_delete.md
@@ -31,7 +31,7 @@ auth0 branding domains delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_list.md
+++ b/docs/auth0_branding_domains_list.md
@@ -32,7 +32,7 @@ auth0 branding domains ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_show.md
+++ b/docs/auth0_branding_domains_show.md
@@ -31,7 +31,7 @@ auth0 branding domains show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_update.md
+++ b/docs/auth0_branding_domains_update.md
@@ -34,7 +34,7 @@ auth0 branding domains update <id> -p compatible --ip-header "cf-connecting-ip"
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_domains_verify.md
+++ b/docs/auth0_branding_domains_verify.md
@@ -31,7 +31,7 @@ auth0 branding domains verify <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_emails.md
+++ b/docs/auth0_branding_emails.md
@@ -20,7 +20,7 @@ Manage custom email templates. This requires a custom email provider to be confi
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_emails_show.md
+++ b/docs/auth0_branding_emails_show.md
@@ -31,7 +31,7 @@ auth0 branding emails show welcome
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_emails_update.md
+++ b/docs/auth0_branding_emails_update.md
@@ -37,7 +37,7 @@ auth0 branding emails update welcome
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_show.md
+++ b/docs/auth0_branding_show.md
@@ -30,7 +30,7 @@ auth0 branding show
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_templates.md
+++ b/docs/auth0_branding_templates.md
@@ -35,7 +35,7 @@ Once you close the window, you’ll be asked if you want to save the template. I
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_templates_show.md
+++ b/docs/auth0_branding_templates_show.md
@@ -30,7 +30,7 @@ auth0 branding templates show
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_templates_update.md
+++ b/docs/auth0_branding_templates_update.md
@@ -30,7 +30,7 @@ auth0 branding templates update
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_texts.md
+++ b/docs/auth0_branding_texts.md
@@ -20,7 +20,7 @@ Manage custom text for prompts.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_texts_show.md
+++ b/docs/auth0_branding_texts_show.md
@@ -33,7 +33,7 @@ auth0 branding texts show <prompt> -l es
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_texts_update.md
+++ b/docs/auth0_branding_texts_update.md
@@ -33,7 +33,7 @@ auth0 branding texts update <prompt> -l es
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_branding_update.md
+++ b/docs/auth0_branding_update.md
@@ -37,7 +37,7 @@ auth0 branding update -a "#FF4F40" -b "#2A2E35" --logo "https://example.com/logo
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_completion.md
+++ b/docs/auth0_completion.md
@@ -64,7 +64,7 @@ auth0 completion
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_ips.md
+++ b/docs/auth0_ips.md
@@ -20,7 +20,7 @@ Manage blocked IP addresses.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_ips_check.md
+++ b/docs/auth0_ips_check.md
@@ -30,7 +30,7 @@ auth0 ips check <ip>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_ips_unblock.md
+++ b/docs/auth0_ips_unblock.md
@@ -30,7 +30,7 @@ auth0 ips unblock <ip>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_login.md
+++ b/docs/auth0_login.md
@@ -24,7 +24,7 @@ auth0 login [flags]
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logout.md
+++ b/docs/auth0_logout.md
@@ -30,7 +30,7 @@ auth0 logout <tenant>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs.md
+++ b/docs/auth0_logs.md
@@ -20,7 +20,7 @@ View tenant logs.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_list.md
+++ b/docs/auth0_logs_list.md
@@ -39,7 +39,7 @@ auth0 logs ls -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams.md
+++ b/docs/auth0_logs_streams.md
@@ -20,7 +20,7 @@ manage resources for log streams.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_create.md
+++ b/docs/auth0_logs_streams_create.md
@@ -53,7 +53,7 @@ auth0 logs streams create -n test-splunk -t splunk --splunk-domain demo.splunk.c
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_delete.md
+++ b/docs/auth0_logs_streams_delete.md
@@ -31,7 +31,7 @@ auth0 logs streams delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_list.md
+++ b/docs/auth0_logs_streams_list.md
@@ -32,7 +32,7 @@ auth0 logs streams ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_open.md
+++ b/docs/auth0_logs_streams_open.md
@@ -30,7 +30,7 @@ auth0 logs streams open <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_show.md
+++ b/docs/auth0_logs_streams_show.md
@@ -31,7 +31,7 @@ auth0 logs streams show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_streams_update.md
+++ b/docs/auth0_logs_streams_update.md
@@ -49,7 +49,7 @@ auth0 logs streams update <id> -n myeventbridge -t eventbridge
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_logs_tail.md
+++ b/docs/auth0_logs_tail.md
@@ -39,7 +39,7 @@ auth0 logs tail -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs.md
+++ b/docs/auth0_orgs.md
@@ -20,7 +20,7 @@ Manage resources for organizations.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_create.md
+++ b/docs/auth0_orgs_create.md
@@ -40,7 +40,7 @@ auth0 orgs create -n myorganization -d "My Organization" -m "KEY=value" -m "OTHE
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_delete.md
+++ b/docs/auth0_orgs_delete.md
@@ -31,7 +31,7 @@ auth0 orgs delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_list.md
+++ b/docs/auth0_orgs_list.md
@@ -34,7 +34,7 @@ auth0 orgs ls -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_members.md
+++ b/docs/auth0_orgs_members.md
@@ -20,7 +20,7 @@ Manage members of an organization.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_members_list.md
+++ b/docs/auth0_orgs_members_list.md
@@ -32,7 +32,7 @@ auth0 orgs members ls <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_open.md
+++ b/docs/auth0_orgs_open.md
@@ -30,7 +30,7 @@ auth0 orgs open <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_roles.md
+++ b/docs/auth0_orgs_roles.md
@@ -20,7 +20,7 @@ Manage roles of an organization.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_roles_list.md
+++ b/docs/auth0_orgs_roles_list.md
@@ -32,7 +32,7 @@ auth0 orgs roles ls <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_roles_members.md
+++ b/docs/auth0_orgs_roles_members.md
@@ -20,7 +20,7 @@ Manage roles assigned to members of an organization.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_roles_members_list.md
+++ b/docs/auth0_orgs_roles_members_list.md
@@ -33,7 +33,7 @@ auth0 orgs roles members list <org id> --role-id role
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_show.md
+++ b/docs/auth0_orgs_show.md
@@ -31,7 +31,7 @@ auth0 orgs show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_orgs_update.md
+++ b/docs/auth0_orgs_update.md
@@ -38,7 +38,7 @@ auth0 orgs update <id> -d "My Organization" -m "KEY=value" -m "OTHER_KEY=other_v
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection.md
+++ b/docs/auth0_protection.md
@@ -20,7 +20,7 @@ Manage resources for attack protection.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_breached-password-detection.md
+++ b/docs/auth0_protection_breached-password-detection.md
@@ -20,7 +20,7 @@ Manage breached password detection settings.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_breached-password-detection_show.md
+++ b/docs/auth0_protection_breached-password-detection_show.md
@@ -30,7 +30,7 @@ auth0 protection breached-password-detection show
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_breached-password-detection_update.md
+++ b/docs/auth0_protection_breached-password-detection_update.md
@@ -34,7 +34,7 @@ auth0 protection breached-password-detection update
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_brute-force-protection.md
+++ b/docs/auth0_protection_brute-force-protection.md
@@ -20,7 +20,7 @@ Manage brute force protection settings.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_brute-force-protection_show.md
+++ b/docs/auth0_protection_brute-force-protection_show.md
@@ -30,7 +30,7 @@ auth0 protection brute-force-protection show
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_brute-force-protection_update.md
+++ b/docs/auth0_protection_brute-force-protection_update.md
@@ -35,7 +35,7 @@ auth0 protection brute-force-protection update
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_suspicious-ip-throttling.md
+++ b/docs/auth0_protection_suspicious-ip-throttling.md
@@ -20,7 +20,7 @@ Manage suspicious ip throttling settings.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_suspicious-ip-throttling_show.md
+++ b/docs/auth0_protection_suspicious-ip-throttling_show.md
@@ -30,7 +30,7 @@ auth0 protection suspicious-ip-throttling show
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_protection_suspicious-ip-throttling_update.md
+++ b/docs/auth0_protection_suspicious-ip-throttling_update.md
@@ -37,7 +37,7 @@ auth0 protection suspicious-ip-throttling update
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_quickstarts.md
+++ b/docs/auth0_quickstarts.md
@@ -20,7 +20,7 @@ Quickstart support for getting bootstrapped.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_quickstarts_download.md
+++ b/docs/auth0_quickstarts_download.md
@@ -32,7 +32,7 @@ auth0 qs download --stack <stack>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_quickstarts_list.md
+++ b/docs/auth0_quickstarts_list.md
@@ -33,7 +33,7 @@ auth0 qs ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles.md
+++ b/docs/auth0_roles.md
@@ -20,7 +20,7 @@ Manage resources for roles.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_create.md
+++ b/docs/auth0_roles_create.md
@@ -34,7 +34,7 @@ auth0 roles create -n myrole --description "awesome role"
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_delete.md
+++ b/docs/auth0_roles_delete.md
@@ -31,7 +31,7 @@ auth0 roles delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_list.md
+++ b/docs/auth0_roles_list.md
@@ -34,7 +34,7 @@ auth0 roles ls -n 100
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_permissions.md
+++ b/docs/auth0_roles_permissions.md
@@ -20,7 +20,7 @@ Manage permissions within the role resource.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_permissions_add.md
+++ b/docs/auth0_roles_permissions_add.md
@@ -36,7 +36,7 @@ auth0 roles permissions add
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_permissions_list.md
+++ b/docs/auth0_roles_permissions_list.md
@@ -32,7 +32,7 @@ auth0 roles permissions ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_permissions_remove.md
+++ b/docs/auth0_roles_permissions_remove.md
@@ -36,7 +36,7 @@ auth0 roles permissions rm
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_show.md
+++ b/docs/auth0_roles_show.md
@@ -31,7 +31,7 @@ auth0 roles show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_roles_update.md
+++ b/docs/auth0_roles_update.md
@@ -34,7 +34,7 @@ auth0 roles update <id> -n myrole --description "awesome role"
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules.md
+++ b/docs/auth0_rules.md
@@ -20,7 +20,7 @@ Manage resources for rules.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_create.md
+++ b/docs/auth0_rules_create.md
@@ -36,7 +36,7 @@ auth0 rules create -n "My Rule" -t "Empty rule" --enabled=false
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_delete.md
+++ b/docs/auth0_rules_delete.md
@@ -31,7 +31,7 @@ auth0 rules delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_disable.md
+++ b/docs/auth0_rules_disable.md
@@ -30,7 +30,7 @@ auth0 rules disable <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_enable.md
+++ b/docs/auth0_rules_enable.md
@@ -30,7 +30,7 @@ auth0 rules enable <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_list.md
+++ b/docs/auth0_rules_list.md
@@ -32,7 +32,7 @@ auth0 rules ls
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_show.md
+++ b/docs/auth0_rules_show.md
@@ -31,7 +31,7 @@ auth0 rules show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_rules_update.md
+++ b/docs/auth0_rules_update.md
@@ -34,7 +34,7 @@ auth0 rules update <id> -n "My Updated Rule" --enabled=false
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_tenants.md
+++ b/docs/auth0_tenants.md
@@ -20,7 +20,7 @@ Manage configured tenants.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_tenants_add.md
+++ b/docs/auth0_tenants_add.md
@@ -30,7 +30,7 @@ auth0 tenants add <tenant> --client-id <id> --client-secret <secret>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_tenants_list.md
+++ b/docs/auth0_tenants_list.md
@@ -30,7 +30,7 @@ auth0 tenants list
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_tenants_open.md
+++ b/docs/auth0_tenants_open.md
@@ -30,7 +30,7 @@ auth0 tenants open <tenant>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_tenants_use.md
+++ b/docs/auth0_tenants_use.md
@@ -30,7 +30,7 @@ auth0 tenants use <tenant>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_test.md
+++ b/docs/auth0_test.md
@@ -20,7 +20,7 @@ Try your Universal Login box or get a token.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_test_login.md
+++ b/docs/auth0_test_login.md
@@ -36,7 +36,7 @@ auth0 test login <client-id> --connection <connection>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_test_token.md
+++ b/docs/auth0_test_token.md
@@ -36,7 +36,7 @@ auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users.md
+++ b/docs/auth0_users.md
@@ -20,7 +20,7 @@ Manage resources for users.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_blocks.md
+++ b/docs/auth0_users_blocks.md
@@ -20,7 +20,7 @@ Manage brute-force protection user blocks.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_blocks_list.md
+++ b/docs/auth0_users_blocks_list.md
@@ -30,7 +30,7 @@ auth0 users blocks list <user-id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_create.md
+++ b/docs/auth0_users_create.md
@@ -38,7 +38,7 @@ auth0 users create -n "John Doe" -e john@example.com --connection "Username-Pass
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_delete.md
+++ b/docs/auth0_users_delete.md
@@ -31,7 +31,7 @@ auth0 users delete <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_import.md
+++ b/docs/auth0_users_import.md
@@ -39,7 +39,7 @@ auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --up
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_open.md
+++ b/docs/auth0_users_open.md
@@ -31,7 +31,7 @@ auth0 users open "auth0|xxxxxxxxxx"
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -36,7 +36,7 @@ auth0 users search -q name -s "name:1"
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_show.md
+++ b/docs/auth0_users_show.md
@@ -31,7 +31,7 @@ auth0 users show <id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_unblock.md
+++ b/docs/auth0_users_unblock.md
@@ -30,7 +30,7 @@ auth0 users unblock <user-id>
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/auth0_users_update.md
+++ b/docs/auth0_users_update.md
@@ -37,7 +37,7 @@ auth0 users update -n John Doe --email john.doe@example.com
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ Supercharge your development workflow.
 ```
       --debug           Enable debug mode.
       --force           Skip confirmation.
-      --format string   Command output format. Options: json.
   -h, --help            help for auth0
+      --json            Output in json format.
       --no-color        Disable colors.
       --no-input        Disable interactivity.
       --tenant string   Specific tenant to use.

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -94,7 +94,7 @@ cat data.json | auth0 api post clients`,
 	}
 
 	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		command.Flags().MarkHidden("format")
+		command.Flags().MarkHidden("json")
 		command.Parent().HelpFunc()(command, strings)
 	})
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,7 +70,7 @@ var errUnauthenticated = errors.New("Not logged in. Try 'auth0 login'.")
 //
 // In addition, it stores a reference to all the flags passed, e.g.:
 //
-// 1. --format
+// 1. --json
 // 2. --tenant
 // 3. --debug.
 type cli struct {
@@ -82,7 +82,7 @@ type cli struct {
 	// set of flags which are user specified.
 	debug   bool
 	tenant  string
-	format  string
+	json    bool
 	force   bool
 	noInput bool
 	noColor bool
@@ -439,30 +439,23 @@ func (c *cli) persistConfig() error {
 
 func (c *cli) init() error {
 	c.initOnce.Do(func() {
-		// Initialize the context -- e.g. the configuration
-		// information, tenants, etc.
 		if c.errOnce = c.initContext(); c.errOnce != nil {
 			return
 		}
+
 		c.renderer.Tenant = c.tenant
 
 		cobra.EnableCommandSorting = false
 	})
 
-	// Determine what the desired output format is.
-	//
-	// NOTE(cyx): Since this isn't expensive to do, we don't need to put it
-	// inside initOnce.
-	format := strings.ToLower(c.format)
-	if format != "" && format != string(display.OutputFormatJSON) {
-		return fmt.Errorf("Invalid format. Use `--format=json` or omit this option to use the default format.")
+	if c.json {
+		c.renderer.Format = display.OutputFormatJSON
 	}
-	c.renderer.Format = display.OutputFormat(format)
 
 	c.renderer.Tenant = c.tenant
 
-	// Once initialized, we'll keep returning the same err that was
-	// originally encountered.
+	// Once initialized, we'll keep returning the
+	// same err that was originally encountered.
 	return c.errOnce
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -151,8 +151,8 @@ func addPersistentFlags(rootCmd *cobra.Command, cli *cli) {
 	rootCmd.PersistentFlags().BoolVar(&cli.debug,
 		"debug", false, "Enable debug mode.")
 
-	rootCmd.PersistentFlags().StringVar(&cli.format,
-		"format", "", "Command output format. Options: json.")
+	rootCmd.PersistentFlags().BoolVar(&cli.json,
+		"json", false, "Output in json format.")
 
 	rootCmd.PersistentFlags().BoolVar(&cli.force,
 		"force", false, "Skip confirmation.")

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -88,22 +88,23 @@ func (r *Renderer) JSONResult(data interface{}) {
 }
 
 func (r *Renderer) Results(data []View) {
-	if len(data) > 0 {
-		switch r.Format {
-		case OutputFormatJSON:
-			var list []interface{}
-			for _, item := range data {
-				list = append(list, item.Object())
-			}
-			r.JSONResult(list)
+	if len(data) == 0 {
+		return
+	}
 
-		default:
-			rows := make([][]string, 0, len(data))
-			for _, d := range data {
-				rows = append(rows, d.AsTableRow())
-			}
-			writeTable(r.ResultWriter, data[0].AsTableHeader(), rows)
+	switch r.Format {
+	case OutputFormatJSON:
+		var list []interface{}
+		for _, item := range data {
+			list = append(list, item.Object())
 		}
+		r.JSONResult(list)
+	default:
+		rows := make([][]string, 0, len(data))
+		for _, d := range data {
+			rows = append(rows, d.AsTableRow())
+		}
+		writeTable(r.ResultWriter, data[0].AsTableHeader(), rows)
 	}
 }
 
@@ -111,7 +112,6 @@ func (r *Renderer) Result(data View) {
 	switch r.Format {
 	case OutputFormatJSON:
 		r.JSONResult(data.Object())
-
 	default:
 		// TODO(cyx): we're type asserting on the fly to prevent too
 		// many changes in other places. In the future we should

--- a/test/integration/scripts/get-api-id.sh
+++ b/test/integration/scripts/get-api-id.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-api=$( auth0 apis create --name integration-test-api-newapi --identifier http://integration-test-api-newapi --scopes read:todos --format json --no-input )
+api=$( auth0 apis create --name integration-test-api-newapi --identifier http://integration-test-api-newapi --scopes read:todos --json --no-input )
 
 mkdir -p ./test/integration/identifiers
 echo "$api" | jq -r '.["id"]' > ./test/integration/identifiers/api-id

--- a/test/integration/scripts/get-app-id.sh
+++ b/test/integration/scripts/get-app-id.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-app=$( auth0 apps create -n integration-test-app-newapp -t native --description NewApp --format json --no-input )
+app=$( auth0 apps create -n integration-test-app-newapp -t native --description NewApp --json --no-input )
 
 mkdir -p ./test/integration/identifiers
 echo "$app" | jq -r '.["client_id"]' > ./test/integration/identifiers/app-id

--- a/test/integration/scripts/get-role-id.sh
+++ b/test/integration/scripts/get-role-id.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-role=$( auth0 roles create -n integration-test-role-newRole -d integration-test-role --format json --no-input )
+role=$( auth0 roles create -n integration-test-role-newRole -d integration-test-role --json --no-input )
 
 mkdir -p ./test/integration/identifiers
 echo "$role" | jq -r '.["id"]' > ./test/integration/identifiers/role-id

--- a/test/integration/scripts/get-rule-id.sh
+++ b/test/integration/scripts/get-rule-id.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 json='{"name":"integration-test-rule-newRule","script":"function(user, context, cb) {\n  cb(null, user, context);\n}\n","enabled":false}'
-rule=$( echo "$json" | auth0 rules create --format json )
+rule=$( echo "$json" | auth0 rules create --json )
 
 mkdir -p ./test/integration/identifiers
 echo "$rule" | jq -r '.["id"]' > ./test/integration/identifiers/rule-id

--- a/test/integration/scripts/get-user-id.sh
+++ b/test/integration/scripts/get-user-id.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-user=$( auth0 users create -n integration-test-user-better -c Username-Password-Authentication -e newuser@example.com -p testUser12 --format json --no-input )
+user=$( auth0 users create -n integration-test-user-better -c Username-Password-Authentication -e newuser@example.com -p testUser12 --json --no-input )
 
 mkdir -p ./test/integration/identifiers
 echo "$user" | jq -r '.["user_id"]' > ./test/integration/identifiers/user-id

--- a/test/integration/scripts/test-cleanup.sh
+++ b/test/integration/scripts/test-cleanup.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-apps=$( auth0 apps list --format json --no-input )
+apps=$( auth0 apps list --json --no-input )
 
 for app in $( echo "${apps}" | jq -r '.[] | @base64' ); do
     _jq() {
@@ -18,7 +18,7 @@ for app in $( echo "${apps}" | jq -r '.[] | @base64' ); do
     fi
 done
 
-apis=$( auth0 apis list --format json --no-input )
+apis=$( auth0 apis list --json --no-input )
 
 for api in $( echo "${apis}" | jq -r '.[] | @base64' ); do
     _jq() {
@@ -37,7 +37,7 @@ for api in $( echo "${apis}" | jq -r '.[] | @base64' ); do
 done
 
 # using the search command since users have no list command
-users=$( auth0 users search -q "*"  --format json --no-input )
+users=$( auth0 users search -q "*"  --json --no-input )
 
 for user in $( echo "${users}" | jq -r '.[] | @base64' ); do
     _jq() {
@@ -53,7 +53,7 @@ for user in $( echo "${users}" | jq -r '.[] | @base64' ); do
     fi
 done
 
-roles=$( auth0 roles list --format json --no-input )
+roles=$( auth0 roles list --json --no-input )
 
 for role in $( echo "${roles}" | jq -r '.[] | @base64' ); do
     _jq() {
@@ -71,7 +71,7 @@ for role in $( echo "${roles}" | jq -r '.[] | @base64' ); do
     fi
 done
 
-rules=$( auth0 rules list --format json --no-input )
+rules=$( auth0 rules list --json --no-input )
 
 for rule in $( echo "${rules}" | jq -r '.[] | @base64' ); do
     _jq() {

--- a/test/integration/test-cases.yaml
+++ b/test/integration/test-cases.yaml
@@ -40,7 +40,7 @@ tests:
   
   # Test 'apps create' --type flag
   apps create type native and check data:
-    command: auth0 apps create --name integration-test-app-nativeapp1 --type native --description NativeApp1 --format json
+    command: auth0 apps create --name integration-test-app-nativeapp1 --type native --description NativeApp1 --json
     exit-code: 0
     stdout:
       json:
@@ -58,7 +58,7 @@ tests:
         - TYPE                 Native
 
   apps create type spa:
-    command: auth0 apps create --name integration-test-app-spaapp1 --type spa --description SpaApp1 --format json
+    command: auth0 apps create --name integration-test-app-spaapp1 --type spa --description SpaApp1 --json
     exit-code: 0
     stdout:
       json:
@@ -67,7 +67,7 @@ tests:
         app_type: spa
 
   apps create type regular:
-    command: auth0 apps create --name integration-test-app-regapp1 --type regular --description RegApp1 --format json
+    command: auth0 apps create --name integration-test-app-regapp1 --type regular --description RegApp1 --json
     exit-code: 0
     stdout:
       json:
@@ -76,7 +76,7 @@ tests:
         app_type: regular_web
 
   apps create type m2m:
-    command: auth0 apps create --name integration-test-app-m2mapp1 --type m2m --description M2mApp1 --format json
+    command: auth0 apps create --name integration-test-app-m2mapp1 --type m2m --description M2mApp1 --json
     exit-code: 0
     stdout:
       json:
@@ -86,7 +86,7 @@ tests:
 
   # Test 'apps create' --auth-method flag
   apps create type spa auth method none:
-    command: auth0 apps create --name integration-test-app-spaapp2 --type spa --description SpaApp2 --auth-method None --format json
+    command: auth0 apps create --name integration-test-app-spaapp2 --type spa --description SpaApp2 --auth-method None --json
     stdout:
       json:
         token_endpoint_auth_method: none
@@ -97,14 +97,14 @@ tests:
     exit-code: 1
 
   apps create type regular auth method post:
-    command: auth0 apps create --name integration-test-app-regapp2 --type regular --description RegApp2 --auth-method Post --format json
+    command: auth0 apps create --name integration-test-app-regapp2 --type regular --description RegApp2 --auth-method Post --json
     stdout:
       json:
         token_endpoint_auth_method: client_secret_post
     exit-code: 0
 
   apps create type regular auth method basic:
-    command: auth0 apps create --name integration-test-app-regapp3 --type regular --description RegApp3 --auth-method Basic --format json
+    command: auth0 apps create --name integration-test-app-regapp3 --type regular --description RegApp3 --auth-method Basic --json
     stdout:
       json:
         token_endpoint_auth_method: client_secret_basic
@@ -119,7 +119,7 @@ tests:
     exit-code: 0
 
   apps create type regular callbacks list:
-    command: auth0 apps create --name integration-test-app-regapp4 --type regular --description RegApp4 --callbacks https://example.com,https://google.com --format json
+    command: auth0 apps create --name integration-test-app-regapp4 --type regular --description RegApp4 --callbacks https://example.com,https://google.com --json
     stdout:
       json:
         callbacks: "[https://example.com https://google.com]"
@@ -134,14 +134,14 @@ tests:
     exit-code: 0
 
   apps create type spa grants:
-    command: auth0 apps create --name integration-test-app-spaapp3 --type spa --description SpaApp3 --grants refresh-token --format json
+    command: auth0 apps create --name integration-test-app-spaapp3 --type spa --description SpaApp3 --grants refresh-token --json
     stdout:
       json:
         grant_types: "[refresh_token]"
     exit-code: 0
 
   apps create type native grants:
-    command: auth0 apps create --name integration-test-app-nativeapp2 --type native --description NativeApp2 --grants refresh-token,code  --format json
+    command: auth0 apps create --name integration-test-app-nativeapp2 --type native --description NativeApp2 --grants refresh-token,code  --json
     stdout:
       json:
         grant_types: "[refresh_token authorization_code]"
@@ -153,7 +153,7 @@ tests:
 
   # Test 'apps create' --logout-urls flag
   apps create type regular logout urls:
-    command: auth0 apps create --name integration-test-app-regapp6 --type native --description RegularApp --logout-urls https://*.example.com/logout,https://example.com/logout --format json
+    command: auth0 apps create --name integration-test-app-regapp6 --type native --description RegularApp --logout-urls https://*.example.com/logout,https://example.com/logout --json
     stdout:
       json:
         allowed_logout_urls: "[https://*.example.com/logout https://example.com/logout]"
@@ -161,7 +161,7 @@ tests:
 
   # Test 'apps create' --origins flag
   apps create type regular origins:
-    command: auth0 apps create --name integration-test-app-regapp7 --type native --description RegularApp --origins https://*.example.com,https://example.com  --format json
+    command: auth0 apps create --name integration-test-app-regapp7 --type native --description RegularApp --origins https://*.example.com,https://example.com  --json
     stdout:
       json:
         allowed_origins: "[https://*.example.com https://example.com]"
@@ -169,7 +169,7 @@ tests:
 
   # Test 'apps create' --web-origins flag
   apps create type native web origins:
-    command: auth0 apps create --name integration-test-app-spaapp4 --type native --description SpaApp4 --web-origins https://example.com  --format json
+    command: auth0 apps create --name integration-test-app-spaapp4 --type native --description SpaApp4 --web-origins https://example.com  --json
     stdout:
       json:
         web_origins: "[https://example.com]"
@@ -181,7 +181,7 @@ tests:
     exit-code: 0
 
   apps show json:
-    command: auth0 apps show $(cat ./test/integration/identifiers/app-id) --format json # depends on "apps create test app" test
+    command: auth0 apps show $(cat ./test/integration/identifiers/app-id) --json # depends on "apps create test app" test
     stdout:
       json:
         name: integration-test-app-newapp
@@ -200,70 +200,70 @@ tests:
 
   # Test 'apps update'; all tests depend on "apps create test app" test
   apps update auth method:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --auth-method Basic --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --auth-method Basic --json
     stdout:
       json:
         token_endpoint_auth_method: client_secret_basic
     exit-code: 0
 
   apps update callbacks:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --callbacks https://example.com --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --callbacks https://example.com --json
     stdout:
       json:
         callbacks: "[https://example.com]"
     exit-code: 0
   
   apps update description:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --description "A better description" --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --description "A better description" --json
     stdout:
       json:
         description: A better description
     exit-code: 0
 
   apps update grants:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --grants code --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --grants code --json
     stdout:
       json:
         grant_types: "[authorization_code]"
     exit-code: 0
 
   apps update logout urls:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --logout-urls https://example.com --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --logout-urls https://example.com --json
     stdout:
       json:
         allowed_logout_urls: "[https://example.com]"
     exit-code: 0
 
   apps update name:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --name integration-test-app-betterAppName --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --name integration-test-app-betterAppName --json
     stdout:
       json:
         name: integration-test-app-betterAppName
     exit-code: 0
 
   apps update origins:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --origins https://example.com --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --origins https://example.com --json
     stdout:
       json:
         allowed_origins: "[https://example.com]"
     exit-code: 0
 
   apps update type:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --type spa --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --type spa --json
     stdout:
       json:
         app_type: spa
     exit-code: 0
 
   apps update web origins:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://example.com --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://example.com --json
     stdout:
       json:
         web_origins: "[https://example.com]"
     exit-code: 0
 
   apps update multiple updates:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://examples.com --type native --format json
+    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://examples.com --type native --json
     stdout:
       json:
         app_type: native
@@ -272,7 +272,7 @@ tests:
 
   # Test 'apis create'
   apis create and check data:
-    command: auth0 apis create --name integration-test-api-def1 --identifier http://integration-test-api-def1 --scopes read:todos,write:todos --format json
+    command: auth0 apis create --name integration-test-api-def1 --identifier http://integration-test-api-def1 --scopes read:todos,write:todos --json
     exit-code: 0
     stdout:
       json:
@@ -295,7 +295,7 @@ tests:
 
   # Test 'apis create' --token-lifetime flag
   apis create token lifetime 1000 and check data:
-    command: auth0 apis create --name integration-test-api-toklif1 --identifier http://integration-test-api-toklif1 --scopes read:todos --token-lifetime 1000 --format json
+    command: auth0 apis create --name integration-test-api-toklif1 --identifier http://integration-test-api-toklif1 --scopes read:todos --token-lifetime 1000 --json
     exit-code: 0
     stdout:
       json:
@@ -310,7 +310,7 @@ tests:
 
   # Test 'apis create' --offline-access flag
   apis create offline access true and check data:
-    command: auth0 apis create --name integration-test-api-offacc1 --identifier http://integration-test-api-offacc1 --scopes read:todos --offline-access --format json
+    command: auth0 apis create --name integration-test-api-offacc1 --identifier http://integration-test-api-offacc1 --scopes read:todos --offline-access --json
     exit-code: 0
     stdout:
       json:
@@ -324,7 +324,7 @@ tests:
         - ALLOW OFFLINE ACCESS  ✓
 
   apis create offline access false and check data:
-    command: auth0 apis create --name integration-test-api-offacc3 --identifier http://integration-test-api-offacc3 --scopes read:todos --offline-access=false --format json
+    command: auth0 apis create --name integration-test-api-offacc3 --identifier http://integration-test-api-offacc3 --scopes read:todos --offline-access=false --json
     exit-code: 0
     stdout:
       json:
@@ -336,7 +336,7 @@ tests:
     exit-code: 0
 
   apis show json:
-    command: auth0 apis show $(cat ./test/integration/identifiers/api-id) --format json # depends on "apis create test app" test
+    command: auth0 apis show $(cat ./test/integration/identifiers/api-id) --json # depends on "apis create test app" test
     stdout:
       json:
         name: integration-test-api-newapi
@@ -363,35 +363,35 @@ tests:
 
   # Test 'apis update'; all tests depend on "apis create test api" test
   apis update name:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --name integration-test-api-betterApiName --format json
+    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --name integration-test-api-betterApiName --json
     stdout:
       json:
         name: integration-test-api-betterApiName
     exit-code: 0
 
   apis update scopes:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --scopes read:todos,write:todos --format json
+    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --scopes read:todos,write:todos --json
     stdout:
       json:
         scopes: "[map[value:read:todos] map[value:write:todos]]"
     exit-code: 0
 
   apis update token lifetime:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --token-lifetime 1000 --format json
+    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --token-lifetime 1000 --json
     stdout:
       json:
         token_lifetime: "1000"
     exit-code: 0
 
   apis update offline access true:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access --format json
+    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access --json
     stdout:
       json:
         allow_offline_access: "true"
     exit-code: 0
 
   apis update offline access false:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access=false --format json
+    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access=false --json
     stdout:
       json:
         allow_offline_access: "false"
@@ -399,7 +399,7 @@ tests:
 
   # Test 'users create'
   users create and check data:
-    command: auth0 users create --name integration-test-user-new --connection Username-Password-Authentication --email testuser@example.com --password testUser12 --format json --no-input
+    command: auth0 users create --name integration-test-user-new --connection Username-Password-Authentication --email testuser@example.com --password testUser12 --json --no-input
     exit-code: 0
     stdout:
       json:
@@ -420,7 +420,7 @@ tests:
     exit-code: 0
 
   users show json:
-    command: auth0 users show $(cat ./test/integration/identifiers/user-id) --format json
+    command: auth0 users show $(cat ./test/integration/identifiers/user-id) --json
     stdout:
       json:
         email:      "newuser@example.com"
@@ -437,14 +437,14 @@ tests:
 
   # Test 'users update'
   users update email:
-    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --email betteruser@example.com  --format json --no-input
+    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --email betteruser@example.com  --json --no-input
     stdout:
       json:
         email: betteruser@example.com
     exit-code: 0
 
   users update name:
-    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --name integration-test-user-bettername  --format json --no-input
+    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --name integration-test-user-bettername  --json --no-input
     stdout:
       json:
         email: betteruser@example.com # Name is not being displayed, hence using email
@@ -452,7 +452,7 @@ tests:
 
     # Test 'roles create'
   roles create and check data:
-    command: auth0 roles create --name integration-test-role-new1 --description testRole --format json --no-input
+    command: auth0 roles create --name integration-test-role-new1 --description testRole --json --no-input
     exit-code: 0
     stdout:
       json:
@@ -473,7 +473,7 @@ tests:
     exit-code: 0
 
   roles show json:
-    command: auth0 roles show $(cat ./test/integration/identifiers/role-id) --format json
+    command: auth0 roles show $(cat ./test/integration/identifiers/role-id) --json
     stdout:
       json:
         name:        integration-test-role-newRole
@@ -490,14 +490,14 @@ tests:
 
   # Test 'roles update'
   roles update name:
-    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --name integration-test-role-betterName --format json
+    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --name integration-test-role-betterName --json
     stdout:
       json:
         name: integration-test-role-betterName
     exit-code: 0
 
   roles update description:
-    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --description betterDescription --format json
+    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --description betterDescription --json
     stdout:
       json:
         description: betterDescription
@@ -505,7 +505,7 @@ tests:
 
   # Test 'rules create'
   rules create and check data:
-    command: cat ./test/integration/fixtures/create-rule.json | jq '.[0]' | auth0 rules create --format json
+    command: cat ./test/integration/fixtures/create-rule.json | jq '.[0]' | auth0 rules create --json
     stdout:
       json:
         name: integration-test-rule-new1
@@ -530,7 +530,7 @@ tests:
     exit-code: 0
 
   rules show json:
-    command: auth0 rules show $(cat ./test/integration/identifiers/rule-id) --format json
+    command: auth0 rules show $(cat ./test/integration/identifiers/rule-id) --json
     stdout:
       json:
         name: integration-test-rule-newRule
@@ -549,7 +549,7 @@ tests:
 
   # Test 'rules update'
   rules update:
-    command: cat ./test/integration/fixtures/update-rule.json | auth0 rules update --format json
+    command: cat ./test/integration/fixtures/update-rule.json | auth0 rules update --json
     stdout:
       json:
         name: integration-test-rule-betterName
@@ -558,7 +558,7 @@ tests:
 
   # Test 'rules enable'
   rules enable:
-    command: auth0 rules enable $(cat ./test/integration/identifiers/rule-id) --format json
+    command: auth0 rules enable $(cat ./test/integration/identifiers/rule-id) --json
     stdout:
       json:
         enabled: "true"
@@ -566,7 +566,7 @@ tests:
 
   # Test 'rules disable'
   rules disable:
-    command: auth0 rules disable $(cat ./test/integration/identifiers/rule-id) --format json
+    command: auth0 rules disable $(cat ./test/integration/identifiers/rule-id) --json
     stdout:
       json:
         enabled: "false"


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Currently, the `--format` flag only has a single option for formatting output in JSON. In this PR we are consolidating that into a single `--json` boolean flag. The `--json` flag is considered a standard (see [CLI guidelines](https://clig.dev/#output)). 

This change does not preclude the ability to add more format types over time, although no major formats are omitted, only other potential option would be `--csv` perhaps.

> **Warning**
This PR will get merged into the v1 branch and not within main.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
