### PR TITLE
DXCDT-303: Fix orgs update cmd

### DIFF
--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -229,15 +229,13 @@ func createOrganizationCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			orgMetadata := inputs.Metadata
-			if orgMetadata == nil {
-				orgMetadata = make(map[string]string)
-			}
-
 			o := &management.Organization{
 				Name:        &inputs.Name,
 				DisplayName: &inputs.DisplayName,
-				Metadata:    &orgMetadata,
+			}
+
+			if inputs.Metadata != nil {
+				o.Metadata = &inputs.Metadata
 			}
 
 			isLogoURLSet := len(inputs.LogoURL) > 0

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -229,10 +229,15 @@ func createOrganizationCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
+			orgMetadata := inputs.Metadata
+			if orgMetadata == nil {
+				orgMetadata = make(map[string]string)
+			}
+
 			o := &management.Organization{
 				Name:        &inputs.Name,
 				DisplayName: &inputs.DisplayName,
-				Metadata:    &inputs.Metadata,
+				Metadata:    &orgMetadata,
 			}
 
 			isLogoURLSet := len(inputs.LogoURL) > 0

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -344,7 +344,6 @@ func updateOrganizationCmd(cli *cli) *cobra.Command {
 			// re-hydrated by the SDK, which we'll use below during
 			// display.
 			o := &management.Organization{
-				ID:          current.ID,
 				DisplayName: &inputs.DisplayName,
 			}
 

--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -229,49 +229,42 @@ func createOrganizationCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			o := &management.Organization{
+			newOrg := &management.Organization{
 				Name:        &inputs.Name,
 				DisplayName: &inputs.DisplayName,
 			}
 
 			if inputs.Metadata != nil {
-				o.Metadata = &inputs.Metadata
+				newOrg.Metadata = &inputs.Metadata
 			}
 
-			isLogoURLSet := len(inputs.LogoURL) > 0
-			isAccentColorSet := len(inputs.AccentColor) > 0
-			isBackgroundColorSet := len(inputs.BackgroundColor) > 0
-			isAnyColorSet := isAccentColorSet || isBackgroundColorSet
+			branding := management.OrganizationBranding{}
+			if inputs.LogoURL != "" {
+				branding.LogoURL = &inputs.LogoURL
+			}
 
-			if isLogoURLSet || isAnyColorSet {
-				o.Branding = &management.OrganizationBranding{}
+			colors := make(map[string]string)
+			if inputs.AccentColor != "" {
+				colors[apiOrganizationColorPrimary] = inputs.AccentColor
+			}
+			if inputs.BackgroundColor != "" {
+				colors[apiOrganizationColorPageBackground] = inputs.BackgroundColor
+			}
+			if len(colors) > 0 {
+				branding.Colors = &colors
+			}
 
-				if isLogoURLSet {
-					o.Branding.LogoURL = &inputs.LogoURL
-				}
-
-				if isAnyColorSet {
-					colors := make(map[string]string)
-
-					if isAccentColorSet {
-						colors[apiOrganizationColorPrimary] = inputs.AccentColor
-					}
-
-					if isBackgroundColorSet {
-						colors[apiOrganizationColorPageBackground] = inputs.BackgroundColor
-					}
-
-					o.Branding.Colors = &colors
-				}
+			if branding.String() != "{}" {
+				newOrg.Branding = &branding
 			}
 
 			if err := ansi.Waiting(func() error {
-				return cli.api.Organization.Create(o)
+				return cli.api.Organization.Create(newOrg)
 			}); err != nil {
-				return fmt.Errorf("An unexpected error occurred while attempting to create an organization with name '%s': %w", inputs.Name, err)
+				return fmt.Errorf("failed to create an organization with name '%s': %w", inputs.Name, err)
 			}
 
-			cli.renderer.OrganizationCreate(o)
+			cli.renderer.OrganizationCreate(newOrg)
 			return nil
 		},
 	}
@@ -320,45 +313,42 @@ func updateOrganizationCmd(cli *cli) *cobra.Command {
 				}
 			}
 
-			var current *management.Organization
+			var oldOrg *management.Organization
 			err := ansi.Waiting(func() error {
 				var err error
-				current, err = cli.api.Organization.Read(inputs.ID)
+				oldOrg, err = cli.api.Organization.Read(inputs.ID)
 				return err
 			})
 			if err != nil {
-				return fmt.Errorf("Failed to fetch organization with ID: %s %v", inputs.ID, err)
+				return fmt.Errorf("failed to fetch organization with ID: %s %w", inputs.ID, err)
 			}
 
-			if err := organizationDisplay.AskU(cmd, &inputs.DisplayName, current.DisplayName); err != nil {
+			if err := organizationDisplay.AskU(cmd, &inputs.DisplayName, oldOrg.DisplayName); err != nil {
 				return err
 			}
 
 			if inputs.DisplayName == "" {
-				inputs.DisplayName = current.GetDisplayName()
+				inputs.DisplayName = oldOrg.GetDisplayName()
 			}
 
-			// Prepare organization payload for update. This will also be
-			// re-hydrated by the SDK, which we'll use below during
-			// display.
-			o := &management.Organization{
+			newOrg := &management.Organization{
 				DisplayName: &inputs.DisplayName,
 			}
 
 			isLogoURLSet := len(inputs.LogoURL) > 0
 			isAccentColorSet := len(inputs.AccentColor) > 0
 			isBackgroundColorSet := len(inputs.BackgroundColor) > 0
-			currentHasBranding := current.Branding != nil
-			currentHasColors := currentHasBranding && current.Branding.Colors != nil
+			currentHasBranding := oldOrg.Branding != nil
+			currentHasColors := currentHasBranding && oldOrg.Branding.Colors != nil
 			needToAddColors := isAccentColorSet || isBackgroundColorSet || currentHasColors
 
 			if isLogoURLSet || needToAddColors {
-				o.Branding = &management.OrganizationBranding{}
+				newOrg.Branding = &management.OrganizationBranding{}
 
 				if isLogoURLSet {
-					o.Branding.LogoURL = &inputs.LogoURL
+					newOrg.Branding.LogoURL = &inputs.LogoURL
 				} else if currentHasBranding {
-					o.Branding.LogoURL = current.Branding.LogoURL
+					newOrg.Branding.LogoURL = oldOrg.Branding.LogoURL
 				}
 
 				if needToAddColors {
@@ -366,33 +356,32 @@ func updateOrganizationCmd(cli *cli) *cobra.Command {
 
 					if isAccentColorSet {
 						colors[apiOrganizationColorPrimary] = inputs.AccentColor
-					} else if currentHasColors && len(current.Branding.GetColors()[apiOrganizationColorPrimary]) > 0 {
-						colors[apiOrganizationColorPrimary] = current.Branding.GetColors()[apiOrganizationColorPrimary]
+					} else if currentHasColors && len(oldOrg.Branding.GetColors()[apiOrganizationColorPrimary]) > 0 {
+						colors[apiOrganizationColorPrimary] = oldOrg.Branding.GetColors()[apiOrganizationColorPrimary]
 					}
 
 					if isBackgroundColorSet {
 						colors[apiOrganizationColorPageBackground] = inputs.BackgroundColor
-					} else if currentHasColors && len(current.Branding.GetColors()[apiOrganizationColorPageBackground]) > 0 {
-						colors[apiOrganizationColorPageBackground] = current.Branding.GetColors()[apiOrganizationColorPageBackground]
+					} else if currentHasColors && len(oldOrg.Branding.GetColors()[apiOrganizationColorPageBackground]) > 0 {
+						colors[apiOrganizationColorPageBackground] = oldOrg.Branding.GetColors()[apiOrganizationColorPageBackground]
 					}
 
-					o.Branding.Colors = &colors
+					newOrg.Branding.Colors = &colors
 				}
 			}
 
-			if len(inputs.Metadata) == 0 {
-				o.Metadata = current.Metadata
-			} else {
-				o.Metadata = &inputs.Metadata
+			newOrg.Metadata = oldOrg.Metadata
+			if len(inputs.Metadata) != 0 {
+				newOrg.Metadata = &inputs.Metadata
 			}
 
 			if err = ansi.Waiting(func() error {
-				return cli.api.Organization.Update(inputs.ID, o)
+				return cli.api.Organization.Update(inputs.ID, newOrg)
 			}); err != nil {
 				return err
 			}
 
-			cli.renderer.OrganizationUpdate(o)
+			cli.renderer.OrganizationUpdate(newOrg)
 			return nil
 		},
 	}

--- a/test/integration/scripts/get-org-id.sh
+++ b/test/integration/scripts/get-org-id.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+org=$( auth0 orgs create -n integration-test-org-better -d "Integration Test Better Organization" --json --no-input )
+
+mkdir -p ./test/integration/identifiers
+echo "$org" | jq -r '.["id"]' > ./test/integration/identifiers/org-id

--- a/test/integration/scripts/test-cleanup.sh
+++ b/test/integration/scripts/test-cleanup.sh
@@ -88,3 +88,19 @@ for rule in $( echo "${rules}" | jq -r '.[] | @base64' ); do
         $( auth0 rules delete "$id")
     fi
 done
+
+orgs=$( auth0 orgs list --json --no-input )
+
+for org in $( echo "${orgs}" | jq -r '.[] | @base64' ); do
+    _jq() {
+     echo "${org}" | base64 --decode | jq -r "${1}"
+    }
+
+    id=$(_jq '.id')
+    name=$(_jq '.name')
+    if [[ $name = integration-test-org-* ]]
+    then
+        echo deleting "$name"
+        $( auth0 orgs delete "$id")
+    fi
+done

--- a/test/integration/test-cases.yaml
+++ b/test/integration/test-cases.yaml
@@ -450,7 +450,7 @@ tests:
         email: betteruser@example.com # Name is not being displayed, hence using email
     exit-code: 0
 
-    # Test 'roles create'
+  # Test 'roles create'
   roles create and check data:
     command: auth0 roles create --name integration-test-role-new1 --description testRole --json --no-input
     exit-code: 0
@@ -664,3 +664,49 @@ tests:
   api patch tenant settings with wrong json:
     command: auth0 api patch "tenants/settings" --data "{\"idle_session_lifetime:72}"
     exit-code: 1
+
+  create organization and check json output:
+    command: auth0 orgs create --name integration-test-org-new --display "Integration Test Organization" --json --no-input
+    exit-code: 0
+    stdout:
+      json:
+        name: "integration-test-org-new"
+        display_name: "Integration Test Organization"
+
+  create organization and check table output:
+    command: auth0 orgs create --name integration-test-org-new2 --display "Integration Test Organization2" --no-input
+    exit-code: 0
+    stdout:
+      contains:
+        - NAME              integration-test-org-new2
+        - DISPLAY NAME      Integration Test Organization2
+
+  create organization to use in other tests:
+    command: ./test/integration/scripts/get-org-id.sh
+    exit-code: 0
+
+  show organization and check json output:
+    command: auth0 orgs show $(cat ./test/integration/identifiers/org-id) --json
+    exit-code: 0
+    stdout:
+      json:
+        name: "integration-test-org-better"
+        display_name: "Integration Test Better Organization"
+
+  show organization and check table output:
+    command: auth0 orgs show $(cat ./test/integration/identifiers/org-id)
+    exit-code: 0
+    stdout:
+      contains:
+        - NAME              integration-test-org-better
+        - DISPLAY NAME      Integration Test Better Organization
+
+  update organization:
+    command: auth0 orgs update $(cat ./test/integration/identifiers/org-id) -d "Integration Test Updated Organization" -a "#00FFAA" -b "#AA1166" --json --no-input
+    exit-code: 0
+    stdout:
+      json:
+        name: "integration-test-org-better"
+        display_name: "Integration Test Updated Organization"
+        branding.colors.page_background: "#AA1166"
+        branding.colors.primary: "#00FFAA"


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes an issue with the `auth0 orgs update` cmd where by mistake the payload sent over to the Management API included as well the ID of the organization. This is the same issue as reported in #467.

Furthermore while fixing and testing the update I noticed an issue with the `auth0 orgs create` cmd as well where we were sending metadata as a null object even when not specified. 


### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

The PR adds additional tests using the commander test file. 

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
