### PR TITLE
Remove unused display code

### DIFF
--- a/internal/display/attack_protection.go
+++ b/internal/display/attack_protection.go
@@ -19,16 +19,11 @@ type breachedPasswordDetectionView struct {
 }
 
 func (bpd *breachedPasswordDetectionView) AsTableHeader() []string {
-	return []string{"Enabled", "Shields", "AdminNotificationFrequency", "Method"}
+	return []string{}
 }
 
 func (bpd *breachedPasswordDetectionView) AsTableRow() []string {
-	return []string{
-		bpd.Enabled,
-		strings.Join(bpd.Shields, ", "),
-		strings.Join(bpd.AdminNotificationFrequency, ", "),
-		bpd.Method,
-	}
+	return []string{}
 }
 
 func (bpd *breachedPasswordDetectionView) KeyValues() [][]string {
@@ -76,17 +71,11 @@ type bruteForceProtectionView struct {
 }
 
 func (bfp *bruteForceProtectionView) AsTableHeader() []string {
-	return []string{"Enabled", "Shields", "AllowList", "Mode", "MaxAttempts"}
+	return []string{}
 }
 
 func (bfp *bruteForceProtectionView) AsTableRow() []string {
-	return []string{
-		bfp.Enabled,
-		strings.Join(bfp.Shields, ", "),
-		strings.Join(bfp.AllowList, ", "),
-		bfp.Mode,
-		strconv.Itoa(bfp.MaxAttempts),
-	}
+	return []string{}
 }
 
 func (bfp *bruteForceProtectionView) KeyValues() [][]string {
@@ -138,27 +127,11 @@ type suspiciousIPThrottlingView struct {
 }
 
 func (sit *suspiciousIPThrottlingView) AsTableHeader() []string {
-	return []string{
-		"Enabled",
-		"Shields",
-		"AllowList",
-		"StagePreLoginMaxAttempts",
-		"StagePreLoginRate",
-		"StagePreUserRegistrationMaxAttempts",
-		"StagePreUserRegistrationRate",
-	}
+	return []string{}
 }
 
 func (sit *suspiciousIPThrottlingView) AsTableRow() []string {
-	return []string{
-		sit.Enabled,
-		strings.Join(sit.Shields, ", "),
-		strings.Join(sit.AllowList, ", "),
-		strconv.Itoa(sit.StagePreLoginMaxAttempts),
-		strconv.Itoa(sit.StagePreLoginRate),
-		strconv.Itoa(sit.StagePreUserRegistrationMaxAttempts),
-		strconv.Itoa(sit.StagePreUserRegistrationRate),
-	}
+	return []string{}
 }
 
 func (sit *suspiciousIPThrottlingView) KeyValues() [][]string {

--- a/internal/display/members.go
+++ b/internal/display/members.go
@@ -23,12 +23,7 @@ func (v *membersView) AsTableRow() []string {
 }
 
 func (v *membersView) KeyValues() [][]string {
-	return [][]string{
-		{"ID", ansi.Faint(v.ID)},
-		{"NAME", v.Name},
-		{"EMAIL", v.Email},
-		{"PICTURE URL", v.PictureURL},
-	}
+	return [][]string{}
 }
 
 func (v *membersView) Object() interface{} {

--- a/internal/display/role_permissions.go
+++ b/internal/display/role_permissions.go
@@ -34,12 +34,7 @@ func (v *rolePermissionView) AsTableRow() []string {
 }
 
 func (v *rolePermissionView) KeyValues() [][]string {
-	return [][]string{
-		{"ID", ansi.Faint(v.APIID)},
-		{"NAME", v.APIName},
-		{"PERMISSION NAME", v.Name},
-		{"DESCRIPTION", v.Description},
-	}
+	return [][]string{}
 }
 
 func (r *Renderer) RolePermissionList(perms []*management.Permission) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR removes unused code in the `display` package.

#### auth0 protection bpd show

<img width="479" alt="Screenshot 2023-04-03 at 12 20 11 PM" src="https://user-images.githubusercontent.com/5055789/229554835-43ba3f53-6306-4055-8290-fcc2224139ad.png">

This command uses a key/value view, yet the list view was still fully implemented. The list view implementation was replaced with an empty array.

#### auth0 protection bfp show

<img width="446" alt="Screenshot 2023-04-03 at 12 20 03 PM" src="https://user-images.githubusercontent.com/5055789/229555011-0a679ca7-e868-4cc0-8c04-6f6224c31a55.png">

This command uses a key/value view, yet the list view was still fully implemented. The list view implementation was replaced with an empty array.

#### auth0 protection sit show

<img width="578" alt="Screenshot 2023-04-03 at 12 19 54 PM" src="https://user-images.githubusercontent.com/5055789/229555046-40b30f28-ec6d-4fe5-94b5-d008bdd2f574.png">

This command uses a key/value view, yet the list view was still fully implemented. The list view implementation was replaced with an empty array.

#### roles permissions add

<img width="839" alt="Screenshot 2023-04-03 at 12 19 47 PM" src="https://user-images.githubusercontent.com/5055789/229555235-ec436221-6815-4273-a02a-7342d2687cc8.png">

Unlike other 'creation' commands, this one does not use a key/value view, but a custom view; yet the key/value view was still fully implemented. The key/value view was replaced with an empty array.

#### orgs members list, orgs roles members list

<img width="1235" alt="Screenshot 2023-04-03 at 12 25 30 PM" src="https://user-images.githubusercontent.com/5055789/229558975-a3911621-720f-4fad-96a4-cb0e3e5d5cd2.png">

<img width="1236" alt="Screenshot 2023-04-03 at 12 20 36 PM" src="https://user-images.githubusercontent.com/5055789/229555309-265d2a36-9ce8-461c-bfb5-7c993f3f9db0.png">

These commands use a list view, yet the key/value view was still fully implemented. The key/value view implementation was replaced with an empty array.

### 🔬 Testing

This PR just removes unused code.

### 📝 Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)
-->