### PR TITLE
DXCDT-315: Refactor log streams create and update cmds

### DIFF
--- a/docs/auth0_logs_streams.md
+++ b/docs/auth0_logs_streams.md
@@ -11,6 +11,6 @@ Auth0's log streaming service allows you to export tenant log events to a log ev
 - [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
+- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by ID
 - [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 

--- a/docs/auth0_logs_streams.md
+++ b/docs/auth0_logs_streams.md
@@ -12,5 +12,5 @@ Auth0's log streaming service allows you to export tenant log events to a log ev
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
 - [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
+- [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 

--- a/docs/auth0_logs_streams_create.md
+++ b/docs/auth0_logs_streams_create.md
@@ -3,79 +3,14 @@ layout: default
 ---
 # auth0 logs streams create
 
-Create a new log stream.
+Log Streaming allows you to export your events in near real-time. Choose an option below to configure.
 
-To create interactively, use `auth0 logs streams create` with no arguments.
+## Commands
 
-To create non-interactively, supply the log stream name, type and other information through the flags.
-
-## Usage
-```
-auth0 logs streams create [flags]
-```
-
-## Examples
-
-```
-  auth0 logs streams create
-
-  # Custom Webhook
-  auth0 logs streams create -n mylogstream -t http --http-type application/json --http-format JSONLINES --http-auth 1343434
-
-  # Datadog 
-  auth0 logs streams create -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
-
-  # EventBridge
-  auth0 logs streams create -n myeventbridge -t eventbridge --eventbridge-id 999999999999 --eventbridge-region us-east-1
-
-  # Splunk
-  auth0 logs streams create -n test-splunk -t splunk --splunk-domain demo.splunk.com --splunk-token 12a34ab5-c6d7-8901-23ef-456b7c89d0c1 --splunk-port 8080 --splunk-secure=true
-```
-
-
-## Flags
-
-```
-      --datadog-id string           The region in which datadog dashboard is created.
-                                    if you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
-      --datadog-key string          Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
-      --eventbridge-id string       Id of the AWS account.
-      --eventbridge-region string   The region in which eventbridge will be created.
-      --eventgrid-group string      The name of the Azure resource group.
-      --eventgrid-id string         Id of the Azure subscription.
-      --eventgrid-region string     The region in which the Azure subscription is hosted.
-      --http-auth string            HTTP Authorization header.
-      --http-endpoint string        HTTP endpoint.
-      --http-format string          HTTP Content-Format header. Possible values: jsonlines, jsonarray, jsonobject.
-      --http-type string            HTTP Content-Type header. Possible values: application/json.
-      --json                        Output in json format.
-  -n, --name string                 Name of the log stream.
-      --splunk-domain string        The domain name of the splunk instance.
-      --splunk-port string          The port of the HTTP event collector.
-      --splunk-secure               This should be set to 'false' when using self-signed certificates.
-      --splunk-token string         Splunk event collector token.
-      --sumo-source string          Generated URL for your defined HTTP source in Sumo Logic.
-  -t, --type string                 Type of the log stream. Possible values: http, eventbridge, eventgrid, datadog, splunk, sumo.
-```
-
-
-## InheritedFlags
-
-```
-      --debug           Enable debug mode.
-      --no-color        Disable colors.
-      --no-input        Disable interactivity.
-      --tenant string   Specific tenant to use.
-```
-
-
-## Related Commands
-
-- [auth0 logs streams create](auth0_logs_streams_create.md) - Create a new log stream
-- [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
-- [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
-- [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
-
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
 

--- a/docs/auth0_logs_streams_create.md
+++ b/docs/auth0_logs_streams_create.md
@@ -3,7 +3,7 @@ layout: default
 ---
 # auth0 logs streams create
 
-Log Streaming allows you to export your events in near real-time. Choose an option below to configure.
+Log Streaming allows you to export your events in near real-time.
 
 ## Commands
 

--- a/docs/auth0_logs_streams_create_datadog.md
+++ b/docs/auth0_logs_streams_create_datadog.md
@@ -1,0 +1,59 @@
+---
+layout: default
+---
+# auth0 logs streams create datadog
+
+Build interactive dashboards and get alerted on critical issues.
+
+To create interactively, use `auth0 logs streams create datadog` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create datadog [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams create datadog
+  auth0 logs streams create datadog --name <name>
+  auth0 logs streams create datadog --name <name> --region <region>
+  auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams create datadog -n <name> -r <region> -k <api-key>
+  auth0 logs streams create datadog -n mylogstream -r eu -k 121233123455 --json
+```
+
+
+## Flags
+
+```
+  -k, --api-key string   Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+      --json             Output in json format.
+  -n, --name string      The name of the log stream.
+  -r, --region string    The region in which the datadog dashboard is created.
+                         If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_create_eventbridge.md
+++ b/docs/auth0_logs_streams_create_eventbridge.md
@@ -1,0 +1,58 @@
+---
+layout: default
+---
+# auth0 logs streams create eventbridge
+
+Stream real-time Auth0 data to over 15 targets like AWS Lambda.
+
+To create interactively, use `auth0 logs streams create eventbridge` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create eventbridge [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams create eventbridge
+  auth0 logs streams create eventbridge --name <name>
+  auth0 logs streams create eventbridge --name <name> --aws-id <aws-id>
+  auth0 logs streams create eventbridge --name <name> --aws-id <aws-id> --aws-region <aws-region>
+  auth0 logs streams create eventbridge -n <name> -i <aws-id> -r <aws-region>
+  auth0 logs streams create eventbridge -n mylogstream -i 999999999999 -r "eu-west-1" --json
+```
+
+
+## Flags
+
+```
+  -i, --aws-id string       Id of the AWS account.
+  -r, --aws-region string   The AWS region in which eventbridge will be created, e.g. 'us-east-2'.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_create_eventbridge.md
+++ b/docs/auth0_logs_streams_create_eventbridge.md
@@ -29,7 +29,7 @@ auth0 logs streams create eventbridge [flags]
 ## Flags
 
 ```
-  -i, --aws-id string       Id of the AWS account.
+  -i, --aws-id string       ID of the AWS account.
   -r, --aws-region string   The AWS region in which eventbridge will be created, e.g. 'us-east-2'.
       --json                Output in json format.
   -n, --name string         The name of the log stream.

--- a/docs/auth0_logs_streams_create_eventgrid.md
+++ b/docs/auth0_logs_streams_create_eventgrid.md
@@ -1,0 +1,60 @@
+---
+layout: default
+---
+# auth0 logs streams create eventgrid
+
+A single service for routing events from any source to destination.
+
+To create interactively, use `auth0 logs streams create eventgrid` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create eventgrid [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams create eventgrid
+  auth0 logs streams create eventgrid --name <name>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> 
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group>
+  auth0 logs streams create eventgrid -n <name> -i <azure-id> -r <azure-region> -g <azure-group>
+  auth0 logs streams create eventgrid -n mylogstream -i "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5" -r northeurope -g "azure-logs-rg" --json
+```
+
+
+## Flags
+
+```
+  -g, --azure-group string    The name of the Azure resource group.
+  -i, --azure-id string       Id of the Azure subscription.
+  -r, --azure-region string   The region in which the Azure subscription is hosted.
+      --json                  Output in json format.
+  -n, --name string           The name of the log stream.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_create_http.md
+++ b/docs/auth0_logs_streams_create_http.md
@@ -1,0 +1,62 @@
+---
+layout: default
+---
+# auth0 logs streams create http
+
+Specify a URL you'd like Auth0 to post events to.
+
+To create interactively, use `auth0 logs streams create http` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create http [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams create http
+  auth0 logs streams create http --name <name>
+  auth0 logs streams create http --name <name> --endpoint <endpoint>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
+  auth0 logs streams create http -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
+  auth0 logs streams create http -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json
+```
+
+
+## Flags
+
+```
+  -a, --authorization string   Sent in the HTTP "Authorization" header with each request.
+  -e, --endpoint string        The HTTP endpoint to send streaming logs to.
+  -f, --format string          The format of data sent over HTTP. Options are "JSONLINES", "JSONARRAY" or "JSONOBJECT"
+      --json                   Output in json format.
+  -n, --name string            The name of the log stream.
+  -t, --type string            The "Content-Type" header to send over HTTP. Common value is "application/json".
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_create_splunk.md
+++ b/docs/auth0_logs_streams_create_splunk.md
@@ -1,0 +1,62 @@
+---
+layout: default
+---
+# auth0 logs streams create splunk
+
+Monitor real-time logs and display log analytics.
+
+To create interactively, use `auth0 logs streams create splunk` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create splunk [flags]
+```
+
+## Examples
+
+```
+  auth0 log streams create splunk
+  auth0 log streams create splunk --name <name>
+  auth0 log streams create splunk --name <name> --domain <domain>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json
+```
+
+
+## Flags
+
+```
+  -d, --domain string   The domain name of the splunk instance.
+      --json            Output in json format.
+  -n, --name string     The name of the log stream.
+  -p, --port string     The port of the HTTP event collector.
+  -s, --secure          This should be set to 'false' when using self-signed certificates.
+  -t, --token string    Splunk event collector token.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_create_sumo.md
+++ b/docs/auth0_logs_streams_create_sumo.md
@@ -1,0 +1,56 @@
+---
+layout: default
+---
+# auth0 logs streams create sumo
+
+Visualize logs and detect threats faster with security insights.
+
+To create interactively, use `auth0 logs streams create sumo` with no arguments.
+
+To create non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams create sumo [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams create sumo
+  auth0 logs streams create sumo --name <name>
+  auth0 logs streams create sumo --name <name> --source <source>
+  auth0 logs streams create sumo -n <name> -s <source>
+  auth0 logs streams create sumo -n "mylogstream" -s "demo.sumo.com" --json
+```
+
+
+## Flags
+
+```
+      --json            Output in json format.
+  -n, --name string     The name of the log stream.
+  -s, --source string   Generated URL for your defined HTTP source in Sumo Logic.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams create datadog](auth0_logs_streams_create_datadog.md) - Create a new Datadog log stream
+- [auth0 logs streams create eventbridge](auth0_logs_streams_create_eventbridge.md) - Create a new Amazon Event Bridge log stream
+- [auth0 logs streams create eventgrid](auth0_logs_streams_create_eventgrid.md) - Create a new Azure Event Grid log stream
+- [auth0 logs streams create http](auth0_logs_streams_create_http.md) - Create a new Custom Webhook log stream
+- [auth0 logs streams create splunk](auth0_logs_streams_create_splunk.md) - Create a new Splunk log stream
+- [auth0 logs streams create sumo](auth0_logs_streams_create_sumo.md) - Create a new Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_delete.md
+++ b/docs/auth0_logs_streams_delete.md
@@ -47,7 +47,7 @@ auth0 logs streams delete [flags]
 - [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
+- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by ID
 - [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_delete.md
+++ b/docs/auth0_logs_streams_delete.md
@@ -48,6 +48,6 @@ auth0 logs streams delete [flags]
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
 - [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
+- [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_list.md
+++ b/docs/auth0_logs_streams_list.md
@@ -43,6 +43,6 @@ auth0 logs streams list [flags]
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
 - [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
+- [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_list.md
+++ b/docs/auth0_logs_streams_list.md
@@ -42,7 +42,7 @@ auth0 logs streams list [flags]
 - [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
+- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by ID
 - [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_open.md
+++ b/docs/auth0_logs_streams_open.md
@@ -37,6 +37,6 @@ auth0 logs streams open [flags]
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
 - [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
+- [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_open.md
+++ b/docs/auth0_logs_streams_open.md
@@ -36,7 +36,7 @@ auth0 logs streams open [flags]
 - [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
+- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by ID
 - [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_show.md
+++ b/docs/auth0_logs_streams_show.md
@@ -42,7 +42,7 @@ auth0 logs streams show [flags]
 - [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
+- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by ID
 - [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_show.md
+++ b/docs/auth0_logs_streams_show.md
@@ -43,6 +43,6 @@ auth0 logs streams show [flags]
 - [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
 - [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
 - [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
+- [auth0 logs streams update](auth0_logs_streams_update.md) - Update an existing log stream
 
 

--- a/docs/auth0_logs_streams_update.md
+++ b/docs/auth0_logs_streams_update.md
@@ -3,7 +3,7 @@ layout: default
 ---
 # auth0 logs streams update
 
-
+Log Streaming allows you to export your events in near real-time.
 
 ## Commands
 

--- a/docs/auth0_logs_streams_update.md
+++ b/docs/auth0_logs_streams_update.md
@@ -3,73 +3,14 @@ layout: default
 ---
 # auth0 logs streams update
 
-Update a log stream.
-
-To update interactively, use `auth0 logs streams update` with no arguments.
-
-To update non-interactively, supply the log stream id, name, type and other information through the flags.
-
-## Usage
-```
-auth0 logs streams update [flags]
-```
-
-## Examples
-
-```
-  auth0 logs streams update
-  auth0 logs streams update <log-stream-id> --name mylogstream
-
-  # Custom Webhook
-  auth0 logs streams update <log-stream-id> -n mylogstream --type http
-  auth0 logs streams update <log-stream-id> -n mylogstream -t http --http-type application/json --http-format JSONLINES
-  
-  # Datadog
-  auth0 logs streams update <log-stream-id> -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
-  
-  # EventBridge
-  auth0 logs streams update <log-stream-id> -n myeventbridge -t eventbridge
-```
 
 
-## Flags
+## Commands
 
-```
-      --datadog-id string      The region in which datadog dashboard is created.
-                               if you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
-      --datadog-key string     Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
-      --http-auth string       HTTP Authorization header.
-      --http-endpoint string   HTTP endpoint.
-      --http-format string     HTTP Content-Format header. Possible values: jsonlines, jsonarray, jsonobject.
-      --http-type string       HTTP Content-Type header. Possible values: application/json.
-      --json                   Output in json format.
-  -n, --name string            Name of the log stream.
-      --splunk-domain string   The domain name of the splunk instance.
-      --splunk-port string     The port of the HTTP event collector.
-      --splunk-secure          This should be set to 'false' when using self-signed certificates.
-      --splunk-token string    Splunk event collector token.
-      --sumo-source string     Generated URL for your defined HTTP source in Sumo Logic.
-  -t, --type string            Type of the log stream. Possible values: http, eventbridge, eventgrid, datadog, splunk, sumo.
-```
-
-
-## InheritedFlags
-
-```
-      --debug           Enable debug mode.
-      --no-color        Disable colors.
-      --no-input        Disable interactivity.
-      --tenant string   Specific tenant to use.
-```
-
-
-## Related Commands
-
-- [auth0 logs streams create](auth0_logs_streams_create.md) - Create a new log stream
-- [auth0 logs streams delete](auth0_logs_streams_delete.md) - Delete a log stream
-- [auth0 logs streams list](auth0_logs_streams_list.md) - List all log streams
-- [auth0 logs streams open](auth0_logs_streams_open.md) - Open the settings page of a log stream
-- [auth0 logs streams show](auth0_logs_streams_show.md) - Show a log stream by Id
-- [auth0 logs streams update](auth0_logs_streams_update.md) - Update a log stream
-
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
 

--- a/docs/auth0_logs_streams_update_datadog.md
+++ b/docs/auth0_logs_streams_update_datadog.md
@@ -1,0 +1,59 @@
+---
+layout: default
+---
+# auth0 logs streams update datadog
+
+Build interactive dashboards and get alerted on critical issues.
+
+To update interactively, use `auth0 logs streams create datadog` with no arguments.
+
+To update non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams update datadog [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams update datadog
+  auth0 logs streams update datadog <log-stream-id> --name <name>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key>
+  auth0 logs streams update datadog <log-stream-id> -n mylogstream -r eu -k 121233123455 --json
+```
+
+
+## Flags
+
+```
+  -k, --api-key string   Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+      --json             Output in json format.
+  -n, --name string      The name of the log stream.
+  -r, --region string    The region in which the datadog dashboard is created.
+                         If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_update_eventbridge.md
+++ b/docs/auth0_logs_streams_update_eventbridge.md
@@ -1,0 +1,54 @@
+---
+layout: default
+---
+# auth0 logs streams update eventbridge
+
+Stream real-time Auth0 data to over 15 targets like AWS Lambda.
+
+To update interactively, use `auth0 logs streams create eventbridge` with no arguments.
+
+To update non-interactively, supply the log stream name through the flag.
+
+## Usage
+```
+auth0 logs streams update eventbridge [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams update eventbridge
+  auth0 logs streams update eventbridge <log-stream-id> --name <name>
+  auth0 logs streams update eventbridge <log-stream-id> -n <name>
+  auth0 logs streams update eventbridge <log-stream-id> -n mylogstream --json
+```
+
+
+## Flags
+
+```
+      --json          Output in json format.
+  -n, --name string   The name of the log stream.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_update_eventgrid.md
+++ b/docs/auth0_logs_streams_update_eventgrid.md
@@ -1,0 +1,54 @@
+---
+layout: default
+---
+# auth0 logs streams update eventgrid
+
+A single service for routing events from any source to destination.
+
+To update interactively, use `auth0 logs streams create eventgrid` with no arguments.
+
+To update non-interactively, supply the log stream name through the flag.
+
+## Usage
+```
+auth0 logs streams update eventgrid [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams update eventgrid
+  auth0 logs streams update eventgrid <log-stream-id> --name <name>
+  auth0 logs streams update eventgrid <log-stream-id> -n <name>
+  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream --json
+```
+
+
+## Flags
+
+```
+      --json          Output in json format.
+  -n, --name string   The name of the log stream.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_update_http.md
+++ b/docs/auth0_logs_streams_update_http.md
@@ -1,0 +1,62 @@
+---
+layout: default
+---
+# auth0 logs streams update http
+
+Specify a URL you'd like Auth0 to post events to.
+
+To update interactively, use `auth0 logs streams create http` with no arguments.
+
+To update non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams update http [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams update http
+  auth0 logs streams update http <log-stream-id> --name <name>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
+  auth0 logs streams update http <log-stream-id> -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
+  auth0 logs streams update http <log-stream-id> -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json
+```
+
+
+## Flags
+
+```
+  -a, --authorization string   Sent in the HTTP "Authorization" header with each request.
+  -e, --endpoint string        The HTTP endpoint to send streaming logs to.
+  -f, --format string          The format of data sent over HTTP. Options are "JSONLINES", "JSONARRAY" or "JSONOBJECT"
+      --json                   Output in json format.
+  -n, --name string            The name of the log stream.
+  -t, --type string            The "Content-Type" header to send over HTTP. Common value is "application/json".
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_update_splunk.md
+++ b/docs/auth0_logs_streams_update_splunk.md
@@ -1,0 +1,62 @@
+---
+layout: default
+---
+# auth0 logs streams update splunk
+
+Monitor real-time logs and display log analytics.
+
+To update interactively, use `auth0 logs streams create splunk` with no arguments.
+
+To update non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams update splunk [flags]
+```
+
+## Examples
+
+```
+  auth0 log streams update splunk
+  auth0 log streams update splunk <log-stream-id> --name <name>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json
+```
+
+
+## Flags
+
+```
+  -d, --domain string   The domain name of the splunk instance.
+      --json            Output in json format.
+  -n, --name string     The name of the log stream.
+  -p, --port string     The port of the HTTP event collector.
+  -s, --secure          This should be set to 'false' when using self-signed certificates.
+  -t, --token string    Splunk event collector token.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/docs/auth0_logs_streams_update_sumo.md
+++ b/docs/auth0_logs_streams_update_sumo.md
@@ -1,0 +1,56 @@
+---
+layout: default
+---
+# auth0 logs streams update sumo
+
+Visualize logs and detect threats faster with security insights.
+
+To update interactively, use `auth0 logs streams create sumo` with no arguments.
+
+To update non-interactively, supply the log stream name and other information through the flags.
+
+## Usage
+```
+auth0 logs streams update sumo [flags]
+```
+
+## Examples
+
+```
+  auth0 logs streams update sumo
+  auth0 logs streams update sumo <log-stream-id> --name <name>
+  auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>
+  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source>
+  auth0 logs streams update sumo <log-stream-id> -n "mylogstream" -s "demo.sumo.com" --json
+```
+
+
+## Flags
+
+```
+      --json            Output in json format.
+  -n, --name string     The name of the log stream.
+  -s, --source string   Generated URL for your defined HTTP source in Sumo Logic.
+```
+
+
+## InheritedFlags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 logs streams update datadog](auth0_logs_streams_update_datadog.md) - Update an existing Datadog log stream
+- [auth0 logs streams update eventbridge](auth0_logs_streams_update_eventbridge.md) - Update an existing Amazon Event Bridge log stream
+- [auth0 logs streams update eventgrid](auth0_logs_streams_update_eventgrid.md) - Update an existing Azure Event Grid log stream
+- [auth0 logs streams update http](auth0_logs_streams_update_http.md) - Update an existing Custom Webhook log stream
+- [auth0 logs streams update splunk](auth0_logs_streams_update_splunk.md) - Update an existing Splunk log stream
+- [auth0 logs streams update sumo](auth0_logs_streams_update_sumo.md) - Update an existing Sumo Logic log stream
+
+

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -47,8 +47,8 @@ func logStreamsCmd(cli *cli) *cobra.Command {
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
 	cmd.AddCommand(listLogStreamsCmd(cli))
+	cmd.AddCommand(createLogStreamCmd(cli))
 	cmd.AddCommand(showLogStreamCmd(cli))
-	cmd.AddCommand(createLogStreamsCmd(cli))
 	cmd.AddCommand(updateLogStreamCmd(cli))
 	cmd.AddCommand(deleteLogStreamCmd(cli))
 	cmd.AddCommand(openLogStreamsCmd(cli))
@@ -96,7 +96,7 @@ func showLogStreamCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Args:  cobra.MaximumNArgs(1),
-		Short: "Show a log stream by Id",
+		Short: "Show a log stream by ID",
 		Long:  "Display information about a log stream.",
 		Example: `  auth0 logs streams show
   auth0 logs streams show <log-stream-id>
@@ -130,11 +130,11 @@ func showLogStreamCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
-func createLogStreamsCmd(cli *cli) *cobra.Command {
+func createLogStreamCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new log stream",
-		Long:  "Log Streaming allows you to export your events in near real-time. Choose an option below to configure.",
+		Long:  "Log Streaming allows you to export your events in near real-time.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
@@ -152,7 +152,7 @@ func updateLogStreamCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update an existing log stream",
-		Long:  "",
+		Long:  "Log Streaming allows you to export your events in near real-time.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -1,30 +1,29 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
-	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
 const (
-	logStreamTypeAmazonEventBridge = "eventbridge"
-	logStreamTypeAzureEventGrid    = "eventgrid"
-	logStreamTypeHTTP              = "http"
-	logStreamTypeDatadog           = "datadog"
-	logStreamTypeSplunk            = "splunk"
-	logStreamTypeSumo              = "sumo"
+	logStreamTypeAmazonEventBridge logStreamType = "eventbridge"
+	logStreamTypeAzureEventGrid    logStreamType = "eventgrid"
+	logStreamTypeHTTP              logStreamType = "http"
+	logStreamTypeDatadog           logStreamType = "datadog"
+	logStreamTypeSplunk            logStreamType = "splunk"
+	logStreamTypeSumo              logStreamType = "sumo"
 )
 
+type logStreamType string
+
 var (
-	logsID = Argument{
+	logStreamID = Argument{
 		Name: "Log stream ID",
 		Help: "Log stream ID",
 	}
@@ -32,118 +31,8 @@ var (
 		Name:         "Name",
 		LongForm:     "name",
 		ShortForm:    "n",
-		Help:         "Name of the log stream.",
+		Help:         "The name of the log stream.",
 		AlwaysPrompt: true,
-	}
-	logStreamType = Flag{
-		Name:       "Type",
-		LongForm:   "type",
-		ShortForm:  "t",
-		Help:       "Type of the log stream. Possible values: http, eventbridge, eventgrid, datadog, splunk, sumo.",
-		IsRequired: true,
-	}
-	typeOptions = []string{
-		"HTTP",
-		"EventBridge",
-		"EventGrid",
-		"DataDog",
-		"Splunk",
-		"Sumo",
-	}
-	httpEndpoint = Flag{
-		Name:       "HTTP Endpoint",
-		LongForm:   "http-endpoint",
-		Help:       "HTTP endpoint.",
-		IsRequired: true,
-	}
-	httpContentType = Flag{
-		Name:         "HTTP Content Type",
-		LongForm:     "http-type",
-		Help:         "HTTP Content-Type header. Possible values: application/json.",
-		AlwaysPrompt: true,
-	}
-	httpContentFormat = Flag{
-		Name:         "HTTP Content Format",
-		LongForm:     "http-format",
-		Help:         "HTTP Content-Format header. Possible values: jsonlines, jsonarray, jsonobject.",
-		AlwaysPrompt: true,
-	}
-	httpAuthorization = Flag{
-		Name:         "HTTP Authorization",
-		LongForm:     "http-auth",
-		Help:         "HTTP Authorization header.",
-		AlwaysPrompt: true,
-	}
-	awsAccountID = Flag{
-		Name:       "AWS Account ID",
-		LongForm:   "eventbridge-id",
-		Help:       "Id of the AWS account.",
-		IsRequired: true,
-	}
-	awsRegion = Flag{
-		Name:       "AWS Region",
-		LongForm:   "eventbridge-region",
-		Help:       "The region in which eventbridge will be created.",
-		IsRequired: true,
-	}
-	azureSubscriptionID = Flag{
-		Name:       "Azure Subscription ID",
-		LongForm:   "eventgrid-id",
-		Help:       "Id of the Azure subscription.",
-		IsRequired: true,
-	}
-	azureRegion = Flag{
-		Name:       "Azure Region",
-		LongForm:   "eventgrid-region",
-		Help:       "The region in which the Azure subscription is hosted.",
-		IsRequired: true,
-	}
-	azureResourceGroup = Flag{
-		Name:       "Azure Resource Group",
-		LongForm:   "eventgrid-group",
-		Help:       "The name of the Azure resource group.",
-		IsRequired: true,
-	}
-	datadogRegion = Flag{
-		Name:     "Datadog Region",
-		LongForm: "datadog-id",
-		Help: "The region in which datadog dashboard is created.\n" +
-			"if you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.",
-		IsRequired: true,
-	}
-	datadogApiKey = Flag{
-		Name:       "Datadog API Key",
-		LongForm:   "datadog-key",
-		Help:       "Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).",
-		IsRequired: true,
-	}
-	splunkDomain = Flag{
-		Name:       "Splunk Domain",
-		LongForm:   "splunk-domain",
-		Help:       "The domain name of the splunk instance.",
-		IsRequired: true,
-	}
-	splunkToken = Flag{
-		Name:       "Splunk Token",
-		LongForm:   "splunk-token",
-		Help:       "Splunk event collector token.",
-		IsRequired: true,
-	}
-	splunkPort = Flag{
-		Name:     "Splunk Port",
-		LongForm: "splunk-port",
-		Help:     "The port of the HTTP event collector.",
-	}
-	splunkVerifyTLS = Flag{
-		Name:     "Splunk Verify TLS",
-		LongForm: "splunk-secure",
-		Help:     "This should be set to 'false' when using self-signed certificates.",
-	}
-	sumoLogicSource = Flag{
-		Name:       "Sumo Logic Source",
-		LongForm:   "sumo-source",
-		Help:       "Generated URL for your defined HTTP source in Sumo Logic.",
-		IsRequired: true,
 	}
 )
 
@@ -159,7 +48,7 @@ func logStreamsCmd(cli *cli) *cobra.Command {
 	cmd.SetUsageTemplate(resourceUsageTemplate())
 	cmd.AddCommand(listLogStreamsCmd(cli))
 	cmd.AddCommand(showLogStreamCmd(cli))
-	cmd.AddCommand(createLogStreamCmd(cli))
+	cmd.AddCommand(createLogStreamsCmd(cli))
 	cmd.AddCommand(updateLogStreamCmd(cli))
 	cmd.AddCommand(deleteLogStreamCmd(cli))
 	cmd.AddCommand(openLogStreamsCmd(cli))
@@ -214,7 +103,7 @@ func showLogStreamCmd(cli *cli) *cobra.Command {
   auth0 logs streams show <log-stream-id> --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logsID.Ask(cmd, &inputs.ID)
+				err := logStreamID.Ask(cmd, &inputs.ID)
 				if err != nil {
 					return err
 				}
@@ -241,486 +130,38 @@ func showLogStreamCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
-func createLogStreamCmd(cli *cli) *cobra.Command {
-	var inputs struct {
-		Name                string
-		Type                string
-		HttpEndpoint        string
-		HttpContentType     string
-		HttpContentFormat   string
-		HttpAuthorization   string
-		SplunkDomain        string
-		SplunkToken         string
-		SplunkPort          string
-		SplunkVerifyTLS     bool
-		SumoLogicSource     string
-		DatadogAPIKey       string
-		DatadogRegion       string
-		AwsAccountID        string
-		AwsRegion           string
-		AzureSubscriptionID string
-		AzureRegion         string
-		AzureResourceGroup  string
-	}
-
+func createLogStreamsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Args:  cobra.NoArgs,
 		Short: "Create a new log stream",
-		Long: "Create a new log stream.\n\n" +
-			"To create interactively, use `auth0 logs streams create` with no arguments.\n\n" +
-			"To create non-interactively, supply the log stream name, type and other information " +
-			"through the flags.",
-		Example: `  auth0 logs streams create
-
-  # Custom Webhook
-  auth0 logs streams create -n mylogstream -t http --http-type application/json --http-format JSONLINES --http-auth 1343434
-
-  # Datadog 
-  auth0 logs streams create -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
-
-  # EventBridge
-  auth0 logs streams create -n myeventbridge -t eventbridge --eventbridge-id 999999999999 --eventbridge-region us-east-1
-
-  # Splunk
-  auth0 logs streams create -n test-splunk -t splunk --splunk-domain demo.splunk.com --splunk-token 12a34ab5-c6d7-8901-23ef-456b7c89d0c1 --splunk-port 8080 --splunk-secure=true`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Prompt for log stream name
-			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
-				return err
-			}
-
-			// Prompt for log stream type
-			if err := logStreamType.Select(cmd, &inputs.Type, typeOptions, nil); err != nil {
-				return err
-			}
-
-			logIsHttp := logsTypeFor(inputs.Type) == logStreamTypeHTTP
-			logIsSplunk := logsTypeFor(inputs.Type) == logStreamTypeSplunk
-			logIsSumo := logsTypeFor(inputs.Type) == logStreamTypeSumo
-			logIsDatadog := logsTypeFor(inputs.Type) == logStreamTypeDatadog
-			logIsEventbridge := logsTypeFor(inputs.Type) == logStreamTypeAmazonEventBridge
-			logIsEventgrid := logsTypeFor(inputs.Type) == logStreamTypeAzureEventGrid
-
-			// Load values into a fresh log stream instance
-			ls := &management.LogStream{
-				Name: &inputs.Name,
-				Type: auth0.String(logsTypeFor(inputs.Type)),
-			}
-
-			// Prompt for http sink details if type is http
-			if logIsHttp {
-				if err := httpEndpoint.Ask(cmd, &inputs.HttpEndpoint, nil); err != nil {
-					return err
-				}
-
-				if err := httpContentType.Ask(cmd, &inputs.HttpContentType, nil); err != nil {
-					return err
-				}
-
-				if err := httpContentFormat.Ask(cmd, &inputs.HttpContentFormat, nil); err != nil {
-					return err
-				}
-
-				if err := httpAuthorization.Ask(cmd, &inputs.HttpAuthorization, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkHTTP{
-					Authorization: &inputs.HttpAuthorization,
-					ContentType:   &inputs.HttpContentType,
-					ContentFormat: apiHTTPContentFormatFor(inputs.HttpContentFormat),
-					Endpoint:      &inputs.HttpEndpoint,
-				}
-			}
-
-			// Prompt for splunk sink details if log stream type is splunk
-			if logIsSplunk {
-				if err := splunkDomain.Ask(cmd, &inputs.SplunkDomain, nil); err != nil {
-					return err
-				}
-
-				if err := splunkToken.Ask(cmd, &inputs.SplunkToken, nil); err != nil {
-					return err
-				}
-
-				if err := splunkPort.Ask(cmd, &inputs.SplunkPort, nil); err != nil {
-					return err
-				}
-
-				if err := splunkVerifyTLS.AskBool(cmd, &inputs.SplunkVerifyTLS, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkSplunk{
-					Domain: &inputs.SplunkDomain,
-					Token:  &inputs.SplunkToken,
-					Port:   &inputs.SplunkPort,
-					Secure: &inputs.SplunkVerifyTLS,
-				}
-			}
-
-			// Prompt for sumo sink details if log stream type is sumo
-			if logIsSumo {
-				if err := sumoLogicSource.Ask(cmd, &inputs.SumoLogicSource, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkSumo{
-					SourceAddress: &inputs.SumoLogicSource,
-				}
-			}
-
-			// Prompt for datadog sink details if log stream type is datadog
-			if logIsDatadog {
-				if err := datadogApiKey.Ask(cmd, &inputs.DatadogAPIKey, nil); err != nil {
-					return err
-				}
-
-				if err := datadogRegion.Ask(cmd, &inputs.DatadogRegion, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkDatadog{
-					Region: &inputs.DatadogRegion,
-					APIKey: &inputs.DatadogAPIKey,
-				}
-			}
-
-			// Prompt for eventbridge sink details if log stream type is eventbridge
-			if logIsEventbridge {
-				if err := awsAccountID.Ask(cmd, &inputs.AwsAccountID, nil); err != nil {
-					return err
-				}
-
-				if err := awsRegion.Ask(cmd, &inputs.AwsRegion, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkAmazonEventBridge{
-					AccountID: &inputs.AwsAccountID,
-					Region:    &inputs.AwsRegion,
-				}
-			}
-
-			// Prompt for eventgrid sink details if log stream type is eventgrid
-			if logIsEventgrid {
-				if err := azureSubscriptionID.Ask(cmd, &inputs.AzureSubscriptionID, nil); err != nil {
-					return err
-				}
-
-				if err := azureRegion.Ask(cmd, &inputs.AzureRegion, nil); err != nil {
-					return err
-				}
-
-				if err := azureResourceGroup.Ask(cmd, &inputs.AzureResourceGroup, nil); err != nil {
-					return err
-				}
-
-				ls.Sink = &management.LogStreamSinkAzureEventGrid{
-					SubscriptionID: &inputs.AzureSubscriptionID,
-					ResourceGroup:  &inputs.AzureResourceGroup,
-					Region:         &inputs.AzureRegion,
-				}
-			}
-
-			// Create log stream
-			if err := ansi.Waiting(func() error {
-				return cli.api.LogStream.Create(ls)
-			}); err != nil {
-				return fmt.Errorf("Unable to create log stream: %v", err)
-			}
-
-			// Render log stream creation specific view
-			cli.renderer.LogStreamCreate(ls)
-			return nil
-		},
+		Long:  "Log Streaming allows you to export your events in near real-time. Choose an option below to configure.",
 	}
 
-	logStreamName.RegisterString(cmd, &inputs.Name, "")
-	logStreamType.RegisterString(cmd, &inputs.Type, "")
-	httpEndpoint.RegisterString(cmd, &inputs.HttpEndpoint, "")
-	httpContentType.RegisterString(cmd, &inputs.HttpContentType, "")
-	httpContentFormat.RegisterString(cmd, &inputs.HttpContentFormat, "")
-	httpAuthorization.RegisterString(cmd, &inputs.HttpAuthorization, "")
-	splunkDomain.RegisterString(cmd, &inputs.SplunkDomain, "")
-	splunkToken.RegisterString(cmd, &inputs.SplunkToken, "")
-	splunkPort.RegisterString(cmd, &inputs.SplunkPort, "")
-	splunkVerifyTLS.RegisterBool(cmd, &inputs.SplunkVerifyTLS, false)
-	sumoLogicSource.RegisterString(cmd, &inputs.SumoLogicSource, "")
-	datadogApiKey.RegisterString(cmd, &inputs.DatadogAPIKey, "")
-	datadogRegion.RegisterString(cmd, &inputs.DatadogRegion, "")
-	awsAccountID.RegisterString(cmd, &inputs.AwsAccountID, "")
-	awsRegion.RegisterString(cmd, &inputs.AwsRegion, "")
-	azureSubscriptionID.RegisterString(cmd, &inputs.AzureSubscriptionID, "")
-	azureRegion.RegisterString(cmd, &inputs.AzureRegion, "")
-	azureResourceGroup.RegisterString(cmd, &inputs.AzureResourceGroup, "")
-
-	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(createLogStreamsAmazonEventBridgeCmd(cli))
+	cmd.AddCommand(createLogStreamsAzureEventGridCmd(cli))
+	cmd.AddCommand(createLogStreamsCustomWebhookCmd(cli))
+	cmd.AddCommand(createLogStreamsDatadogCmd(cli))
+	cmd.AddCommand(createLogStreamsSplunkCmd(cli))
+	cmd.AddCommand(createLogStreamsSumoLogicCmd(cli))
 
 	return cmd
 }
 
 func updateLogStreamCmd(cli *cli) *cobra.Command {
-	var inputs struct {
-		ID                string
-		Name              string
-		Type              string
-		HttpEndpoint      string
-		HttpContentType   string
-		HttpContentFormat string
-		HttpAuthorization string
-		HttpCustomHeaders []string
-		SplunkDomain      string
-		SplunkToken       string
-		SplunkPort        string
-		SplunkVerifyTLS   bool
-		SumoLogicSource   string
-		DatadogAPIKey     string
-		DatadogRegion     string
-	}
-
 	cmd := &cobra.Command{
 		Use:   "update",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Update a log stream",
-		Long: "Update a log stream.\n\n" +
-			"To update interactively, use `auth0 logs streams update` with no arguments.\n\n" +
-			"To update non-interactively, supply the log stream id, name, type and other " +
-			"information through the flags.",
-		Example: `  auth0 logs streams update
-  auth0 logs streams update <log-stream-id> --name mylogstream
-
-  # Custom Webhook
-  auth0 logs streams update <log-stream-id> -n mylogstream --type http
-  auth0 logs streams update <log-stream-id> -n mylogstream -t http --http-type application/json --http-format JSONLINES
-  
-  # Datadog
-  auth0 logs streams update <log-stream-id> -n mydatadog -t datadog --datadog-key 9999999 --datadog-id us
-  
-  # EventBridge
-  auth0 logs streams update <log-stream-id> -n myeventbridge -t eventbridge`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			var current *management.LogStream
-
-			if len(args) == 0 {
-				err := logsID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptions)
-				if err != nil {
-					return err
-				}
-			} else {
-				inputs.ID = args[0]
-			}
-
-			// Load log stream by id
-			if err := ansi.Waiting(func() error {
-				var err error
-				current, err = cli.api.LogStream.Read(inputs.ID)
-				return err
-			}); err != nil {
-				return fmt.Errorf("Unable to load logstream: %w", err)
-			}
-
-			// Prompt for log stream name
-			if err := logStreamName.AskU(cmd, &inputs.Name, current.Name); err != nil {
-				return err
-			}
-
-			logIsHttp := auth0.StringValue(current.Type) == logStreamTypeHTTP
-			logIsSplunk := auth0.StringValue(current.Type) == logStreamTypeSplunk
-			logIsSumo := auth0.StringValue(current.Type) == logStreamTypeSumo
-			logIsDatadog := auth0.StringValue(current.Type) == logStreamTypeDatadog
-
-			// Load values into a fresh log stream instance
-			ls := &management.LogStream{
-				Status: current.Status,
-			}
-
-			// Prompt for datadog sink details if log stream type is datadog
-			if logIsDatadog {
-				s := &management.LogStreamSinkDatadog{}
-
-				res := cli.getLogStreamSink(current.GetID())
-				if err := json.Unmarshal([]byte(res), s); err != nil {
-					fmt.Println(err)
-				}
-
-				if err := datadogApiKey.AskU(cmd, &inputs.DatadogAPIKey, s.APIKey); err != nil {
-					return err
-				}
-
-				if err := datadogRegion.AskU(cmd, &inputs.DatadogRegion, s.Region); err != nil {
-					return err
-				}
-
-				if len(inputs.DatadogAPIKey) > 0 {
-					s.APIKey = &inputs.DatadogAPIKey
-				}
-
-				if len(inputs.DatadogRegion) > 0 {
-					s.Region = &inputs.DatadogRegion
-				}
-
-				ls.Sink = &management.LogStreamSinkDatadog{
-					Region: s.Region,
-					APIKey: s.APIKey,
-				}
-			}
-
-			// Prompt for sumo sink details if log stream type is sumo
-			if logIsSumo {
-				s := &management.LogStreamSinkSumo{}
-
-				res := cli.getLogStreamSink(current.GetID())
-				if err := json.Unmarshal([]byte(res), s); err != nil {
-					fmt.Println(err)
-				}
-
-				if err := sumoLogicSource.AskU(cmd, &inputs.SumoLogicSource, s.SourceAddress); err != nil {
-					return err
-				}
-
-				if len(inputs.SumoLogicSource) > 0 {
-					s.SourceAddress = &inputs.SumoLogicSource
-				}
-
-				ls.Sink = &management.LogStreamSinkSumo{
-					SourceAddress: s.SourceAddress,
-				}
-			}
-
-			// Prompt for splunk sink details if log stream type is splunk
-			if logIsSplunk {
-				s := &management.LogStreamSinkSplunk{}
-
-				res := cli.getLogStreamSink(current.GetID())
-				if err := json.Unmarshal([]byte(res), s); err != nil {
-					fmt.Println(err)
-				}
-
-				if err := splunkDomain.AskU(cmd, &inputs.SplunkDomain, s.Domain); err != nil {
-					return err
-				}
-
-				if err := splunkToken.AskU(cmd, &inputs.SplunkToken, s.Token); err != nil {
-					return err
-				}
-
-				if err := splunkPort.AskU(cmd, &inputs.SplunkPort, s.Port); err != nil {
-					return err
-				}
-
-				if err := splunkVerifyTLS.AskBoolU(cmd, &inputs.SplunkVerifyTLS, s.Secure); err != nil {
-					return err
-				}
-
-				if len(inputs.SplunkDomain) > 0 {
-					s.Domain = &inputs.SplunkDomain
-				}
-
-				if len(inputs.SplunkToken) > 0 {
-					s.Token = &inputs.SplunkToken
-				}
-
-				if len(inputs.SplunkPort) > 0 {
-					s.Port = &inputs.SplunkPort
-				}
-
-				if !splunkVerifyTLS.IsSet(cmd) {
-					s.Secure = auth0.Bool(inputs.SplunkVerifyTLS)
-				}
-
-				ls.Sink = &management.LogStreamSinkSplunk{
-					Domain: s.Domain,
-					Token:  s.Token,
-					Port:   s.Port,
-					Secure: s.Secure,
-				}
-			}
-
-			// Prompt for http sink details if type is http
-			if logIsHttp {
-				s := &management.LogStreamSinkHTTP{}
-
-				res := cli.getLogStreamSink(current.GetID())
-				if err := json.Unmarshal([]byte(res), s); err != nil {
-					fmt.Println(err)
-				}
-
-				if err := httpEndpoint.AskU(cmd, &inputs.HttpEndpoint, s.Endpoint); err != nil {
-					return err
-				}
-
-				if err := httpContentType.AskU(cmd, &inputs.HttpContentType, s.ContentType); err != nil {
-					return err
-				}
-
-				if err := httpContentFormat.AskU(cmd, &inputs.HttpContentFormat, s.ContentFormat); err != nil {
-					return err
-				}
-
-				if err := httpAuthorization.AskU(cmd, &inputs.HttpAuthorization, s.Authorization); err != nil {
-					return err
-				}
-
-				if len(inputs.HttpEndpoint) > 0 {
-					s.Endpoint = &inputs.HttpEndpoint
-				}
-
-				if len(inputs.HttpContentType) > 0 {
-					s.ContentType = &inputs.HttpContentType
-				}
-
-				if len(inputs.HttpContentFormat) > 0 {
-					s.ContentFormat = apiHTTPContentFormatFor(inputs.HttpContentFormat)
-				}
-
-				if len(inputs.HttpAuthorization) > 0 {
-					s.Authorization = &inputs.HttpAuthorization
-				}
-
-				ls.Sink = &management.LogStreamSinkHTTP{
-					Authorization: s.Authorization,
-					ContentType:   s.ContentType,
-					ContentFormat: s.ContentFormat,
-					Endpoint:      s.Endpoint,
-				}
-			}
-
-			if len(inputs.Name) == 0 {
-				ls.Name = current.Name
-			} else {
-				ls.Name = &inputs.Name
-			}
-
-			// Update a log stream
-			if err := ansi.Waiting(func() error {
-				return cli.api.LogStream.Update(current.GetID(), ls)
-			}); err != nil {
-				return fmt.Errorf("Unable to update log stream: %v", err)
-			}
-
-			// Render log stream update specific view
-			cli.renderer.LogStreamUpdate(ls)
-			return nil
-		},
+		Short: "Update an existing log stream",
+		Long:  "",
 	}
 
-	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
-	logStreamType.RegisterStringU(cmd, &inputs.Type, "")
-	httpEndpoint.RegisterStringU(cmd, &inputs.HttpEndpoint, "")
-	httpContentType.RegisterStringU(cmd, &inputs.HttpContentType, "")
-	httpContentFormat.RegisterStringU(cmd, &inputs.HttpContentFormat, "")
-	httpAuthorization.RegisterStringU(cmd, &inputs.HttpAuthorization, "")
-	splunkDomain.RegisterStringU(cmd, &inputs.SplunkDomain, "")
-	splunkToken.RegisterStringU(cmd, &inputs.SplunkToken, "")
-	splunkPort.RegisterStringU(cmd, &inputs.SplunkPort, "")
-	splunkVerifyTLS.RegisterBoolU(cmd, &inputs.SplunkVerifyTLS, false)
-	sumoLogicSource.RegisterStringU(cmd, &inputs.SumoLogicSource, "")
-	datadogApiKey.RegisterStringU(cmd, &inputs.DatadogAPIKey, "")
-	datadogRegion.RegisterStringU(cmd, &inputs.DatadogRegion, "")
-
-	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(updateLogStreamsAmazonEventBridgeCmd(cli))
+	cmd.AddCommand(updateLogStreamsAzureEventGridCmd(cli))
+	cmd.AddCommand(updateLogStreamsCustomWebhookCmd(cli))
+	cmd.AddCommand(updateLogStreamsDatadogCmd(cli))
+	cmd.AddCommand(updateLogStreamsSplunkCmd(cli))
+	cmd.AddCommand(updateLogStreamsSumoLogicCmd(cli))
 
 	return cmd
 }
@@ -745,7 +186,7 @@ func deleteLogStreamCmd(cli *cli) *cobra.Command {
   auth0 logs streams delete <log-stream-id> --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logsID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptions)
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.allLogStreamsPickerOptions)
 				if err != nil {
 					return err
 				}
@@ -790,8 +231,7 @@ func openLogStreamsCmd(cli *cli) *cobra.Command {
   auth0 logs streams open <log-stream-id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logsID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptions)
-				if err != nil {
+				if err := logStreamID.Pick(cmd, &inputs.ID, cli.allLogStreamsPickerOptions); err != nil {
 					return err
 				}
 			} else {
@@ -799,6 +239,7 @@ func openLogStreamsCmd(cli *cli) *cobra.Command {
 			}
 
 			openManageURL(cli, cli.config.DefaultTenant, formatLogStreamSettingsPath(inputs.ID))
+
 			return nil
 		},
 	}
@@ -813,57 +254,44 @@ func formatLogStreamSettingsPath(id string) string {
 	return fmt.Sprintf("log-streams/%s/settings", id)
 }
 
-func (c *cli) logStreamPickerOptions() (pickerOptions, error) {
-	list, err := c.api.LogStream.List()
+func (c *cli) allLogStreamsPickerOptions() (pickerOptions, error) {
+	logStreams, err := c.api.LogStream.List()
 	if err != nil {
 		return nil, err
 	}
 
-	var opts pickerOptions
-
-	for _, c := range list {
-		value := c.GetID()
-		label := fmt.Sprintf("%s %s", c.GetName(), ansi.Faint("("+value+")"))
-		opts = append(opts, pickerOption{value: value, label: label})
+	var options pickerOptions
+	for _, logStream := range logStreams {
+		value := logStream.GetID()
+		label := fmt.Sprintf("%s %s", logStream.GetName(), ansi.Faint("("+value+")"))
+		options = append(options, pickerOption{value: value, label: label})
 	}
-
-	if len(opts) == 0 {
+	if len(options) == 0 {
 		return nil, errors.New("there are currently no log streams")
 	}
 
-	return opts, nil
+	return options, nil
 }
 
-func apiHTTPContentFormatFor(v string) *string {
-	return auth0.String(strings.ToUpper(v))
-}
+func (c *cli) logStreamPickerOptionsByType(desiredType logStreamType) pickerOptionsFunc {
+	return func() (pickerOptions, error) {
+		logStreams, err := c.api.LogStream.List()
+		if err != nil {
+			return nil, err
+		}
 
-func logsTypeFor(v string) string {
-	switch strings.ToLower(v) {
-	case "http":
-		return logStreamTypeHTTP
-	case "eventbridge", "amazon eventbridge":
-		return logStreamTypeAmazonEventBridge
-	case "eventgrid", "azure eventgrid":
-		return logStreamTypeAzureEventGrid
-	case "datadog":
-		return logStreamTypeDatadog
-	case "splunk":
-		return logStreamTypeSplunk
-	case "sumo":
-		return logStreamTypeSumo
-	default:
-		return v
+		var options pickerOptions
+		for _, logStream := range logStreams {
+			if logStream.GetType() == string(desiredType) {
+				value := logStream.GetID()
+				label := fmt.Sprintf("%s %s", logStream.GetName(), ansi.Faint("("+value+")"))
+				options = append(options, pickerOption{value: value, label: label})
+			}
+		}
+		if len(options) == 0 {
+			return nil, fmt.Errorf("there are currently no log streams of type: %s", desiredType)
+		}
+
+		return options, nil
 	}
-}
-
-// getLogStreamSink.
-func (c *cli) getLogStreamSink(id string) string {
-	conn, err := c.api.LogStream.Read(id)
-	if err != nil {
-		fmt.Println(err)
-	}
-	res := fmt.Sprintln(conn.Sink)
-
-	return res
 }

--- a/internal/cli/log_streams_datadog.go
+++ b/internal/cli/log_streams_datadog.go
@@ -19,6 +19,9 @@ var (
 			"If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.",
 		IsRequired: true,
 	}
+
+	datadogRegionOptions = []string{"eu", "us", "us3", "us5"}
+
 	datadogApiKey = Flag{
 		Name:       "Datadog API Key",
 		LongForm:   "api-key",
@@ -53,7 +56,7 @@ func createLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			if err := datadogRegion.Ask(cmd, &inputs.DatadogRegion, nil); err != nil {
+			if err := datadogRegion.Select(cmd, &inputs.DatadogRegion, datadogRegionOptions, nil); err != nil {
 				return err
 			}
 
@@ -135,7 +138,7 @@ func updateLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 
 			datadogSink := oldLogStream.Sink.(*management.LogStreamSinkDatadog)
 
-			if err := datadogRegion.AskU(cmd, &inputs.DatadogRegion, datadogSink.Region); err != nil {
+			if err := datadogRegion.SelectU(cmd, &inputs.DatadogRegion, datadogRegionOptions, datadogSink.Region); err != nil {
 				return err
 			}
 

--- a/internal/cli/log_streams_datadog.go
+++ b/internal/cli/log_streams_datadog.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	datadogRegion = Flag{
+		Name:      "Datadog Region",
+		LongForm:  "region",
+		ShortForm: "r",
+		Help: "The region in which the datadog dashboard is created.\n" +
+			"If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.",
+		IsRequired: true,
+	}
+	datadogApiKey = Flag{
+		Name:       "Datadog API Key",
+		LongForm:   "api-key",
+		ShortForm:  "k",
+		Help:       "Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).",
+		IsRequired: true,
+	}
+)
+
+func createLogStreamsDatadogCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name          string
+		DatadogAPIKey string
+		DatadogRegion string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "datadog",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Datadog log stream",
+		Long: "Build interactive dashboards and get alerted on critical issues.\n\n" +
+			"To create interactively, use `auth0 logs streams create datadog` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams create datadog
+  auth0 logs streams create datadog --name <name>
+  auth0 logs streams create datadog --name <name> --region <region>
+  auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams create datadog -n <name> -r <region> -k <api-key>
+  auth0 logs streams create datadog -n mylogstream -r eu -k 121233123455 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := datadogRegion.Ask(cmd, &inputs.DatadogRegion, nil); err != nil {
+				return err
+			}
+
+			if err := datadogApiKey.AskPassword(cmd, &inputs.DatadogAPIKey, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeDatadog)),
+				Sink: &management.LogStreamSinkDatadog{
+					Region: &inputs.DatadogRegion,
+					APIKey: &inputs.DatadogAPIKey,
+				},
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %v", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	datadogApiKey.RegisterString(cmd, &inputs.DatadogAPIKey, "")
+	datadogRegion.RegisterString(cmd, &inputs.DatadogRegion, "")
+
+	return cmd
+}
+
+func updateLogStreamsDatadogCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID            string
+		Name          string
+		DatadogAPIKey string
+		DatadogRegion string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "datadog",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Update an existing Datadog log stream",
+		Long: "Build interactive dashboards and get alerted on critical issues.\n\n" +
+			"To update interactively, use `auth0 logs streams create datadog` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams update datadog
+  auth0 logs streams update datadog <log-stream-id> --name <name>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key>
+  auth0 logs streams update datadog <log-stream-id> -n mylogstream -r eu -k 121233123455 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeDatadog))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			datadogSink := oldLogStream.Sink.(*management.LogStreamSinkDatadog)
+
+			if err := datadogRegion.AskU(cmd, &inputs.DatadogRegion, datadogSink.Region); err != nil {
+				return err
+			}
+
+			if err := datadogApiKey.AskPasswordU(cmd, &inputs.DatadogAPIKey, datadogSink.APIKey); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+			if inputs.DatadogRegion != "" {
+				datadogSink.Region = &inputs.DatadogRegion
+			}
+			if inputs.DatadogAPIKey != "" {
+				datadogSink.APIKey = &inputs.DatadogAPIKey
+			}
+
+			updatedLogStream.Sink = datadogSink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+	datadogApiKey.RegisterStringU(cmd, &inputs.DatadogAPIKey, "")
+	datadogRegion.RegisterStringU(cmd, &inputs.DatadogRegion, "")
+
+	return cmd
+}

--- a/internal/cli/log_streams_event_bridge.go
+++ b/internal/cli/log_streams_event_bridge.go
@@ -15,7 +15,7 @@ var (
 		Name:       "AWS Account ID",
 		LongForm:   "aws-id",
 		ShortForm:  "i",
-		Help:       "Id of the AWS account.",
+		Help:       "ID of the AWS account.",
 		IsRequired: true,
 	}
 	awsRegion = Flag{

--- a/internal/cli/log_streams_event_bridge.go
+++ b/internal/cli/log_streams_event_bridge.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	awsAccountID = Flag{
+		Name:       "AWS Account ID",
+		LongForm:   "aws-id",
+		ShortForm:  "i",
+		Help:       "Id of the AWS account.",
+		IsRequired: true,
+	}
+	awsRegion = Flag{
+		Name:       "AWS Region",
+		LongForm:   "aws-region",
+		ShortForm:  "r",
+		Help:       "The AWS region in which eventbridge will be created, e.g. 'us-east-2'.",
+		IsRequired: true,
+	}
+)
+
+func createLogStreamsAmazonEventBridgeCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name         string
+		AwsAccountID string
+		AwsRegion    string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "eventbridge",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Amazon Event Bridge log stream",
+		Long: "Stream real-time Auth0 data to over 15 targets like AWS Lambda.\n\n" +
+			"To create interactively, use `auth0 logs streams create eventbridge` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams create eventbridge
+  auth0 logs streams create eventbridge --name <name>
+  auth0 logs streams create eventbridge --name <name> --aws-id <aws-id>
+  auth0 logs streams create eventbridge --name <name> --aws-id <aws-id> --aws-region <aws-region>
+  auth0 logs streams create eventbridge -n <name> -i <aws-id> -r <aws-region>
+  auth0 logs streams create eventbridge -n mylogstream -i 999999999999 -r "eu-west-1" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := awsAccountID.Ask(cmd, &inputs.AwsAccountID, nil); err != nil {
+				return err
+			}
+
+			if err := awsRegion.Ask(cmd, &inputs.AwsRegion, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeAmazonEventBridge)),
+				Sink: &management.LogStreamSinkAmazonEventBridge{
+					AccountID: &inputs.AwsAccountID,
+					Region:    &inputs.AwsRegion,
+				},
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %w", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	awsAccountID.RegisterString(cmd, &inputs.AwsAccountID, "")
+	awsRegion.RegisterString(cmd, &inputs.AwsRegion, "")
+
+	return cmd
+}
+
+func updateLogStreamsAmazonEventBridgeCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID   string
+		Name string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "eventbridge",
+		Args:  cobra.NoArgs,
+		Short: "Update an existing Amazon Event Bridge log stream",
+		Long: "Stream real-time Auth0 data to over 15 targets like AWS Lambda.\n\n" +
+			"To update interactively, use `auth0 logs streams create eventbridge` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name through the flag.",
+		Example: `  auth0 logs streams update eventbridge
+  auth0 logs streams update eventbridge <log-stream-id> --name <name>
+  auth0 logs streams update eventbridge <log-stream-id> -n <name>
+  auth0 logs streams update eventbridge <log-stream-id> -n mylogstream --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeAmazonEventBridge))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+
+	return cmd
+}

--- a/internal/cli/log_streams_event_grid.go
+++ b/internal/cli/log_streams_event_grid.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	azureSubscriptionID = Flag{
+		Name:       "Azure Subscription ID",
+		LongForm:   "azure-id",
+		ShortForm:  "i",
+		Help:       "Id of the Azure subscription.",
+		IsRequired: true,
+	}
+	azureRegion = Flag{
+		Name:       "Azure Region",
+		LongForm:   "azure-region",
+		ShortForm:  "r",
+		Help:       "The region in which the Azure subscription is hosted.",
+		IsRequired: true,
+	}
+	azureResourceGroup = Flag{
+		Name:       "Azure Resource Group",
+		LongForm:   "azure-group",
+		ShortForm:  "g",
+		Help:       "The name of the Azure resource group.",
+		IsRequired: true,
+	}
+)
+
+func createLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name                string
+		AzureSubscriptionID string
+		AzureRegion         string
+		AzureResourceGroup  string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "eventgrid",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Azure Event Grid log stream",
+		Long: "A single service for routing events from any source to destination.\n\n" +
+			"To create interactively, use `auth0 logs streams create eventgrid` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams create eventgrid
+  auth0 logs streams create eventgrid --name <name>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> 
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group>
+  auth0 logs streams create eventgrid -n <name> -i <azure-id> -r <azure-region> -g <azure-group>
+  auth0 logs streams create eventgrid -n mylogstream -i "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5" -r northeurope -g "azure-logs-rg" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := azureSubscriptionID.Ask(cmd, &inputs.AzureSubscriptionID, nil); err != nil {
+				return err
+			}
+
+			if err := azureRegion.Ask(cmd, &inputs.AzureRegion, nil); err != nil {
+				return err
+			}
+
+			if err := azureResourceGroup.Ask(cmd, &inputs.AzureResourceGroup, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeAzureEventGrid)),
+				Sink: &management.LogStreamSinkAzureEventGrid{
+					SubscriptionID: &inputs.AzureSubscriptionID,
+					ResourceGroup:  &inputs.AzureResourceGroup,
+					Region:         &inputs.AzureRegion,
+				},
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %w", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	azureSubscriptionID.RegisterString(cmd, &inputs.AzureSubscriptionID, "")
+	azureRegion.RegisterString(cmd, &inputs.AzureRegion, "")
+	azureResourceGroup.RegisterString(cmd, &inputs.AzureResourceGroup, "")
+
+	return cmd
+}
+
+func updateLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID   string
+		Name string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "eventgrid",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Update an existing Azure Event Grid log stream",
+		Long: "A single service for routing events from any source to destination.\n\n" +
+			"To update interactively, use `auth0 logs streams create eventgrid` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name through the flag.",
+		Example: `  auth0 logs streams update eventgrid
+  auth0 logs streams update eventgrid <log-stream-id> --name <name>
+  auth0 logs streams update eventgrid <log-stream-id> -n <name>
+  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeAzureEventGrid))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+
+	return cmd
+}

--- a/internal/cli/log_streams_http.go
+++ b/internal/cli/log_streams_http.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	httpEndpoint = Flag{
+		Name:       "HTTP Endpoint",
+		LongForm:   "endpoint",
+		ShortForm:  "e",
+		Help:       "The HTTP endpoint to send streaming logs to.",
+		IsRequired: true,
+	}
+	httpContentType = Flag{
+		Name:         "HTTP Content Type",
+		LongForm:     "type",
+		ShortForm:    "t",
+		Help:         "The \"Content-Type\" header to send over HTTP. Common value is \"application/json\".",
+		AlwaysPrompt: true,
+	}
+	httpContentFormat = Flag{
+		Name:         "HTTP Content Format",
+		LongForm:     "format",
+		ShortForm:    "f",
+		Help:         "The format of data sent over HTTP. Options are \"JSONLINES\", \"JSONARRAY\" or \"JSONOBJECT\"",
+		AlwaysPrompt: true,
+	}
+	httpAuthorization = Flag{
+		Name:         "HTTP Authorization",
+		LongForm:     "authorization",
+		ShortForm:    "a",
+		Help:         "Sent in the HTTP \"Authorization\" header with each request.",
+		AlwaysPrompt: true,
+	}
+)
+
+func createLogStreamsCustomWebhookCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name              string
+		HttpEndpoint      string
+		HttpContentType   string
+		HttpContentFormat string
+		HttpAuthorization string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "http",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Custom Webhook log stream",
+		Long: "Specify a URL you'd like Auth0 to post events to.\n\n" +
+			"To create interactively, use `auth0 logs streams create http` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams create http
+  auth0 logs streams create http --name <name>
+  auth0 logs streams create http --name <name> --endpoint <endpoint>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
+  auth0 logs streams create http -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
+  auth0 logs streams create http -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := httpEndpoint.Ask(cmd, &inputs.HttpEndpoint, nil); err != nil {
+				return err
+			}
+
+			if err := httpContentType.Ask(cmd, &inputs.HttpContentType, nil); err != nil {
+				return err
+			}
+
+			if err := httpContentFormat.Ask(cmd, &inputs.HttpContentFormat, nil); err != nil {
+				return err
+			}
+
+			if err := httpAuthorization.AskPassword(cmd, &inputs.HttpAuthorization, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeHTTP)),
+			}
+			sink := &management.LogStreamSinkHTTP{
+				Endpoint: &inputs.HttpEndpoint,
+			}
+			if inputs.HttpAuthorization != "" {
+				sink.Authorization = &inputs.HttpAuthorization
+			}
+			if inputs.HttpContentType != "" {
+				sink.ContentType = &inputs.HttpContentType
+			}
+			if inputs.HttpContentFormat != "" {
+				sink.ContentFormat = apiHTTPContentFormatFor(inputs.HttpContentFormat)
+			}
+			newLogStream.Sink = sink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %v", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	httpEndpoint.RegisterString(cmd, &inputs.HttpEndpoint, "")
+	httpContentType.RegisterString(cmd, &inputs.HttpContentType, "")
+	httpContentFormat.RegisterString(cmd, &inputs.HttpContentFormat, "")
+	httpAuthorization.RegisterString(cmd, &inputs.HttpAuthorization, "")
+
+	return cmd
+}
+
+func updateLogStreamsCustomWebhookCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID                string
+		Name              string
+		HttpEndpoint      string
+		HttpContentType   string
+		HttpContentFormat string
+		HttpAuthorization string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "http",
+		Args:  cobra.NoArgs,
+		Short: "Update an existing Custom Webhook log stream",
+		Long: "Specify a URL you'd like Auth0 to post events to.\n\n" +
+			"To update interactively, use `auth0 logs streams create http` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams update http
+  auth0 logs streams update http <log-stream-id> --name <name>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
+  auth0 logs streams update http <log-stream-id> -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
+  auth0 logs streams update http <log-stream-id> -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeHTTP))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			httpSink := oldLogStream.Sink.(*management.LogStreamSinkHTTP)
+
+			if err := httpEndpoint.AskU(cmd, &inputs.HttpEndpoint, httpSink.Endpoint); err != nil {
+				return err
+			}
+			if err := httpContentType.AskU(cmd, &inputs.HttpContentType, httpSink.ContentType); err != nil {
+				return err
+			}
+			if err := httpContentFormat.AskU(cmd, &inputs.HttpContentFormat, httpSink.ContentFormat); err != nil {
+				return err
+			}
+			if err := httpAuthorization.AskPasswordU(cmd, &inputs.HttpAuthorization, httpSink.Authorization); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+			if inputs.HttpEndpoint != "" {
+				httpSink.Endpoint = &inputs.HttpEndpoint
+			}
+			if inputs.HttpAuthorization != "" {
+				httpSink.Authorization = &inputs.HttpAuthorization
+			}
+			if inputs.HttpContentType != "" {
+				httpSink.ContentType = &inputs.HttpContentType
+			}
+			if inputs.HttpContentFormat != "" {
+				httpSink.ContentFormat = apiHTTPContentFormatFor(inputs.HttpContentFormat)
+			}
+
+			updatedLogStream.Sink = httpSink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+	httpEndpoint.RegisterStringU(cmd, &inputs.HttpEndpoint, "")
+	httpContentType.RegisterStringU(cmd, &inputs.HttpContentType, "")
+	httpContentFormat.RegisterStringU(cmd, &inputs.HttpContentFormat, "")
+	httpAuthorization.RegisterStringU(cmd, &inputs.HttpAuthorization, "")
+
+	return cmd
+}
+
+func apiHTTPContentFormatFor(v string) *string {
+	return auth0.String(strings.ToUpper(v))
+}

--- a/internal/cli/log_streams_http.go
+++ b/internal/cli/log_streams_http.go
@@ -33,6 +33,9 @@ var (
 		Help:         "The format of data sent over HTTP. Options are \"JSONLINES\", \"JSONARRAY\" or \"JSONOBJECT\"",
 		AlwaysPrompt: true,
 	}
+
+	httpContentFormatOptions = []string{"JSONLINES", "JSONARRAY", "JSONOBJECT"}
+
 	httpAuthorization = Flag{
 		Name:         "HTTP Authorization",
 		LongForm:     "authorization",
@@ -79,7 +82,7 @@ func createLogStreamsCustomWebhookCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			if err := httpContentFormat.Ask(cmd, &inputs.HttpContentFormat, nil); err != nil {
+			if err := httpContentFormat.Select(cmd, &inputs.HttpContentFormat, httpContentFormatOptions, nil); err != nil {
 				return err
 			}
 
@@ -182,7 +185,7 @@ func updateLogStreamsCustomWebhookCmd(cli *cli) *cobra.Command {
 			if err := httpContentType.AskU(cmd, &inputs.HttpContentType, httpSink.ContentType); err != nil {
 				return err
 			}
-			if err := httpContentFormat.AskU(cmd, &inputs.HttpContentFormat, httpSink.ContentFormat); err != nil {
+			if err := httpContentFormat.SelectU(cmd, &inputs.HttpContentFormat, httpContentFormatOptions, httpSink.ContentFormat); err != nil {
 				return err
 			}
 			if err := httpAuthorization.AskPasswordU(cmd, &inputs.HttpAuthorization, httpSink.Authorization); err != nil {

--- a/internal/cli/log_streams_splunk.go
+++ b/internal/cli/log_streams_splunk.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	splunkDomain = Flag{
+		Name:       "Splunk Domain",
+		LongForm:   "domain",
+		ShortForm:  "d",
+		Help:       "The domain name of the splunk instance.",
+		IsRequired: true,
+	}
+	splunkToken = Flag{
+		Name:       "Splunk Token",
+		LongForm:   "token",
+		ShortForm:  "t",
+		Help:       "Splunk event collector token.",
+		IsRequired: true,
+	}
+	splunkPort = Flag{
+		Name:      "Splunk Port",
+		LongForm:  "port",
+		ShortForm: "p",
+		Help:      "The port of the HTTP event collector.",
+	}
+	splunkVerifyTLS = Flag{
+		Name:      "Splunk Verify TLS",
+		LongForm:  "secure",
+		ShortForm: "s",
+		Help:      "This should be set to 'false' when using self-signed certificates.",
+	}
+)
+
+func createLogStreamsSplunkCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name            string
+		SplunkDomain    string
+		SplunkToken     string
+		SplunkPort      string
+		SplunkVerifyTLS bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "splunk",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Splunk log stream",
+		Long: "Monitor real-time logs and display log analytics.\n\n" +
+			"To create interactively, use `auth0 logs streams create splunk` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 log streams create splunk
+  auth0 log streams create splunk --name <name>
+  auth0 log streams create splunk --name <name> --domain <domain>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := splunkDomain.Ask(cmd, &inputs.SplunkDomain, nil); err != nil {
+				return err
+			}
+
+			if err := splunkToken.Ask(cmd, &inputs.SplunkToken, nil); err != nil {
+				return err
+			}
+
+			if err := splunkPort.Ask(cmd, &inputs.SplunkPort, nil); err != nil {
+				return err
+			}
+
+			if err := splunkVerifyTLS.AskBool(cmd, &inputs.SplunkVerifyTLS, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeSplunk)),
+			}
+			sink := &management.LogStreamSinkSplunk{
+				Domain: &inputs.SplunkDomain,
+				Token:  &inputs.SplunkToken,
+				Secure: &inputs.SplunkVerifyTLS,
+			}
+			if inputs.SplunkPort != "" {
+				sink.Port = &inputs.SplunkPort
+			}
+			newLogStream.Sink = sink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %v", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	splunkDomain.RegisterString(cmd, &inputs.SplunkDomain, "")
+	splunkToken.RegisterString(cmd, &inputs.SplunkToken, "")
+	splunkPort.RegisterString(cmd, &inputs.SplunkPort, "")
+	splunkVerifyTLS.RegisterBool(cmd, &inputs.SplunkVerifyTLS, false)
+
+	return cmd
+}
+
+func updateLogStreamsSplunkCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID              string
+		Name            string
+		SplunkDomain    string
+		SplunkToken     string
+		SplunkPort      string
+		SplunkVerifyTLS bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "splunk",
+		Args:  cobra.NoArgs,
+		Short: "Update an existing Splunk log stream",
+		Long: "Monitor real-time logs and display log analytics.\n\n" +
+			"To update interactively, use `auth0 logs streams create splunk` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 log streams update splunk
+  auth0 log streams update splunk <log-stream-id> --name <name>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeSplunk))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			splunkSink := oldLogStream.Sink.(*management.LogStreamSinkSplunk)
+
+			if err := splunkDomain.AskU(cmd, &inputs.SplunkDomain, splunkSink.Domain); err != nil {
+				return err
+			}
+			if err := splunkToken.AskU(cmd, &inputs.SplunkToken, splunkSink.Token); err != nil {
+				return err
+			}
+			if err := splunkPort.AskU(cmd, &inputs.SplunkPort, splunkSink.Port); err != nil {
+				return err
+			}
+			if err := splunkVerifyTLS.AskBoolU(cmd, &inputs.SplunkVerifyTLS, splunkSink.Secure); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+			if inputs.SplunkDomain != "" {
+				splunkSink.Domain = &inputs.SplunkDomain
+			}
+			if inputs.SplunkToken != "" {
+				splunkSink.Token = &inputs.SplunkToken
+			}
+			if inputs.SplunkPort != "" {
+				splunkSink.Port = &inputs.SplunkPort
+			}
+			splunkSink.Secure = &inputs.SplunkVerifyTLS
+			updatedLogStream.Sink = splunkSink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+	splunkDomain.RegisterStringU(cmd, &inputs.SplunkDomain, "")
+	splunkToken.RegisterStringU(cmd, &inputs.SplunkToken, "")
+	splunkPort.RegisterStringU(cmd, &inputs.SplunkPort, "")
+	splunkVerifyTLS.RegisterBoolU(cmd, &inputs.SplunkVerifyTLS, false)
+
+	return cmd
+}

--- a/internal/cli/log_streams_sumo.go
+++ b/internal/cli/log_streams_sumo.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+var (
+	sumoLogicSource = Flag{
+		Name:       "Sumo Logic Source",
+		LongForm:   "source",
+		ShortForm:  "s",
+		Help:       "Generated URL for your defined HTTP source in Sumo Logic.",
+		IsRequired: true,
+	}
+)
+
+func createLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		Name            string
+		SumoLogicSource string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "sumo",
+		Args:  cobra.NoArgs,
+		Short: "Create a new Sumo Logic log stream",
+		Long: "Visualize logs and detect threats faster with security insights.\n\n" +
+			"To create interactively, use `auth0 logs streams create sumo` with no arguments.\n\n" +
+			"To create non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams create sumo
+  auth0 logs streams create sumo --name <name>
+  auth0 logs streams create sumo --name <name> --source <source>
+  auth0 logs streams create sumo -n <name> -s <source>
+  auth0 logs streams create sumo -n "mylogstream" -s "demo.sumo.com" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+				return err
+			}
+
+			if err := sumoLogicSource.Ask(cmd, &inputs.SumoLogicSource, nil); err != nil {
+				return err
+			}
+
+			newLogStream := &management.LogStream{
+				Name: &inputs.Name,
+				Type: auth0.String(string(logStreamTypeSumo)),
+				Sink: &management.LogStreamSinkSumo{
+					SourceAddress: &inputs.SumoLogicSource,
+				},
+			}
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Create(newLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to create log stream: %v", err)
+			}
+
+			cli.renderer.LogStreamCreate(newLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterString(cmd, &inputs.Name, "")
+	sumoLogicSource.RegisterString(cmd, &inputs.SumoLogicSource, "")
+
+	return cmd
+}
+
+func updateLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ID              string
+		Name            string
+		SumoLogicSource string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "sumo",
+		Args:  cobra.NoArgs,
+		Short: "Update an existing Sumo Logic log stream",
+		Long: "Visualize logs and detect threats faster with security insights.\n\n" +
+			"To update interactively, use `auth0 logs streams create sumo` with no arguments.\n\n" +
+			"To update non-interactively, supply the log stream name and other information through the flags.",
+		Example: `  auth0 logs streams update sumo
+  auth0 logs streams update sumo <log-stream-id> --name <name>
+  auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>
+  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source>
+  auth0 logs streams update sumo <log-stream-id> -n "mylogstream" -s "demo.sumo.com" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeSumo))
+				if err != nil {
+					return err
+				}
+			} else {
+				inputs.ID = args[0]
+			}
+
+			var oldLogStream *management.LogStream
+			if err := ansi.Waiting(func() (err error) {
+				oldLogStream, err = cli.api.LogStream.Read(inputs.ID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read log stream with ID %s: %w", inputs.ID, err)
+			}
+
+			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			sumoSink := oldLogStream.Sink.(*management.LogStreamSinkSumo)
+			if err := sumoLogicSource.AskU(cmd, &inputs.SumoLogicSource, sumoSink.SourceAddress); err != nil {
+				return err
+			}
+
+			updatedLogStream := &management.LogStream{}
+			if inputs.Name != "" {
+				updatedLogStream.Name = &inputs.Name
+			}
+			if inputs.SumoLogicSource != "" {
+				sumoSink.SourceAddress = &inputs.SumoLogicSource
+			}
+			updatedLogStream.Sink = sumoSink
+
+			if err := ansi.Waiting(func() error {
+				return cli.api.LogStream.Update(oldLogStream.GetID(), updatedLogStream)
+			}); err != nil {
+				return fmt.Errorf("failed to update log stream with ID %s: %w", oldLogStream.GetID(), err)
+			}
+
+			cli.renderer.LogStreamUpdate(updatedLogStream)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+	sumoLogicSource.RegisterStringU(cmd, &inputs.SumoLogicSource, "")
+
+	return cmd
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Refactoring `auth0 logs streams create|update` to have an extra subcommand to create a specific log stream type that only has a subset of the flags actually needed for that log stream e.g. `auth0 logs streams create datadog [flags]`.


https://user-images.githubusercontent.com/28300158/211884934-05cc3543-5c45-42b6-92b0-556b922d06f0.mov



<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
