### PR TITLE
Removing -v govulncheck flag 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ lint: $(GO_BIN)/golangci-lint ## Run go linter checks
 
 check-vuln: $(GO_BIN)/govulncheck ## Check go vulnerabilities
 	${call print, "Running govulncheck over project"}
-	@govulncheck -v ./...
+	@govulncheck ./...
 
 check-docs: ## Check that documentation was generated correctly
 	${call print, "Checking that documentation was generated correctly"}


### PR DESCRIPTION
### 🔧 Changes

The `govulncheck` vulnerability detection utility removed the `-v` flag that we had previously been using for verbose output. This caused our builds to [fail at the "Checks" step](https://github.com/auth0/auth0-cli/actions/runs/4632685641/jobs/8197056423?pr=718). 

The specific commit can be seen here: https://github.com/golang/vuln/commit/ebda8dc8a2d6000060ede47302142dee6a10319a. 

This tool is still versioned v0.0.0 so still very early days. Perhaps we should reconsider its maturity and wether the instability is worth the benefits.

### 📚 References

- [Govulncheck removal commit](https://github.com/golang/vuln/commit/ebda8dc8a2d6000060ede47302142dee6a10319a): 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
