### PR TITLE
Remove extra headings in `apis list`

### DIFF
--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -70,7 +70,6 @@ func (v *apiTableView) Object() interface{} {
 func (r *Renderer) APIList(apis []*management.ResourceServer) {
 	resource := "apis"
 
-	r.Heading(resource)
 	r.Heading(fmt.Sprintf("%s (%d)", resource, len(apis)))
 
 	if len(apis) == 0 {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes an issue where the output of `apis list` would print the header twice.

#### Before

<img width="856" alt="Screenshot 2023-04-03 at 8 04 22 PM" src="https://user-images.githubusercontent.com/5055789/229649903-4bba6d96-6cf8-44ca-983f-57bbfe067d03.png">

#### After

<img width="847" alt="Screenshot 2023-04-03 at 8 42 36 PM" src="https://user-images.githubusercontent.com/5055789/229650094-07034d34-2568-431f-9ac7-afe350f82d09.png">

### 📝 Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)