### PR TITLE
Add test for deleting all tenant secrets from keyring

### DIFF
--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -88,7 +88,9 @@ func GetAccessToken(tenant string) (string, error) {
 
 	for i := 0; i < secretAccessTokenMaxChunks; i++ {
 		a, err := keyring.Get(fmt.Sprintf("%s %d", secretAccessToken, i), tenant)
-		if err == keyring.ErrNotFound {
+		// Only return if we have pulled more than 1 item from the keyring, otherwise this will be
+		// a valid "secret not found in keyring"
+		if err == keyring.ErrNotFound && i > 1 {
 			return accessToken, nil
 		}
 		if err != nil {

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -90,7 +90,7 @@ func GetAccessToken(tenant string) (string, error) {
 		a, err := keyring.Get(fmt.Sprintf("%s %d", secretAccessToken, i), tenant)
 		// Only return if we have pulled more than 1 item from the keyring, otherwise this will be
 		// a valid "secret not found in keyring"
-		if err == keyring.ErrNotFound && i > 1 {
+		if err == keyring.ErrNotFound && i > 0 {
 			return accessToken, nil
 		}
 		if err != nil {

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -101,6 +101,48 @@ func TestSecrets(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "chunk0chunk1chunk2", actualAccessToken)
 	})
+
+	t.Run("it successfully deletes all secrets for a tenant", func(t *testing.T) {
+		keyring.MockInit()
+
+		// Store keys and check they were set
+		expectedAccessToken := randomStringOfLength((2048 * 5) + 1) // Some arbitrarily long random string
+		err := StoreAccessToken(testTenantName, expectedAccessToken)
+		assert.NoError(t, err)
+		actualAccessToken, err := GetAccessToken(testTenantName)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedAccessToken, actualAccessToken)
+
+		expectedClientSecret := "some-client-secret"
+		err = StoreClientSecret(testTenantName, expectedClientSecret)
+		assert.NoError(t, err)
+		actualClientSecret, err := GetClientSecret(testTenantName)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedClientSecret, actualClientSecret)
+
+		expectedRefreshToken := "fake-refresh-token"
+		err = StoreRefreshToken(testTenantName, expectedRefreshToken)
+		assert.NoError(t, err)
+		actualRefreshToken, err := GetRefreshToken(testTenantName)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedRefreshToken, actualRefreshToken)
+
+		err = DeleteSecretsForTenant(testTenantName)
+		assert.NoError(t, err)
+
+		// Assert that values were deleted
+		actualAccessToken, err = GetAccessToken(testTenantName)
+		assert.EqualError(t, err, keyring.ErrNotFound.Error())
+		assert.Equal(t, "", actualAccessToken)
+
+		actualClientSecret, err = GetClientSecret(testTenantName)
+		assert.EqualError(t, err, keyring.ErrNotFound.Error())
+		assert.Equal(t, "", actualClientSecret)
+
+		actualRefreshToken, err = GetRefreshToken(testTenantName)
+		assert.EqualError(t, err, keyring.ErrNotFound.Error())
+		assert.Equal(t, "", actualRefreshToken)
+	})
 }
 
 func randomStringOfLength(length int) string {


### PR DESCRIPTION

### 🔧 Changes

This adds a test that stores tokens/secrets, calls `DeleteSecretsForTenant` to delete them, and then asserts they were deleted.

Also fixes an issue where the secret not found error was not being returned for GetAccessToken as looking it up would return an empty string and nil on the first token lookup as it satisfied the `err == keyring.ErrNotFound` condition. The change here is to only return the accessToken early if we have pulled more than 1 item from the keyring 

### 📚 References


### 🔬 Testing

Adds tests mostly, and change included is covered by said tests

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
