### PR TITLE
Add missing getter tests

### DIFF
--- a/internal/cli/arguments_test.go
+++ b/internal/cli/arguments_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArgumentGetters(t *testing.T) {
+	t.Run("returns the name", func(t *testing.T) {
+		argument := Argument{Name: "Foo"}
+		want := "Foo"
+		got := argument.GetName()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the label", func(t *testing.T) {
+		argument := Argument{Name: "Foo"}
+		want := "Foo:"
+		got := argument.GetLabel()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the help", func(t *testing.T) {
+		argument := Argument{Help: "Foo"}
+		want := "Foo"
+		got := argument.GetHelp()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns that the argument is required", func(t *testing.T) {
+		argument := Argument{}
+		want := true
+		got := argument.GetIsRequired()
+
+		assert.Equal(t, want, got)
+	})
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagGetters(t *testing.T) {
+	t.Run("returns the name", func(t *testing.T) {
+		flag := Flag{Name: "Foo"}
+		want := "Foo"
+		got := flag.GetName()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the label", func(t *testing.T) {
+		flag := Flag{Name: "Foo"}
+		want := "Foo:"
+		got := flag.GetLabel()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the help", func(t *testing.T) {
+		flag := Flag{Help: "Foo"}
+		want := "Foo"
+		got := flag.GetHelp()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns that the flag is required", func(t *testing.T) {
+		flag := Flag{IsRequired: true}
+		want := true
+		got := flag.GetIsRequired()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns that the flag is not required", func(t *testing.T) {
+		flag := Flag{IsRequired: false}
+		want := false
+		got := flag.GetIsRequired()
+
+		assert.Equal(t, want, got)
+	})
+}

--- a/internal/cli/picker_option_test.go
+++ b/internal/cli/picker_option_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPickerOptions(t *testing.T) {
+	t.Run("returns the labels", func(t *testing.T) {
+		options := pickerOptions{pickerOption{label: "Foo"}, pickerOption{label: "Bar"}}
+		want := []string{"Foo", "Bar"}
+		got := options.labels()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the default label", func(t *testing.T) {
+		options := pickerOptions{pickerOption{label: "Foo"}, pickerOption{label: "Bar"}}
+		want := "Foo"
+		got := options.defaultLabel()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns an empty label when there are no options", func(t *testing.T) {
+		options := pickerOptions{}
+		want := ""
+		got := options.defaultLabel()
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns the value for a given label", func(t *testing.T) {
+		options := pickerOptions{pickerOption{label: "Foo", value: "0"}, pickerOption{label: "Bar", value: "1"}}
+		want := "1"
+		got := options.getValue("Bar")
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns an empty value given a non-existent label", func(t *testing.T) {
+		options := pickerOptions{pickerOption{label: "Foo"}}
+		want := ""
+		got := options.getValue("Bar")
+
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

This PR adds unit tests for the getters of:

- `Argument`
- `Flag`
- `pickerOptions`

### 🔬 Testing

This PR just adds unit tests.

### 📝 Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
