### PR TITLE
Fix apps shown in multi select when no app-id is passed

### DIFF
--- a/internal/cli/quickstarts.go
+++ b/internal/cli/quickstarts.go
@@ -356,7 +356,11 @@ func (i *qsInputs) fromArgs(cmd *cobra.Command, args []string, cli *cli) error {
 	}
 
 	if len(args) == 0 {
-		if err := qsClientID.Pick(cmd, &i.ClientID, cli.appPickerOptions); err != nil {
+		if err := qsClientID.Pick(
+			cmd,
+			&i.ClientID,
+			cli.appPickerOptions(management.Parameter("app_type", "native,spa,regular_web,non_interactive")),
+		); err != nil {
 			return err
 		}
 	} else {

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -355,7 +355,7 @@ func (c *cli) customDomainPickerOptions() (pickerOptions, error) {
 }
 
 func (c *cli) appPickerWithCreateOption() (pickerOptions, error) {
-	options, err := c.appPickerOptions()
+	options, err := c.appPickerOptions()()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes a bug with the appPickerOptions func where it was skipping all generic app types. Furthermore we enhance the function to accept request options so we can reuse the same func within the quickstart download command and skip fetching generic app types for it. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
