### PR TITLE
DXCDT-327: `test` command `--no-input` compliance

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -225,7 +225,7 @@ func testTokenCmd(cli *cli) *cobra.Command {
 		Short: "Fetch a token for the given application and API",
 		Long: `Fetch an access token for the given application.
 If --client-id is not provided, the default client "CLI Login Testing" will be used (and created if not exists).
-Specify the API you want this token for with --audience (API identifier). Additionally, you can also specify the --scope to use.`,
+Specify the API you want this token for with --audience (API Identifer). Additionally, you can also specify the --scope to use.`,
 		Example: `  auth0 test token
   auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>
   auth0 test token -c <id> -a <audience> -s <scope1,scope2>

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -225,7 +225,7 @@ func testTokenCmd(cli *cli) *cobra.Command {
 		Short: "Fetch a token for the given application and API",
 		Long: `Fetch an access token for the given application.
 If --client-id is not provided, the default client "CLI Login Testing" will be used (and created if not exists).
-Specify the API you want this token for with --audience (API Identifer). Additionally, you can also specify the --scope to use.`,
+Specify the API you want this token for with --audience (API identifier). Additionally, you can also specify the --scope to use.`,
 		Example: `  auth0 test token
   auth0 test token --client-id <id> --audience <audience> --scopes <scope1,scope2>
   auth0 test token -c <id> -a <audience> -s <scope1,scope2>


### PR DESCRIPTION
### 🔧 Changes

As reported by #511, the `auth0 test token` and `auth0 test login` commands do not respect the `--no-input` flag because they open the browser and force an interaction. Instead, we should only provide the login URL and enable the user to facilitate the remainder of the login flow as they like. This approach is consistent to what we have implemented for `auth0 login --no-input`.

### 📚 References

Original Github issue: #511 

### 🔬 Testing

Currently, no integration tests are possible because of the commands waiting for browser callbacks and never exiting. All tests performed manually.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
