### PR TITLE
DXCDT-389: Automate code coverage reporting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,19 +1,19 @@
 name: Go
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: one-at-time
   cancel-in-progress: false
 
 jobs:
-  unit:
-    name: Unit Test
+  checks:
+    name: Checks
     runs-on: ubuntu-latest
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
@@ -36,13 +36,33 @@ jobs:
           version: latest
           args: -v -c .golangci.yml
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
       - name: Run unit tests
         run: make test-unit
 
-  integration:
-    name: Integration Test
+      - name: Upload unit test coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests-artifact
+          path: ./coverage-unit-tests.out
+
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
-    # skip running this action if the PR is coming from a fork:
+    needs: unit-tests
+    # Skip running this action if the PR is coming from a fork.
     if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
 
     steps:
@@ -64,13 +84,22 @@ jobs:
           AUTH0_CLI_CLIENT_ID: ${{ secrets.AUTH0_CLI_CLIENT_ID }}
           AUTH0_CLI_CLIENT_SECRET: ${{ secrets.AUTH0_CLI_CLIENT_SECRET }}
 
+      - name: Download unit test coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-tests-artifact
+          path: ./unit-tests-artifact
+
+      - name: Update codecov report
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./unit-tests-artifact/coverage-unit-tests.out,./coverage-integration-tests.out
+          fail_ci_if_error: false
+          verbose: true
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     steps:
       - name: Check out the code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
   push:
 
-env:
-  GO_VERSION: 1.19.4
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,9 +3,9 @@ name: Semgrep
 on:
   pull_request_target: {}
   push:
-    branches: ["master", "main"]
+    branches: ["main"]
   schedule:
-    - cron: '30 0 1,15 * *' # scheduled for 00:30 UTC on both the 1st and 15th of the month
+    - cron: '30 0 1,15 * *' # Scheduled for 00:30 UTC on both the 1st and 15th of the month.
 
 jobs:
   semgrep:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # Project artifacts
 /auth0
 /test/integration/identifiers
-/coverage
-coverage.out
+coverage*
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,13 @@ test: test-unit test-integration ## Run all tests
 
 test-unit: ## Run unit tests
 	${call print, "Running unit tests"}
-	@go test -race ${GO_PACKAGES} -count 1
+	@go test -v -race ${GO_PACKAGES} -coverprofile="coverage-unit-tests.out"
 
-test-integration: $(GO_BIN)/commander ## Run integration tests. To run a specific test pass the FILTER var. Usage: `make test-integration FILTER="attack protection"`
+test-integration: install-with-cover $(GO_BIN)/commander ## Run integration tests. To run a specific test pass the FILTER var. Usage: `make test-integration FILTER="attack protection"`
 	${call print, "Running integration tests"}
-	@$(MAKE) install # ensure fresh install prior to running test
-	@bash ./test/integration/scripts/run-test-suites.sh
+	@mkdir -p "coverage"
+	@GOCOVERDIR=coverage bash ./test/integration/scripts/run-test-suites.sh
+	@go tool covdata textfmt -i "coverage" -o "coverage-integration-tests.out"
 
 test-mocks: $(GO_BIN)/mockgen ## Generate testing mocks using mockgen
 	${call print, "Generating test mocks"}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The aim of this PR is to leverage the newly added functionality within go 1.20 to be able to capture code coverage from integration tests that run against a compiled binary with the `-cover` flag and upload the coverage to codecov so we can have it as a metric to improve.

Additionally further enhancements are done to the github actions pipeline:
- Checks were split into separate job
- Only conditional present is for the integration tests (we don't want to run them against forks). 

> **Note**
> I'll update the required PR checks before merging this.


> **Warning**
> A codecov badge added to the README will follow after this PR as we need this PR in main to correctly show the badge first.

### 📚 References

- https://go.dev/testing/coverage/

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
