### PR TITLE
Add tests for authutil package

### DIFF
--- a/internal/auth/authutil/browser_test.go
+++ b/internal/auth/authutil/browser_test.go
@@ -72,6 +72,5 @@ func TestWaitForBrowserCallback(t *testing.T) {
 		assert.EqualError(t, callbackErr, "listen tcp 127.0.0.1:1234: bind: address already in use")
 		assert.Equal(t, "", code)
 		assert.Equal(t, "", state)
-
 	})
 }

--- a/internal/auth/authutil/browser_test.go
+++ b/internal/auth/authutil/browser_test.go
@@ -52,6 +52,5 @@ func TestWaitForBrowserCallbackSuccess(t *testing.T) {
 		assert.Error(t, callbackErr)
 		assert.Equal(t, "", code)
 		assert.Equal(t, "", state)
-
 	})
 }

--- a/internal/auth/authutil/browser_test.go
+++ b/internal/auth/authutil/browser_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWaitForBrowserCallbackSuccess(t *testing.T) {
+func TestWaitForBrowserCallback(t *testing.T) {
 	t.Run("Test success callback", func(t *testing.T) {
 		// Set a timer to wait for the server to have started and then call the URL and assert.
 		time.AfterFunc(1*time.Second, func() {

--- a/internal/auth/authutil/browser_test.go
+++ b/internal/auth/authutil/browser_test.go
@@ -1,0 +1,57 @@
+package authutil
+
+import (
+	_ "embed"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitForBrowserCallbackSuccess(t *testing.T) {
+	t.Run("Test success callback", func(t *testing.T) {
+		// Set a timer to wait for the server to have started and then call the URL and assert.
+		time.AfterFunc(1*time.Second, func() {
+			client := &http.Client{}
+			url := "http://localhost:1234?code=1234&state=1234"
+			resp, err := client.Get(url)
+			assert.NoError(t, err)
+
+			bytes, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			body := string(bytes)
+
+			defer resp.Body.Close()
+			assert.Contains(t, body, "You can close the window and go back to the CLI to see the user info and tokens.")
+		})
+
+		code, state, callbackErr := WaitForBrowserCallback("localhost:1234")
+		assert.NoError(t, callbackErr)
+		assert.Equal(t, "1234", code)
+		assert.Equal(t, "1234", state)
+	})
+
+	t.Run("Test error callback", func(t *testing.T) {
+		// Set a timer to wait for the server to have started and then call the URL and assert.
+		time.AfterFunc(1*time.Second, func() {
+			client := &http.Client{}
+			url := "http://localhost:1234?error=foo&error_description=bar"
+			resp, err := client.Get(url)
+			assert.NoError(t, err)
+			bytes, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			body := string(bytes)
+			defer resp.Body.Close()
+
+			assert.Contains(t, body, "Unable to extract code from request, please try authenticating again")
+		})
+
+		code, state, callbackErr := WaitForBrowserCallback("localhost:1234")
+		assert.Error(t, callbackErr)
+		assert.Equal(t, "", code)
+		assert.Equal(t, "", state)
+
+	})
+}

--- a/internal/auth/authutil/exchange.go
+++ b/internal/auth/authutil/exchange.go
@@ -18,7 +18,7 @@ type TokenResponse struct {
 }
 
 // ExchangeCodeForToken fetches an access token for the given application using the provided code.
-func ExchangeCodeForToken(baseDomain, clientID, clientSecret, code, cbURL string) (*TokenResponse, error) {
+func ExchangeCodeForToken(httpClient *http.Client, baseDomain, clientID, clientSecret, code, cbURL string) (*TokenResponse, error) {
 	data := url.Values{
 		"grant_type":    {"authorization_code"},
 		"client_id":     {clientID},
@@ -28,7 +28,7 @@ func ExchangeCodeForToken(baseDomain, clientID, clientSecret, code, cbURL string
 	}
 
 	u := url.URL{Scheme: "https", Host: baseDomain, Path: "/oauth/token"}
-	r, err := http.PostForm(u.String(), data)
+	r, err := httpClient.PostForm(u.String(), data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to exchange code for token: %w", err)
 	}

--- a/internal/auth/authutil/exchange_test.go
+++ b/internal/auth/authutil/exchange_test.go
@@ -1,0 +1,38 @@
+package authutil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExchangeCodeForToken(t *testing.T) {
+	t.Run("Test success call", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{
+				"access_token": "access-token-here",
+				"id_token": "id-token-here",
+				"token_type": "token-type-here",
+				"expires_in": 1000
+			}`)
+		}))
+
+		defer ts.Close()
+		parsedURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+
+		token, err := ExchangeCodeForToken(ts.Client(), parsedURL.Host, "some-client-id", "some-client-secret", "some-code", "http://localhost:8484")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "access-token-here", token.AccessToken)
+		assert.Equal(t, "id-token-here", token.IDToken)
+		assert.Equal(t, "token-type-here", token.TokenType)
+		assert.Equal(t, int64(1000), token.ExpiresIn)
+	})
+
+}

--- a/internal/auth/authutil/exchange_test.go
+++ b/internal/auth/authutil/exchange_test.go
@@ -34,5 +34,4 @@ func TestExchangeCodeForToken(t *testing.T) {
 		assert.Equal(t, "token-type-here", token.TokenType)
 		assert.Equal(t, int64(1000), token.ExpiresIn)
 	})
-
 }

--- a/internal/auth/authutil/user_info.go
+++ b/internal/auth/authutil/user_info.go
@@ -32,7 +32,7 @@ type UserInfo struct {
 }
 
 // FetchUserInfo fetches and parses user information with the provided access token.
-func FetchUserInfo(baseDomain, token string) (*UserInfo, error) {
+func FetchUserInfo(httpClient *http.Client, baseDomain, token string) (*UserInfo, error) {
 	endpoint := url.URL{Scheme: "https", Host: baseDomain, Path: "/userinfo"}
 
 	req, err := http.NewRequest("GET", endpoint.String(), nil)
@@ -41,7 +41,7 @@ func FetchUserInfo(baseDomain, token string) (*UserInfo, error) {
 	}
 	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", token))
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to exchange code for token: %w", err)
 	}

--- a/internal/auth/authutil/user_info_test.go
+++ b/internal/auth/authutil/user_info_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUserInfo(t *testing.T) {
-	t.Run("Test success call", func(t *testing.T) {
+	t.Run("Successfully call user info endpoint", func(t *testing.T) {
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer token", r.Header.Get("authorization"))
 
@@ -28,4 +28,42 @@ func TestUserInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Joe Bloggs", *user.Name)
 	})
+
+	testCases := []struct {
+		name       string
+		expect     string
+		httpStatus int
+		response   string
+	}{
+		{
+			name:       "Bad status code",
+			expect:     "unable to fetch user info: 404 Not Found",
+			httpStatus: http.StatusNotFound,
+		},
+		{
+			name:       "Malformed JSON",
+			expect:     "cannot decode response: unexpected EOF",
+			httpStatus: http.StatusOK,
+			response:   `{ "foo": "bar" `,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(testCase.httpStatus)
+				if testCase.response != "" {
+					io.WriteString(w, testCase.response)
+				}
+			}))
+
+			defer ts.Close()
+			parsedURL, err := url.Parse(ts.URL)
+			assert.NoError(t, err)
+
+			_, err = FetchUserInfo(ts.Client(), parsedURL.Host, "token")
+
+			assert.EqualError(t, err, testCase.expect)
+		})
+	}
 }

--- a/internal/auth/authutil/user_info_test.go
+++ b/internal/auth/authutil/user_info_test.go
@@ -1,0 +1,31 @@
+package authutil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserInfo(t *testing.T) {
+	t.Run("Test success call", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer token", r.Header.Get("authorization"))
+
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"name": "Joe Bloggs"}`)
+		}))
+
+		defer ts.Close()
+		parsedURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+
+		user, err := FetchUserInfo(ts.Client(), parsedURL.Host, "token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "Joe Bloggs", *user.Name)
+	})
+}

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/spf13/cobra"
@@ -153,7 +154,7 @@ func testLoginCmd(cli *cli) *cobra.Command {
 			var userInfo *authutil.UserInfo
 			if err := ansi.Spinner("Fetching user metadata", func() error {
 				// Use the access token to fetch user information from the /userinfo endpoint.
-				userInfo, err = authutil.FetchUserInfo(tenant.Domain, tokenResponse.AccessToken)
+				userInfo, err = authutil.FetchUserInfo(http.DefaultClient, tenant.Domain, tokenResponse.AccessToken)
 				return err
 			}); err != nil {
 				return fmt.Errorf("failed to fetch user info: %w", err)

--- a/internal/cli/utils_shared.go
+++ b/internal/cli/utils_shared.go
@@ -165,6 +165,7 @@ func runLoginFlow(cli *cli, t Tenant, c *management.Client, connName, audience, 
 		// once the callback is received, exchange the code for an access
 		// token.
 		tokenResponse, err = authutil.ExchangeCodeForToken(
+			http.DefaultClient,
 			t.Domain,
 			c.GetClientID(),
 			c.GetClientSecret(),


### PR DESCRIPTION
### 🔧 Changes

Add tests that cover the `authutil` package (this is used by `auth0 test`). In order to facilitate the testing of `FetchUserInfo` and `ExchangeCodeForToken` the signature of these functions was changed to accept an `http.Client` as the first argument as these require HTTPS calls.

### 📚 References


### 🔬 Testing

This mostly adds test coverage, but the code refactors are covered by said tests and a manual run of `auth0 test`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
