### PR TITLE
[4/4] DXCDT-317: Add confirmation prompt on open editor updates

### DIFF
--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -310,9 +310,18 @@ func updateActionCmd(cli *cli) *cobra.Command {
 				&inputs.Code,
 				oldAction.GetCode(),
 				inputs.Name+".*.js",
-				cli.actionEditorHint,
 			); err != nil {
 				return fmt.Errorf("failed to capture input from the editor: %w", err)
+			}
+
+			if !cli.force && canPrompt(cmd) {
+				var confirmed bool
+				if err := prompt.AskBool("Do you want to save the action code?", &confirmed, true); err != nil {
+					return fmt.Errorf("failed to capture prompt input: %w", err)
+				}
+				if !confirmed {
+					return nil
+				}
 			}
 
 			updatedAction := &management.Action{
@@ -344,6 +353,7 @@ func updateActionCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 	actionName.RegisterStringU(cmd, &inputs.Name, "")
 	actionCode.RegisterStringU(cmd, &inputs.Code, "")
 	actionDependency.RegisterStringMapU(cmd, &inputs.Dependencies, nil)

--- a/internal/cli/email_templates.go
+++ b/internal/cli/email_templates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
 const (
@@ -211,9 +212,18 @@ func updateEmailTemplateCmd(cli *cli) *cobra.Command {
 				&inputs.Body,
 				oldTemplate.GetBody(),
 				inputs.Template+".*.liquid",
-				cli.emailTemplateEditorHint,
 			); err != nil {
 				return fmt.Errorf("failed to capture input from the editor: %w", err)
+			}
+
+			if !cli.force && canPrompt(cmd) {
+				var confirmed bool
+				if err := prompt.AskBool("Do you want to save the email template body?", &confirmed, true); err != nil {
+					return fmt.Errorf("failed to capture prompt input: %w", err)
+				}
+				if !confirmed {
+					return nil
+				}
 			}
 
 			if err := emailTemplateEnabled.AskBoolU(cmd, &inputs.Enabled, oldTemplate.Enabled); err != nil {
@@ -254,6 +264,7 @@ func updateEmailTemplateCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 	emailTemplateBody.RegisterStringU(cmd, &inputs.Body, "")
 	emailTemplateFrom.RegisterStringU(cmd, &inputs.From, "")
 	emailTemplateSubject.RegisterStringU(cmd, &inputs.Subject, "")

--- a/internal/cli/email_templates.go
+++ b/internal/cli/email_templates.go
@@ -275,10 +275,6 @@ func updateEmailTemplateCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
-func (c *cli) emailTemplateEditorHint() {
-	c.renderer.Infof("%s Once you close the editor, the email template will be saved. To cancel, press CTRL+C.", ansi.Faint("Hint:"))
-}
-
 func (c *cli) emailTemplatePickerOptions() (pickerOptions, error) {
 	return emailTemplateOptions, nil
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -94,7 +94,7 @@ func (f *Flag) OpenEditorW(cmd *cobra.Command, value *string, defaultValue, file
 	return openEditorFlag(cmd, f, value, defaultValue, filename, infoFn, tempFileFn, false)
 }
 
-func (f *Flag) OpenEditorU(cmd *cobra.Command, value *string, defaultValue string, filename string, infoFn func()) error {
+func (f *Flag) OpenEditorU(cmd *cobra.Command, value *string, defaultValue string, filename string) error {
 	return openEditorFlag(cmd, f, value, defaultValue, filename, nil, nil, true)
 }
 

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -352,10 +352,19 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 					&inputs.Script,
 					oldRule.GetScript(),
 					oldRule.GetName()+".*.js",
-					cli.ruleEditorHint,
 				)
 				if err != nil {
 					return fmt.Errorf("failed to capture input from the editor: %w", err)
+				}
+
+				if !cli.force && canPrompt(cmd) {
+					var confirmed bool
+					if err := prompt.AskBool("Do you want to save the rule script?", &confirmed, true); err != nil {
+						return fmt.Errorf("failed to capture prompt input: %w", err)
+					}
+					if !confirmed {
+						return nil
+					}
 				}
 
 				updatedRule.Enabled = &inputs.Enabled
@@ -381,6 +390,7 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 	ruleName.RegisterStringU(cmd, &inputs.Name, "")
 	ruleEnabled.RegisterBool(cmd, &inputs.Enabled, true)
 	ruleScript.RegisterStringU(cmd, &inputs.Script, "")


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The CLI asks for confirmation before an entity is deleted. However, we should also ask for confirmation before updating a template. The reason is because sometimes developers have a tough time wielding the built-in editor (ex: VIM) and accidents may occur; a confirmation would prevent any unintended updates. This practice is already employed with the universal login template. This can be overridden with a --force flag or if the templates are piped-in.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
