### PR TITLE
[1/4] DXCDT-266: Move domains subcommand one level up the hierarchy

### DIFF
--- a/internal/cli/branding.go
+++ b/internal/cli/branding.go
@@ -84,7 +84,6 @@ func brandingCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(showBrandingCmd(cli))
 	cmd.AddCommand(updateBrandingCmd(cli))
 	cmd.AddCommand(templateCmd(cli))
-	cmd.AddCommand(customDomainsCmd(cli))
 	cmd.AddCommand(emailTemplateCmd(cli))
 	cmd.AddCommand(textsCmd(cli))
 	return cmd

--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -95,9 +95,9 @@ func listCustomDomainsCmd(cli *cli) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Short:   "List your custom domains",
 		Long: `List your existing custom domains. To create one try:
-auth0 branding domains create`,
-		Example: `auth0 branding domains list
-auth0 branding domains ls`,
+auth0 domains create`,
+		Example: `auth0 domains list
+auth0 domains ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var list []*management.CustomDomain
 
@@ -127,8 +127,8 @@ func showCustomDomainCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Show a custom domain",
 		Long:  "Show a custom domain.",
-		Example: `auth0 branding domains show 
-auth0 branding domains show <id>`,
+		Example: `auth0 domains show 
+auth0 domains show <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := customDomainID.Pick(cmd, &inputs.ID, cli.customDomainsPickerOptions)
@@ -171,8 +171,8 @@ func createCustomDomainCmd(cli *cli) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Create a custom domain",
 		Long:  "Create a custom domain.",
-		Example: `auth0 branding domains create 
-auth0 branding domains create <id>`,
+		Example: `auth0 domains create 
+auth0 domains create <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := customDomainDomain.Ask(cmd, &inputs.Domain, nil); err != nil {
 				return err
@@ -232,9 +232,9 @@ func updateCustomDomainCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Update a custom domain",
 		Long:  "Update a custom domain.",
-		Example: `auth0 branding domains update
-auth0 branding domains update <id> --policy compatible
-auth0 branding domains update <id> -p compatible --ip-header "cf-connecting-ip"`,
+		Example: `auth0 domains update
+auth0 domains update <id> --policy compatible
+auth0 domains update <id> -p compatible --ip-header "cf-connecting-ip"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.CustomDomain
 
@@ -308,8 +308,8 @@ func deleteCustomDomainCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Delete a custom domain",
 		Long:  "Delete a custom domain.",
-		Example: `auth0 branding domains delete 
-auth0 branding domains delete <id>`,
+		Example: `auth0 domains delete 
+auth0 domains delete <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := customDomainID.Pick(cmd, &inputs.ID, cli.customDomainsPickerOptions)
@@ -358,8 +358,8 @@ func verifyCustomDomainCmd(cli *cli) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Verify a custom domain",
 		Long:  "Verify a custom domain.",
-		Example: `auth0 branding domains verify 
-auth0 branding domains verify <id>`,
+		Example: `auth0 domains verify 
+auth0 domains verify <id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := customDomainID.Pick(cmd, &inputs.ID, cli.customDomainsPickerOptions)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -177,6 +177,7 @@ func addSubcommands(rootCmd *cobra.Command, cli *cli) {
 	rootCmd.AddCommand(rolesCmd(cli))
 	rootCmd.AddCommand(organizationsCmd(cli))
 	rootCmd.AddCommand(brandingCmd(cli))
+	rootCmd.AddCommand(customDomainsCmd(cli))
 	rootCmd.AddCommand(ipsCmd(cli))
 	rootCmd.AddCommand(quickstartsCmd(cli))
 	rootCmd.AddCommand(attackProtectionCmd(cli))

--- a/internal/display/custom_domain.go
+++ b/internal/display/custom_domain.go
@@ -54,7 +54,7 @@ func (r *Renderer) CustomDomainList(customDomains []*management.CustomDomain) {
 
 	if len(customDomains) == 0 {
 		r.EmptyState(resource)
-		r.Infof("Use 'auth0 branding domains create' to add one")
+		r.Infof("Use 'auth0 domains create' to add one")
 		return
 	}
 

--- a/test/integration/test-cases.yaml
+++ b/test/integration/test-cases.yaml
@@ -29,7 +29,7 @@ tests:
   auth0 orgs list:
     exit-code: 0
 
-  auth0 branding domains list:
+  auth0 domains list:
     exit-code: 0
 
   auth0 quickstarts list:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Currently, there are several nested subcommands underneath the `auth0 branding` command. They include management options for page templates, custom domains, emails, and custom text prompts. 

This may impact discoverability as people are unaware of the association between branding and these subcommands. To address this we are extracting the domains cmd to the root level.

> **Warning**
The docs are updated in the final PR: https://github.com/auth0/auth0-cli/pull/542

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- https://github.com/auth0/auth0-cli/pull/540
- https://github.com/auth0/auth0-cli/pull/541
- https://github.com/auth0/auth0-cli/pull/542

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
