### PR TITLE
DXCDT-325: Prevent erroneous truncation message with `--json` flag

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -177,7 +177,7 @@ func showApiCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("Unable to get an API with Id '%s': %w", inputs.ID, err)
 			}
 
-			cli.renderer.ApiShow(api)
+			cli.renderer.ApiShow(api, cli.json)
 			return nil
 		},
 	}

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -88,11 +88,11 @@ func (r *Renderer) ApiList(apis []*management.ResourceServer) {
 	r.Results(results)
 }
 
-func (r *Renderer) ApiShow(api *management.ResourceServer) {
+func (r *Renderer) ApiShow(api *management.ResourceServer, jsonFlag bool) {
 	r.Heading("api")
 	view, scopesTruncated := makeApiView(api)
 	r.Result(view)
-	if scopesTruncated {
+	if scopesTruncated && !jsonFlag {
 		r.Newline()
 		r.Infof("Scopes truncated for display. To see the full list, run %s", ansi.Faint(fmt.Sprintf("apis scopes list %s", *api.ID)))
 	}


### PR DESCRIPTION
### 🔧 Changes

When running the auth0 apis show command normally, the output is very large and the scopes become truncated. In these cases, the CLI will display a message noting the truncation. However, when running in conjunction with the --json flag, the message still appears even though that flag will return all scopes. This is not only incorrect but could interfere with the JSON parsing.

**Example:**
<img width="965" alt="Screen Shot 2023-01-12 at 5 15 15 PM" src="https://user-images.githubusercontent.com/4614315/212192659-bbdf233f-1067-44df-9e9d-61602380154a.png">

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
