### PR TITLE
DXCDT-330: Colorize JSON output by default

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -84,7 +84,7 @@ func (r *Renderer) JSONResult(data interface{}) {
 		r.Errorf("couldn't marshal results as JSON: %v", err)
 		return
 	}
-	r.Output(string(b))
+	r.Output(ansi.ColorizeJSON(string(b), false))
 }
 
 func (r *Renderer) Results(data []View) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Making sure we colorize JSON output to improve readability by default. The colors can be removed with the `--no-color` flag. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Confirmed working manually.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
