### PR TITLE
Combining test scripts for predictable and isolate test cases

### DIFF
--- a/test/integration/actions-test-cases.yaml
+++ b/test/integration/actions-test-cases.yaml
@@ -35,12 +35,8 @@ tests:
         secrets.0.value: "value"
         status: "pending"
 
-  004 - given a test action:
-    command: ./test/integration/scripts/create-action.sh
-    exit-code: 0
-
-  005 - given a test action, it successfully gets the action's details:
-    command: auth0 actions show $(cat ./test/integration/identifiers/action-id)
+  004 - given a test action, it successfully gets the action's details:
+    command: auth0 actions show $(./test/integration/scripts/get-action-id.sh)
     exit-code: 0
     stdout:
       contains:
@@ -53,8 +49,8 @@ tests:
         - "CREATED"
         - "CODE           function() {}"
 
-  006 - given a test action, it successfully gets the action's details and outputs in json:
-    command: auth0 actions show $(cat ./test/integration/identifiers/action-id) --json
+  005 - given a test action, it successfully gets the action's details and outputs in json:
+    command: auth0 actions show $(./test/integration/scripts/get-action-id.sh) --json
     exit-code: 0
     stdout:
       json:
@@ -66,8 +62,8 @@ tests:
         dependencies.0.version: "4.0.0"
         secrets.0.name: "SECRET"
 
-  007 - given a test action, it successfully updates the action's details:
-    command: auth0 actions update $(cat ./test/integration/identifiers/action-id) -n "integration-test-action-updated" -c "function() {console.log()}" -d "uuid=9.0.0" -s "SECRET2=newValue"
+  006 - given a test action, it successfully updates the action's details:
+    command: auth0 actions update $(./test/integration/scripts/get-action-id.sh) -n "integration-test-action-updated" -c "function() {console.log()}" -d "uuid=9.0.0" -s "SECRET2=newValue"
     exit-code: 0
     stdout:
       contains:
@@ -80,8 +76,8 @@ tests:
         - "CREATED"
         - "CODE           function() {console.log()}"
 
-  008 - given a test action, it successfully updates the action's details and outputs in json:
-    command: auth0 actions update $(cat ./test/integration/identifiers/action-id) -n "integration-test-action-updated-again" -c "function() {console.log()}" -d "uuid=9.0.0" -s "SECRET3=newValue" --json
+  007 - given a test action, it successfully updates the action's details and outputs in json:
+    command: auth0 actions update $(./test/integration/scripts/get-action-id.sh) -n "integration-test-action-updated-again" -c "function() {console.log()}" -d "uuid=9.0.0" -s "SECRET3=newValue" --json
     exit-code: 0
     stdout:
       json:
@@ -94,13 +90,13 @@ tests:
         secrets.0.name: "SECRET3"
         secrets.0.value: "newValue"
 
-  011 - given a test action, it successfully opens the settings page:
-    command: auth0 actions open $(cat ./test/integration/identifiers/action-id) --no-input
+  008 - given a test action, it successfully opens the settings page:
+    command: auth0 actions open $(./test/integration/scripts/get-action-id.sh) --no-input
     exit-code: 0
     stderr:
       contains:
         - "Open the following URL in a browser"
 
-  012 - given a test action, it successfully deletes the action:
-    command: auth0 actions delete $(cat ./test/integration/identifiers/action-id) --force
+  009 - given a test action, it successfully deletes the action:
+    command: auth0 actions delete $(./test/integration/scripts/get-action-id.sh) --force
     exit-code: 0

--- a/test/integration/apps-test-cases.yaml
+++ b/test/integration/apps-test-cases.yaml
@@ -149,12 +149,8 @@ tests:
       json:
         web_origins: "[https://example.com]"
 
-  021 - given a test app:
-    command: ./test/integration/scripts/get-app-id.sh
-    exit-code: 0
-
-  022 - given a test app, it successfully gets the app's details and outputs in json:
-    command: auth0 apps show $(cat ./test/integration/identifiers/app-id) --json
+  021 - given a test app, it successfully gets the app's details and outputs in json:
+    command: auth0 apps show $(./test/integration/scripts/get-app-id.sh) --json
     exit-code: 0
     stdout:
       json:
@@ -162,8 +158,8 @@ tests:
         description: NewApp
         app_type: native
 
-  023 - given a test app, it successfully gets the app's details:
-    command: auth0 apps show $(cat ./test/integration/identifiers/app-id)
+  022 - given a test app, it successfully gets the app's details:
+    command: auth0 apps show $(./test/integration/scripts/get-app-id.sh)
     exit-code: 0
     stdout:
       contains:
@@ -171,93 +167,91 @@ tests:
         - DESCRIPTION          NewApp
         - TYPE                 Native
 
-  024 - given a test app, it successfully updates the app's auth method and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --auth-method Basic --json
+  023 - given a test app, it successfully updates the app's auth method and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --auth-method Basic --json
     exit-code: 0
     stdout:
       json:
         token_endpoint_auth_method: client_secret_basic
 
-  025 - given a test app, it successfully updates the app's callbacks and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --callbacks https://example.com --json
+  024 - given a test app, it successfully updates the app's callbacks and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --callbacks https://example.com --json
     stdout:
       json:
         callbacks: "[https://example.com]"
     exit-code: 0
 
-  026 - given a test app, it successfully updates the app's description and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --description "A better description" --json
+  025 - given a test app, it successfully updates the app's description and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --description "A better description" --json
     exit-code: 0
     stdout:
       json:
         description: A better description
 
-  027 - given a test app, it successfully updates the app's grants and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --grants code --json
+  026 - given a test app, it successfully updates the app's grants and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --grants code --json
     exit-code: 0
     stdout:
       json:
         grant_types: "[authorization_code]"
 
-  028 - given a test app, it successfully updates the app's logout urls and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --logout-urls https://example.com --json
+  027 - given a test app, it successfully updates the app's logout urls and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --logout-urls https://example.com --json
     exit-code: 0
     stdout:
       json:
         allowed_logout_urls: "[https://example.com]"
 
-  029 - given a test app, it successfully updates the app's name and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --name integration-test-app-betterAppName --json
+  028 - given a test app, it successfully updates the app's name and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --name integration-test-app-betterAppName --json
     exit-code: 0
     stdout:
       json:
         name: integration-test-app-betterAppName
 
-  030 - given a test app, it successfully updates the app's origins and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --origins https://example.com --json
+  029 - given a test app, it successfully updates the app's origins and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --origins https://example.com --json
     exit-code: 0
     stdout:
       json:
         allowed_origins: "[https://example.com]"
 
-  031 - given a test app, it successfully updates the app's type and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --type spa --json
+  030 - given a test app, it successfully updates the app's type and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --type spa --json
     exit-code: 0
     stdout:
       json:
         app_type: spa
 
-  032 - given a test app, it successfully updates the app's web origins and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://example.com --json
+  031 - given a test app, it successfully updates the app's web origins and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --web-origins https://example.com --json
     exit-code: 0
     stdout:
       json:
         web_origins: "[https://example.com]"
 
-  033 - given a test app, it successfully updates the app's web origins and type and outputs in json:
-    command: auth0 apps update $(cat ./test/integration/identifiers/app-id) --web-origins https://examples.com --type native --json
+  032 - given a test app, it successfully updates the app's web origins and type and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --web-origins https://examples.com --type native --json
     exit-code: 0
     stdout:
       json:
         app_type: native
         web_origins: "[https://examples.com]"
 
-  034 - given a test app, it successfully opens the settings page:
-    command: auth0 apps open $(cat ./test/integration/identifiers/app-id) --no-input
+  033 - given a test app, it successfully opens the settings page:
+    command: auth0 apps open $(./test/integration/scripts/get-app-id.sh) --no-input
     exit-code: 0
     stderr:
       contains:
         - "Open the following URL in a browser"
 
-
-  035 - given a test app, it successfully sets the default application:
-    command: auth0 apps use $(cat ./test/integration/identifiers/app-id) --no-input
+  034 - given a test app, it successfully sets the default application:
+    command: auth0 apps use $(./test/integration/scripts/get-app-id.sh) --no-input
     exit-code: 0
     stderr:
       contains:
         - "Successfully set the default application to"
 
-
-  036 - given a test app, it successfully deletes the app:
-    command: auth0 apps delete $(cat ./test/integration/identifiers/app-id) --force
+  035 - given a test app, it successfully deletes the app:
+    command: auth0 apps delete $(./test/integration/scripts/get-app-id.sh) --force
     exit-code: 0

--- a/test/integration/fixtures/update-rule.json
+++ b/test/integration/fixtures/update-rule.json
@@ -1,5 +1,5 @@
 {
-  "id": "rul_ftj6AEesNkFz5ZVQ",
+  "id": "rul_LBnc1o7UxvuiEmkt",
   "name": "integration-test-rule-betterName",
   "script": "function(user, context, cb) {\n  cb(null, user, context);\n}\n",
   "order": 3,

--- a/test/integration/logs-test-cases.yaml
+++ b/test/integration/logs-test-cases.yaml
@@ -94,7 +94,6 @@ tests:
         sink.httpContentType: "application/json"
         sink.httpEndpoint: "https://example.com/webhook/logs/v2"
 
-
   014 - given an http log stream, it successfully deletes the log stream:
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-http-id) --force --no-input
     exit-code: 0

--- a/test/integration/organzations-test-cases.yaml
+++ b/test/integration/organzations-test-cases.yaml
@@ -39,35 +39,31 @@ tests:
       contains:
         - failed to create an organization with name 'integration-test-org-new2'
 
-  006 - create organization to use in other tests:
-    command: ./test/integration/scripts/get-org-id.sh
-    exit-code: 0
-
-  007 - show organization and check json output:
-    command: auth0 orgs show $(cat ./test/integration/identifiers/org-id) --json
+  006 - show organization and check json output:
+    command: auth0 orgs show $(./test/integration/scripts/get-org-id.sh) --json
     exit-code: 0
     stdout:
       json:
         name: "integration-test-org-better"
         display_name: "Integration Test Better Organization"
 
-  008 - show organization and check table output:
-    command: auth0 orgs show $(cat ./test/integration/identifiers/org-id)
+  007 - show organization and check table output:
+    command: auth0 orgs show $(./test/integration/scripts/get-org-id.sh)
     exit-code: 0
     stdout:
       contains:
         - NAME              integration-test-org-better
         - DISPLAY NAME      Integration Test Better Organization
 
-  009 - show organization with invalid organization ID:
+  008 - show organization with invalid organization ID:
     command: auth0 orgs show "this-org-id-does-not-exist"
     exit-code: 1
     stderr:
       contains:
-        - "Unable to get an organization with ID 'this-org-id-does-not-exist'"
+        - "Unable to get an organization with Id 'this-org-id-does-not-exist'"
 
-  010 - update organization:
-    command: auth0 orgs update $(cat ./test/integration/identifiers/org-id) -d "Integration Test Updated Organization" -a "#00FFAA" -b "#AA1166" --json --no-input
+  009 - update organization:
+    command: auth0 orgs update $(./test/integration/scripts/get-org-id.sh) -d "Integration Test Updated Organization" -a "#00FFAA" -b "#AA1166" --json --no-input
     exit-code: 0
     stdout:
       json:
@@ -75,8 +71,8 @@ tests:
         display_name: "Integration Test Updated Organization"
         branding.colors.page_background: "#AA1166"
         branding.colors.primary: "#00FFAA"
-  011 - update organization with minimal flags:
-    command: auth0 orgs update $(cat ./test/integration/identifiers/org-id) --no-input
+  010 - update organization with minimal flags:
+    command: auth0 orgs update $(./test/integration/scripts/get-org-id.sh) --no-input
     exit-code: 0
     stdout:
       contains:
@@ -86,31 +82,28 @@ tests:
         - "ACCENT COLOR      #00FFAA"
         - LOGO URL
         - METADATA          null
-  012 - open organization dashboard view in browser:
-    command: auth0 orgs open $(cat ./test/integration/identifiers/org-id) --no-input
+  011 - open organization dashboard view in browser:
+    command: auth0 orgs open $(./test/integration/scripts/get-org-id.sh) --no-input
     exit-code: 0
     stderr:
       contains:
         - "Open the following URL in a browser: https://manage.auth0.com/dashboard/"
         - "/organizations/org_"
-  013 - add organization members:
-    command: ./test/integration/scripts/get-user-id.sh && auth0 api POST "organizations/$(cat ./test/integration/identifiers/org-id)/members" --data "{\"members\":[\"$(cat ./test/integration/identifiers/user-id)\"]}"
+  012 - add organization members:
+    command: auth0 api POST "organizations/$(./test/integration/scripts/get-org-id.sh)/members" --data "{\"members\":[\"$(./test/integration/scripts/get-user-id.sh)\"]}"
     exit-code: 0
-  014 - list organization members:
-    command: auth0 orgs members list $(cat ./test/integration/identifiers/org-id) --json
+  013 - list organization members:
+    command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh) --json
     exit-code: 0
     stdout:
       contains:
         - '"user_id": "auth0|'
         - '"picture": "'
-      json:
-        "0.email": "newuser@example.com"
-        "0.name": "integration-test-user-better"
-  015 - list organization roles:
-    command: auth0 orgs roles list $(cat ./test/integration/identifiers/org-id)
+  014 - list organization roles:
+    command: auth0 orgs roles list $(./test/integration/scripts/get-org-id.sh)
     exit-code: 0
-  016 - list organization roles with invalid number:
-    command: auth0 orgs roles list $(cat ./test/integration/identifiers/org-id) --number 1001
+  015 - list organization roles with invalid number:
+    command: auth0 orgs roles list $(./test/integration/scripts/get-org-id.sh) --number 1001
     exit-code: 1
     stderr:
       contains:

--- a/test/integration/organzations-test-cases.yaml
+++ b/test/integration/organzations-test-cases.yaml
@@ -60,7 +60,7 @@ tests:
     exit-code: 1
     stderr:
       contains:
-        - "Unable to get an organization with Id 'this-org-id-does-not-exist'"
+        - "Unable to get an organization with ID 'this-org-id-does-not-exist'"
 
   009 - update organization:
     command: auth0 orgs update $(./test/integration/scripts/get-org-id.sh) -d "Integration Test Updated Organization" -a "#00FFAA" -b "#AA1166" --json --no-input

--- a/test/integration/scripts/create-log-stream-datadog-id.sh
+++ b/test/integration/scripts/create-log-stream-datadog-id.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/log-stream-datadog-id
+if [ -f "$FILE" ]; then
+    exit 0
+fi
+
 logStream=$( auth0 logs streams create datadog --name integration-test-datadog --region eu --api-key 123233123455 --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$logStream" | jq -r '.["id"]' > ./test/integration/identifiers/log-stream-datadog-id
+echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-eventbridge-id.sh
+++ b/test/integration/scripts/create-log-stream-eventbridge-id.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/log-stream-eventbridge-id
+if [ -f "$FILE" ]; then
+    exit 0
+fi
+
 logStream=$( auth0 logs streams create eventbridge --name integration-test-eventbridge --aws-id 999999999999 --aws-region eu-west-1 --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$logStream" | jq -r '.["id"]' > ./test/integration/identifiers/log-stream-eventbridge-id
+echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-http-id.sh
+++ b/test/integration/scripts/create-log-stream-http-id.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/log-stream-http-id
+if [ -f "$FILE" ]; then
+    exit 0
+fi
+
 logStream=$( auth0 logs streams create http --name integration-test-http --endpoint "https://example.com/webhook/logs" --type "application/json" --format "JSONLINES" --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$logStream" | jq -r '.["id"]' > ./test/integration/identifiers/log-stream-http-id
+echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-splunk-id.sh
+++ b/test/integration/scripts/create-log-stream-splunk-id.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/log-stream-splunk-id
+if [ -f "$FILE" ]; then
+    exit 0
+fi
+
 logStream=$( auth0 logs streams create splunk --name integration-test-splunk --domain "demo.splunk.com" --token "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" --port "8088" --secure --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$logStream" | jq -r '.["id"]' > ./test/integration/identifiers/log-stream-splunk-id
+echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-sumo-id.sh
+++ b/test/integration/scripts/create-log-stream-sumo-id.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/log-stream-sumo-id
+if [ -f "$FILE" ]; then
+    exit 0
+fi
+
 logStream=$( auth0 logs streams create sumo --name integration-test-sumo --source "demo.sumo.com" --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$logStream" | jq -r '.["id"]' > ./test/integration/identifiers/log-stream-sumo-id
+echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/get-action-id.sh
+++ b/test/integration/scripts/get-action-id.sh
@@ -1,6 +1,13 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/action-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
 action=$( auth0 actions create -n "integration-test-action" -t "post-login" -c "function() {}" -d "lodash=4.0.0" -s "SECRET=value" --json )
 
 mkdir -p ./test/integration/identifiers
-echo "$action" | jq -r '.["id"]' > ./test/integration/identifiers/action-id
+echo "$action" | jq -r '.["id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-api-id.sh
+++ b/test/integration/scripts/get-api-id.sh
@@ -1,6 +1,13 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/api-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
 api=$( auth0 apis create --name integration-test-api-newapi --identifier http://integration-test-api-newapi --scopes read:todos --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$api" | jq -r '.["id"]' > ./test/integration/identifiers/api-id
+echo "$api" | jq -r '.["id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-app-id.sh
+++ b/test/integration/scripts/get-app-id.sh
@@ -1,6 +1,13 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/app-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
 app=$( auth0 apps create -n integration-test-app-newapp -t native --description NewApp --json --no-input )
 
 mkdir -p ./test/integration/identifiers
-echo "$app" | jq -r '.["client_id"]' > ./test/integration/identifiers/app-id
+echo "$app" | jq -r '.["client_id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-org-id.sh
+++ b/test/integration/scripts/get-org-id.sh
@@ -2,6 +2,7 @@
 
 FILE=./test/integration/identifiers/org-id
 if [ -f "$FILE" ]; then
+    cat $FILE
     exit 0
 fi
 
@@ -9,3 +10,4 @@ org=$( auth0 orgs create -n integration-test-org-better -d "Integration Test Bet
 
 mkdir -p ./test/integration/identifiers
 echo "$org" | jq -r '.["id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-role-id.sh
+++ b/test/integration/scripts/get-role-id.sh
@@ -2,6 +2,7 @@
 
 FILE=./test/integration/identifiers/role-id
 if [ -f "$FILE" ]; then
+    cat $FILE
     exit 0
 fi
 
@@ -9,3 +10,4 @@ role=$( auth0 roles create -n integration-test-role-newRole -d integration-test-
 
 mkdir -p ./test/integration/identifiers
 echo "$role" | jq -r '.["id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-rule-id.sh
+++ b/test/integration/scripts/get-rule-id.sh
@@ -1,8 +1,15 @@
 #! /bin/bash
 
+FILE=./test/integration/identifiers/rule-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
 json='{"name":"integration-test-rule-newRule","script":"function(user, context, cb) {\n  cb(null, user, context);\n}\n","enabled":false}'
 rule=$( echo "$json" | auth0 rules create --json )
 
 mkdir -p ./test/integration/identifiers
-echo "$rule" | jq -r '.["id"]' > ./test/integration/identifiers/rule-id
+echo "$rule" | jq -r '.["id"]' > $FILE
 echo "$rule" | jq '.name = "integration-test-rule-betterName"' | jq '.enabled = false' > ./test/integration/fixtures/update-rule.json
+cat $FILE

--- a/test/integration/scripts/get-user-id.sh
+++ b/test/integration/scripts/get-user-id.sh
@@ -2,6 +2,7 @@
 
 FILE=./test/integration/identifiers/user-id
 if [ -f "$FILE" ]; then
+    cat $FILE
     exit 0
 fi
 
@@ -9,3 +10,4 @@ user=$( auth0 users create -n integration-test-user-better -c Username-Password-
 
 mkdir -p ./test/integration/identifiers
 echo "$user" | jq -r '.["user_id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/test-cleanup.sh
+++ b/test/integration/scripts/test-cleanup.sh
@@ -73,7 +73,7 @@ done
 
 rules=$( auth0 rules list --json --no-input )
 
-for rule in $( echo "${rules}" | jq -r '.[] | @base64' ); do
+for rule in $( printf "%s" "$rules" | jq -r '.[] | @base64' ); do
     _jq() {
      echo "${rule}" | base64 --decode | jq -r "${1}"
     }
@@ -122,4 +122,4 @@ for action in $( echo "${actions}" | jq -r '.[] | @base64' ); do
     fi
 done
 
-rm -r test/integration/identifiers
+rm -rf test/integration/identifiers

--- a/test/integration/test-cases.yaml
+++ b/test/integration/test-cases.yaml
@@ -83,12 +83,8 @@ tests:
       json:
         allow_offline_access: "false"
 
-  apis create test api: # create an api and capture its id
-    command: ./test/integration/scripts/get-api-id.sh
-    exit-code: 0
-
   apis show json:
-    command: auth0 apis show $(cat ./test/integration/identifiers/api-id) --json # depends on "apis create test app" test
+    command: auth0 apis show $(./test/integration/scripts/get-api-id.sh) --json # depends on "apis create test app" test
     stdout:
       json:
         name: integration-test-api-newapi
@@ -99,7 +95,7 @@ tests:
     exit-code: 0
 
   apis show:
-    command: auth0 apis show $(cat ./test/integration/identifiers/api-id) # depends on "apis create test app" test
+    command: auth0 apis show $(./test/integration/scripts/get-api-id.sh) # depends on "apis create test app" test
     stdout:
       contains:
         - NAME                  integration-test-api-newapi
@@ -110,40 +106,40 @@ tests:
     exit-code: 0
 
   apis scopes list:
-    command: auth0 apis scopes list $(cat ./test/integration/identifiers/api-id) # depends on "apis create test app" test
+    command: auth0 apis scopes list $(./test/integration/scripts/get-api-id.sh) # depends on "apis create test app" test
     exit-code: 0
 
   # Test 'apis update'; all tests depend on "apis create test api" test
   apis update name:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --name integration-test-api-betterApiName --json
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --name integration-test-api-betterApiName --json
     stdout:
       json:
         name: integration-test-api-betterApiName
     exit-code: 0
 
   apis update scopes:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --scopes read:todos,write:todos --json
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --scopes read:todos,write:todos --json
     stdout:
       json:
         scopes: "[map[value:read:todos] map[value:write:todos]]"
     exit-code: 0
 
   apis update token lifetime:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --token-lifetime 1000 --json
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --token-lifetime 1000 --json
     stdout:
       json:
         token_lifetime: "1000"
     exit-code: 0
 
   apis update offline access true:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access --json
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --offline-access --json
     stdout:
       json:
         allow_offline_access: "true"
     exit-code: 0
 
   apis update offline access false:
-    command: auth0 apis update $(cat ./test/integration/identifiers/api-id) --offline-access=false --json
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --offline-access=false --json
     stdout:
       json:
         allow_offline_access: "false"
@@ -166,13 +162,8 @@ tests:
         - EMAIL       testuser2@example.com
         - CONNECTION  Username-Password-Authentication
 
-  # Test 'users show'
-  users create test user:
-    command: ./test/integration/scripts/get-user-id.sh
-    exit-code: 0
-
   users show json:
-    command: auth0 users show $(cat ./test/integration/identifiers/user-id) --json
+    command: auth0 users show $(./test/integration/scripts/get-user-id.sh) --json
     stdout:
       json:
         email: "newuser@example.com"
@@ -180,7 +171,7 @@ tests:
     exit-code: 0
 
   users show:
-    command: auth0 users show $(cat ./test/integration/identifiers/user-id)
+    command: auth0 users show $(./test/integration/scripts/get-user-id.sh)
     stdout:
       contains:
         - EMAIL       newuser@example.com
@@ -188,7 +179,7 @@ tests:
     exit-code: 0
 
   users search:
-    command: auth0 users search --query user_id:"$(cat ./test/integration/identifiers/user-id)" --number 1 --sort "name:-1"
+    command: auth0 users search --query user_id:"$(./test/integration/scripts/get-user-id.sh)" --number 1 --sort "name:-1"
     exit-code: 0
     stdout:
       contains:
@@ -196,14 +187,14 @@ tests:
 
   # Test 'users update'
   users update email:
-    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --email betteruser@example.com  --json --no-input
+    command: auth0 users update $(./test/integration/scripts/get-user-id.sh)  --email betteruser@example.com  --json --no-input
     stdout:
       json:
         email: betteruser@example.com
     exit-code: 0
 
   users update name:
-    command: auth0 users update $(cat ./test/integration/identifiers/user-id)  --name integration-test-user-bettername  --json --no-input
+    command: auth0 users update $(./test/integration/scripts/get-user-id.sh)  --name integration-test-user-bettername  --json --no-input
     stdout:
       json:
         email: betteruser@example.com # Name is not being displayed, hence using email
@@ -226,13 +217,8 @@ tests:
         - DESCRIPTION  testRole2
     exit-code: 0
 
-  # Test 'roles show'
-  roles create test role:
-    command: ./test/integration/scripts/get-role-id.sh
-    exit-code: 0
-
   roles show json:
-    command: auth0 roles show $(cat ./test/integration/identifiers/role-id) --json
+    command: auth0 roles show $(./test/integration/scripts/get-role-id.sh) --json
     stdout:
       json:
         name: integration-test-role-newRole
@@ -240,7 +226,7 @@ tests:
     exit-code: 0
 
   roles show:
-    command: auth0 roles show $(cat ./test/integration/identifiers/role-id)
+    command: auth0 roles show $(./test/integration/scripts/get-role-id.sh)
     stdout:
       contains:
         - NAME         integration-test-role-newRole
@@ -249,14 +235,14 @@ tests:
 
   # Test 'roles update'
   roles update name:
-    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --name integration-test-role-betterName --json
+    command: auth0 roles update $(./test/integration/scripts/get-role-id.sh) --name integration-test-role-betterName --json
     stdout:
       json:
         name: integration-test-role-betterName
     exit-code: 0
 
   roles update description:
-    command: auth0 roles update $(cat ./test/integration/identifiers/role-id) --description betterDescription --json
+    command: auth0 roles update $(./test/integration/scripts/get-role-id.sh) --description betterDescription --json
     stdout:
       json:
         description: betterDescription
@@ -283,13 +269,8 @@ tests:
         - SCRIPT   function(user, context, cb) {
     exit-code: 0
 
-  # Test 'rules show'
-  rules create test rule:
-    command: ./test/integration/scripts/get-rule-id.sh
-    exit-code: 0
-
   rules show json:
-    command: auth0 rules show $(cat ./test/integration/identifiers/rule-id) --json
+    command: auth0 rules show $(./test/integration/scripts/get-rule-id.sh) --json
     stdout:
       json:
         name: integration-test-rule-newRule
@@ -298,7 +279,7 @@ tests:
     exit-code: 0
 
   rules show:
-    command: auth0 rules show $(cat ./test/integration/identifiers/rule-id)
+    command: auth0 rules show $(./test/integration/scripts/get-rule-id.sh)
     stdout:
       contains:
         - NAME     integration-test-rule-newRule
@@ -317,7 +298,7 @@ tests:
 
   # Test 'rules enable'
   rules enable:
-    command: auth0 rules enable $(cat ./test/integration/identifiers/rule-id) --json
+    command: auth0 rules enable $(./test/integration/scripts/get-rule-id.sh) --json
     stdout:
       json:
         enabled: "true"
@@ -325,7 +306,7 @@ tests:
 
   # Test 'rules disable'
   rules disable:
-    command: auth0 rules disable $(cat ./test/integration/identifiers/rule-id) --json
+    command: auth0 rules disable $(./test/integration/scripts/get-rule-id.sh) --json
     stdout:
       json:
         enabled: "false"
@@ -408,13 +389,13 @@ tests:
     exit-code: 0
 
   users roles show:
-    command: auth0 users roles show $(cat ./test/integration/identifiers/user-id)
+    command: auth0 users roles show $(./test/integration/scripts/get-user-id.sh)
     exit-code: 0
 
   users roles add:
-    command: auth0 users roles add $(cat ./test/integration/identifiers/user-id) -r $(cat ./test/integration/identifiers/role-id)
+    command: auth0 users roles add $(./test/integration/scripts/get-user-id.sh) -r $(./test/integration/scripts/get-role-id.sh)
     exit-code: 0
 
   users roles remove:
-    command: auth0 users roles rm $(cat ./test/integration/identifiers/user-id) -r $(cat ./test/integration/identifiers/role-id)
+    command: auth0 users roles rm $(./test/integration/scripts/get-user-id.sh) -r $(./test/integration/scripts/get-role-id.sh)
     exit-code: 0


### PR DESCRIPTION
### 🔧 Changes

In order for many integration tests to pass with strong assertions, test resources must exist on the testing tenant. Previously, this was a two step process, creating a resource and then fetching the ID. However, this meant that in order to use a test resource's ID in a test, it needs to be explicitly created beforehand. With many Auth0 resources existing in a web of co-dependencies, it is arduous to orchestrate the creation of these test resources and prohibits test files from being run in isolation. Instead, this PR combine the process into a single script, precluding the need to explicitly define a steps for creating test resources.

The result are tests that are simpler, eliminate dependencies and increase the ability to run tests in isolation.

### 🔬 Testing

Manually tested to confirm that tests run in isolation. All tests should pass here.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
