### PR TITLE
DXCDT-319: Refactor how we select the tenant domain for multiple cmds

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -296,7 +296,7 @@ func (c *cli) getTenant() (Tenant, error) {
 	return t, nil
 }
 
-// listTenants fetches all of the configured tenants.
+// listTenants fetches all the configured tenants.
 func (c *cli) listTenants() ([]Tenant, error) {
 	if err := c.init(); err != nil {
 		return []Tenant{}, err

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -16,7 +16,7 @@ func logoutCmd(cli *cli) *cobra.Command {
   auth0 logout <tenant>
   auth0 logout "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			selectedTenant, err := selectTenant(cli, cmd, args)
+			selectedTenant, err := selectValidTenantFromConfig(cli, cmd, args)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -1,12 +1,9 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
 func logoutCmd(cli *cli) *cobra.Command {
@@ -19,42 +16,16 @@ func logoutCmd(cli *cli) *cobra.Command {
   auth0 logout <tenant>
   auth0 logout "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// NOTE(cyx): This was mostly copy/pasted from tenants
-			// use command. Consider refactoring.
-			var selectedTenant string
-			if len(args) == 0 {
-				tens, err := cli.listTenants()
-				if err != nil {
-					return err // This error is already formatted for display
-				}
-
-				if len(tens) == 0 {
-					return errors.New("there are no tenants available to perform the logout")
-				}
-
-				tenNames := make([]string, len(tens))
-				for i, t := range tens {
-					tenNames[i] = t.Domain
-				}
-
-				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to logout", tenNames, tenNames[0], true)
-				if err := prompt.AskOne(input, &selectedTenant); err != nil {
-					return handleInputError(err)
-				}
-			} else {
-				requestedTenant := args[0]
-				t, ok := cli.config.Tenants[requestedTenant]
-				if !ok {
-					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
-				}
-				selectedTenant = t.Domain
-			}
-
-			if err := cli.removeTenant(selectedTenant); err != nil {
+			selectedTenant, err := selectTenant(cli, cmd, args)
+			if err != nil {
 				return err
 			}
 
-			cli.renderer.Infof("Successfully logged out tenant: %s", selectedTenant)
+			if err := cli.removeTenant(selectedTenant); err != nil {
+				return fmt.Errorf("failed to log out from the tenant %s: %w", selectedTenant, err)
+			}
+
+			cli.renderer.Infof("Successfully logged out from tenant: %s", selectedTenant)
 			return nil
 		},
 	}

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -63,7 +63,7 @@ func useTenantCmd(cli *cli) *cobra.Command {
   auth0 tenants use <tenant>
   auth0 tenants use "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			selectedTenant, err := selectTenant(cli, cmd, args)
+			selectedTenant, err := selectValidTenantFromConfig(cli, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -91,7 +91,7 @@ func openTenantCmd(cli *cli) *cobra.Command {
   auth0 tenants open <tenant>
   auth0 tenants open "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			selectedTenant, err := selectTenant(cli, cmd, args)
+			selectedTenant, err := selectValidTenantFromConfig(cli, cmd, args)
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func openTenantCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
-func selectTenant(cli *cli, cmd *cobra.Command, args []string) (string, error) {
+func selectValidTenantFromConfig(cli *cli, cmd *cobra.Command, args []string) (string, error) {
 	var selectedTenant string
 
 	if len(args) == 0 {

--- a/internal/cli/tenants.go
+++ b/internal/cli/tenants.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/auth0/auth0-cli/internal/prompt"
 )
+
+var tenantDomain = Argument{
+	Name: "Tenant",
+	Help: "Tenant to select",
+}
 
 func tenantsCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
@@ -32,20 +35,21 @@ func listTenantCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 tenants list
   auth0 tenants ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tens, err := cli.listTenants()
+			tenants, err := cli.listTenants()
 			if err != nil {
-				return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+				return fmt.Errorf("failed to load tenants: %w", err)
 			}
 
-			tenNames := make([]string, len(tens))
-			for i, t := range tens {
-				tenNames[i] = t.Domain
+			tenantNames := make([]string, len(tenants))
+			for i, t := range tenants {
+				tenantNames[i] = t.Domain
 			}
 
-			cli.renderer.TenantList(tenNames)
+			cli.renderer.TenantList(tenantNames)
 			return nil
 		},
 	}
+
 	return cmd
 }
 
@@ -59,35 +63,16 @@ func useTenantCmd(cli *cli) *cobra.Command {
   auth0 tenants use <tenant>
   auth0 tenants use "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var selectedTenant string
-			if len(args) == 0 {
-				tens, err := cli.listTenants()
-				if err != nil {
-					return fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
-				}
-
-				tenNames := make([]string, len(tens))
-				for i, t := range tens {
-					tenNames[i] = t.Domain
-				}
-
-				input := prompt.SelectInput("tenant", "Tenant:", "Tenant to activate", tenNames, tenNames[0], true)
-				if err := prompt.AskOne(input, &selectedTenant); err != nil {
-					return handleInputError(err)
-				}
-			} else {
-				requestedTenant := args[0]
-				t, ok := cli.config.Tenants[requestedTenant]
-				if !ok {
-					return fmt.Errorf("Unable to find tenant %s; run 'auth0 tenants use' to see your configured tenants or run 'auth0 login' to configure a new tenant", requestedTenant)
-				}
-				selectedTenant = t.Domain
+			selectedTenant, err := selectTenant(cli, cmd, args)
+			if err != nil {
+				return err
 			}
 
 			cli.config.DefaultTenant = selectedTenant
 			if err := cli.persistConfig(); err != nil {
-				return fmt.Errorf("An error occurred while setting the default tenant: %w", err)
+				return fmt.Errorf("failed to set the default tenant: %w", err)
 			}
+
 			cli.renderer.Infof("Default tenant switched to: %s", selectedTenant)
 			return nil
 		},
@@ -97,15 +82,6 @@ func useTenantCmd(cli *cli) *cobra.Command {
 }
 
 func openTenantCmd(cli *cli) *cobra.Command {
-	var inputs struct {
-		Domain string
-	}
-
-	var tenantDomain = Argument{
-		Name: "Tenant",
-		Help: "Tenant to select",
-	}
-
 	cmd := &cobra.Command{
 		Use:   "open",
 		Args:  cobra.MaximumNArgs(1),
@@ -115,20 +91,12 @@ func openTenantCmd(cli *cli) *cobra.Command {
   auth0 tenants open <tenant>
   auth0 tenants open "example.us.auth0.com"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				err := tenantDomain.Pick(cmd, &inputs.Domain, cli.tenantPickerOptions)
-				if err != nil {
-					return err
-				}
-			} else {
-				inputs.Domain = args[0]
-
-				if _, ok := cli.config.Tenants[inputs.Domain]; !ok {
-					return fmt.Errorf("Unable to find tenant %s; run 'auth0 login' to configure a new tenant", inputs.Domain)
-				}
+			selectedTenant, err := selectTenant(cli, cmd, args)
+			if err != nil {
+				return err
 			}
 
-			openManageURL(cli, inputs.Domain, "tenant/general")
+			openManageURL(cli, selectedTenant, "tenant/general")
 			return nil
 		},
 	}
@@ -136,19 +104,37 @@ func openTenantCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
+func selectTenant(cli *cli, cmd *cobra.Command, args []string) (string, error) {
+	var selectedTenant string
+
+	if len(args) == 0 {
+		err := tenantDomain.Pick(cmd, &selectedTenant, cli.tenantPickerOptions)
+		return selectedTenant, err
+	}
+
+	selectedTenant = args[0]
+	if _, ok := cli.config.Tenants[selectedTenant]; !ok {
+		return "", fmt.Errorf(
+			"failed to find tenant %s.\n\nRun 'auth0 login' to configure a new tenant.",
+			selectedTenant,
+		)
+	}
+
+	return selectedTenant, nil
+}
+
 func (c *cli) tenantPickerOptions() (pickerOptions, error) {
-	tens, err := c.listTenants()
+	tenants, err := c.listTenants()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to load tenants due to an unexpected error: %w", err)
+		return nil, fmt.Errorf("failed to load tenants: %w", err)
 	}
 
 	var priorityOpts, opts pickerOptions
+	for _, tenant := range tenants {
+		opt := pickerOption{value: tenant.Domain, label: tenant.Domain}
 
-	for _, t := range tens {
-		opt := pickerOption{value: t.Domain, label: t.Domain}
-
-		// check if this is currently the default tenant.
-		if t.Domain == c.config.DefaultTenant {
+		// Check if this is currently the default tenant.
+		if tenant.Domain == c.config.DefaultTenant {
 			priorityOpts = append(priorityOpts, opt)
 		} else {
 			opts = append(opts, opt)
@@ -156,7 +142,7 @@ func (c *cli) tenantPickerOptions() (pickerOptions, error) {
 	}
 
 	if len(opts)+len(priorityOpts) == 0 {
-		return nil, errNoApps
+		return nil, fmt.Errorf("there are currently no tenants to pick from")
 	}
 
 	return append(priorityOpts, opts...), nil


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

For the logout cmd when we were passing `--no-input`, the flag wasn't being respected and we were still shown a picker to select the tenant. However after investigating the codebase the exact same logic was used throughout the `tenants use`, `tenants open` and `logout` commands. So in this PR we're refactoring the logic of selecting the tenant and reusing the same function on all 3 commands that will now respect the `--no-input` flag when passed.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
