### PR TITLE
DXCDT-293: Access token management for client credentials

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -183,7 +183,6 @@ func (c *cli) prepareTenant(ctx context.Context) (Tenant, error) {
 			}
 
 			t := Tenant{
-				Name:        t.Domain,
 				Domain:      t.Domain,
 				AccessToken: token.AccessToken,
 				ExpiresAt:   token.ExpiresAt,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -214,7 +214,6 @@ func (c *cli) prepareTenant(ctx context.Context) (Tenant, error) {
 			return t, nil
 		}
 
-		// persist the updated tenant with renewed access token
 		t.AccessToken = res.AccessToken
 		t.ExpiresAt = time.Now().Add(
 			time.Duration(res.ExpiresIn) * time.Second,

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -109,10 +108,8 @@ func RunLogin(ctx context.Context, cli *cli, expired bool) (Tenant, error) {
 		Name:        result.Tenant,
 		Domain:      result.Domain,
 		AccessToken: result.AccessToken,
-		ExpiresAt: time.Now().Add(
-			time.Duration(result.ExpiresIn) * time.Second,
-		),
-		Scopes: auth.RequiredScopes(),
+		ExpiresAt:   result.ExpiresAt,
+		Scopes:      auth.RequiredScopes(),
 	}
 
 	err = cli.addTenant(tenant)

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -222,9 +222,6 @@ func addTenantCmd(cli *cli) *cobra.Command {
 		},
 	}
 
-	tenantClientID.RegisterString(cmd, &inputs.ClientID, "")
-	tenantClientSecret.RegisterString(cmd, &inputs.ClientSecret, "")
-
 	return cmd
 }
 


### PR DESCRIPTION
### 🔧 Changes

The `api` command requires an access token to make authenticated management API requests. However, access tokens are not created for tenants authenticated via client credentials, only those authenticated via device code flow. This PR introduces the facilitation of access token management for tenants that are authenticated with client credentials.

Immediately, this work enables the above-mentioned `api` compatibility, however the intent is broader. This PR retrieves and stores the access token with client credentials. But more importantly, it standardizes both authentication processes and reduces the number of forks in the code to accommodate the two authentication mechanisms. but also lays the groundwork for code simplifications to occur later in time.


### 🔬 Testing

No tests created directly in this PR, IMO there is insufficient framework to facilitate them. However, the mechanism added will be tested before the running of all integration tests once #532 gets merged in.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
