### PR TITLE
DXCDT-331: Fix how we check if we should prompt when no flags set on cmd invocation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -536,16 +536,15 @@ func shouldPrompt(cmd *cobra.Command, flag *Flag) bool {
 	return canPrompt(cmd) && !flag.IsSet(cmd)
 }
 
-func shouldPromptWhenFlagless(cmd *cobra.Command, flag string) bool {
-	isSet := false
-
+func shouldPromptWhenNoLocalFlagsSet(cmd *cobra.Command) bool {
+	localFlagIsSet := false
 	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
-		if f.Changed {
-			isSet = true
+		if f.Name != "json" && f.Name != "force" && f.Changed {
+			localFlagIsSet = true
 		}
 	})
 
-	return canPrompt(cmd) && !isSet
+	return canPrompt(cmd) && !localFlagIsSet
 }
 
 func prepareInteractivity(cmd *cobra.Command) {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -285,7 +285,7 @@ func shouldAsk(cmd *cobra.Command, f *Flag, isUpdate bool) bool {
 		if !f.IsRequired && !f.AlwaysPrompt {
 			return false
 		}
-		return shouldPromptWhenFlagless(cmd, f.LongForm)
+		return shouldPromptWhenNoLocalFlagsSet(cmd)
 	}
 
 	return shouldPrompt(cmd, f)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Sadly, a regression was introduced through https://github.com/auth0/auth0-cli/pull/563, where we moved the `--json` flag from a global flag to a local flag. This caused the old `shouldPromptWhenNoLocalFlagsSet()` func to miss behave and incorrectly skip prompting for flag values to be set in interactive mode when just the `--json` flag was present (e.g. `auth0 ap bpd update --json`). This PR addresses this and as well includes a check for the `--force` flag as that was removed from the global level as well in a subsequent PR. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
