### PR TITLE
Add tests for auth0 orgs roles members list

### DIFF
--- a/internal/cli/organizations.go
+++ b/internal/cli/organizations.go
@@ -638,12 +638,13 @@ func listMembersRolesOrganizationCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List organization members for a role",
-		Long:  "List organization members that have a given role assigned to them.",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List organization members for a role",
+		Long:    "List organization members that have a given role assigned to them.",
 		Example: `  auth0 orgs roles members list
-  auth0 orgs roles members ls
+  auth0 orgs roles members ls <org-id>
   auth0 orgs roles members list <org-id> --role-id role
   auth0 orgs roles members list <org-id> --role-id role --number 100
   auth0 orgs roles members ls <org-id> -r role -n 100

--- a/test/integration/organzations-test-cases.yaml
+++ b/test/integration/organzations-test-cases.yaml
@@ -108,3 +108,12 @@ tests:
     stderr:
       contains:
         - number flag invalid, please pass a number between 1 and 1000
+  016 - list organization roles members:
+    command: auth0 orgs roles members list $(./test/integration/scripts/get-org-id.sh)
+    exit-code: 0
+  017 - list organization roles members with invalid number:
+    command: auth0 orgs roles members list $(./test/integration/scripts/get-org-id.sh) --number 1001
+    exit-code: 1
+    stderr:
+      contains:
+        - number flag invalid, please pass a number between 1 and 1000


### PR DESCRIPTION
### 🔧 Changes

Probably a small increase, but this PR adds a couple basic tests for `auth0 orgs roles members list` and corrects the command alias and help text.

This command could probably be exercised better but without a `auth0 orgs roles members add` command it would probably involve crafting requests using `auth0 api`

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Mostly testing, but verified that `auth0 orgs roles members ls` works and the help text is as expected

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
