### PR TITLE
DXCDT-271: Move bundle install out of make docs and into docs-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,9 @@ $(GO_BIN)/auth0:
 docs: docs-clean ## Build the documentation
 	@go run ./cmd/build_doc
 	@mv ./docs/auth0.md ./docs/index.md
-	@cd docs && bundle install
 
 docs-start: ## Start the doc site locally for testing purposes
-	@cd docs && bundle exec jekyll serve
+	@cd docs && bundle install && bundle exec jekyll serve
 
 docs-clean: ## Remove the documentation
 	@rm -f ./docs/auth0_*.md


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes the `/bin/sh: 1: bundle: not found` error within the ci step that checks if docs are generated. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
