### PR TITLE
DXCDT-286: Hide global flags from commands when not applicable

### DIFF
--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -405,6 +405,11 @@ auth0 actions delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd
@@ -480,6 +485,11 @@ func openActionCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -401,6 +401,11 @@ auth0 apis delete <id|audience>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd
@@ -451,6 +456,11 @@ auth0 apis open <id|audience>`,
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -188,7 +188,13 @@ func useAppCmd(cli *cli) *cobra.Command {
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	appNone.RegisterBool(cmd, &inputs.None, false)
+
 	return cmd
 }
 
@@ -323,6 +329,11 @@ auth0 apps delete <id>`,
 			})
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
@@ -704,6 +715,11 @@ func openAppCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -338,6 +338,11 @@ auth0 branding domains delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -733,6 +733,11 @@ auth0 logs streams delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd
@@ -763,6 +768,11 @@ func openLogStreamsCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -33,6 +33,7 @@ func loginCmd(cli *cli) *cobra.Command {
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		_ = cmd.Flags().MarkHidden("tenant")
+		_ = cmd.Flags().MarkHidden("json")
 		cmd.Parent().HelpFunc()(cmd, args)
 	})
 

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -57,5 +57,11 @@ func logoutCmd(cli *cli) *cobra.Command {
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("tenant")
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	return cmd
 }

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -429,6 +429,11 @@ auth0 orgs delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd
@@ -459,6 +464,11 @@ func openOrganizationCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -302,6 +302,11 @@ auth0 roles delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -268,6 +268,11 @@ auth0 rules delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -115,6 +115,11 @@ func useTenantCmd(cli *cli) *cobra.Command {
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	return cmd
 }
 
@@ -147,6 +152,11 @@ func openTenantCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -346,6 +346,11 @@ auth0 users delete <id>`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 
 	return cmd
@@ -483,6 +488,11 @@ auth0 users open "auth0|xxxxxxxxxx"`,
 		},
 	}
 
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
+
 	return cmd
 }
 
@@ -569,6 +579,11 @@ func deleteUserBlocksCmd(cli *cli) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Flags().MarkHidden("json")
+		cmd.Parent().HelpFunc()(cmd, args)
+	})
 
 	return cmd
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

There are certain commands where the global flags confuse and pollute the help text as they are not applicable for certain commands. So in this PR we're cleaning them up. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
