### PR TITLE
Fix: Including missing `--force` documentation updates

### DIFF
--- a/docs/auth0_actions_update.md
+++ b/docs/auth0_actions_update.md
@@ -32,6 +32,7 @@ auth0 actions update [flags]
 ```
   -c, --code string                 Code content for the action.
   -d, --dependency stringToString   Third party npm module, and its version, that the action depends on. (default [])
+      --force                       Skip confirmation.
       --json                        Output in json format.
   -n, --name string                 Name of the action.
   -s, --secret stringToString       Secrets to be used in the action. (default [])

--- a/docs/auth0_email_templates_update.md
+++ b/docs/auth0_email_templates_update.md
@@ -35,6 +35,7 @@ auth0 email templates update [flags]
 ```
   -b, --body string      Body of the email template.
   -e, --enabled          Whether the template is enabled (true) or disabled (false). (default true)
+      --force            Skip confirmation.
   -f, --from string      Sender's 'from' email address.
       --json             Output in json format.
   -l, --lifetime int     Lifetime in seconds that the link within the email will be valid for.

--- a/docs/auth0_rules_update.md
+++ b/docs/auth0_rules_update.md
@@ -30,6 +30,7 @@ auth0 rules update [flags]
 
 ```
   -e, --enabled         Enable (or disable) a rule. (default true)
+      --force           Skip confirmation.
       --json            Output in json format.
   -n, --name string     Name of the rule.
   -s, --script string   Script contents for the rule.


### PR DESCRIPTION
### 🔧 Changes

[Build is failing](https://github.com/auth0/auth0-cli/actions/runs/3906258779/jobs/6674225625) because of missing documentation changes that should have been introduced in #603. Need to investigate why the build checks allowed merging with the [failed check](https://github.com/auth0/auth0-cli/actions/runs/3905209349). 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
