### PR TITLE
DXCDT-288: Add perms alias for permissions subcommand

### DIFF
--- a/internal/cli/roles_permissions.go
+++ b/internal/cli/roles_permissions.go
@@ -32,9 +32,10 @@ var (
 
 func rolePermissionsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "permissions",
-		Short: "Manage permissions within the role resource",
-		Long:  "Manage permissions within the role resource.",
+		Use:     "permissions",
+		Short:   "Manage permissions within the role resource",
+		Long:    "Manage permissions within the role resource.",
+		Aliases: []string{"perms"},
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The auth0 roles permissions command is very long to type out. A shorter alias is added for brevity. 

Example: `auth0 roles perms`

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
