### PR TITLE
Log streams scripts – check success

### DIFF
--- a/test/integration/logs-test-cases.yaml
+++ b/test/integration/logs-test-cases.yaml
@@ -22,12 +22,10 @@ tests:
         - Use 'auth0 logs streams create' to add one
 
   003 - it successfully creates a datadog log stream:
-    skip: true
     command: ./test/integration/scripts/create-log-stream-datadog-id.sh
     exit-code: 0
 
   004 - it successfully lists all log streams with data:
-    skip: true
     command: auth0 logs streams list
     exit-code: 0
     stdout:
@@ -38,7 +36,6 @@ tests:
         - STATUS
 
   005 - given a datadog log stream, it successfully gets the log stream's details:
-    skip: true
     command: auth0 logs streams show $(cat ./test/integration/identifiers/log-stream-datadog-id)
     exit-code: 0
     stdout:
@@ -48,7 +45,6 @@ tests:
         - STATUS  active
 
   006 - given a datadog log stream, it successfully gets the log stream's details and outputs in json:
-    skip: true
     command: auth0 logs streams show $(cat ./test/integration/identifiers/log-stream-datadog-id) --json
     exit-code: 0
     stdout:
@@ -59,7 +55,6 @@ tests:
         sink.datadogRegion: "eu"
 
   007 - given a datadog log stream, it successfully updates the log stream's details:
-    skip: true
     command: auth0 logs streams update datadog $(cat ./test/integration/identifiers/log-stream-datadog-id) --name integration-test-updated-datadog --region us --api-key 123123123123123 --json
     exit-code: 0
     stdout:
@@ -70,7 +65,6 @@ tests:
         sink.datadogRegion: "us"
 
   008 - given a datadog log stream, it successfully opens the log stream's settings page:
-    skip: true
     command: auth0 logs streams open $(cat ./test/integration/identifiers/log-stream-datadog-id) --no-input
     exit-code: 0
     stderr:
@@ -78,17 +72,14 @@ tests:
         - "Open the following URL in a browser"
 
   009 - given a datadog log stream, it successfully deletes the log stream:
-    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-datadog-id) --force --no-input
     exit-code: 0
 
   010 - it successfully creates an eventbridge log stream:
-    skip: true
     command: ./test/integration/scripts/create-log-stream-eventbridge-id.sh
     exit-code: 0
 
   011 - given an eventbridge log stream, it successfully updates the log stream's details:
-    skip: true
     command: auth0 logs streams update eventbridge $(cat ./test/integration/identifiers/log-stream-eventbridge-id) --name integration-test-updated-eventbridge --json
     exit-code: 0
     stdout:
@@ -98,17 +89,14 @@ tests:
         status: "active"
 
   012 - given an eventbridge log stream, it successfully deletes the log stream:
-    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-eventbridge-id) --force --no-input
     exit-code: 0
 
   013 - it successfully creates an http log stream:
-    skip: true
     command: ./test/integration/scripts/create-log-stream-http-id.sh
     exit-code: 0
 
   014 - given an http log stream, it successfully updates the log stream's details:
-    skip: true
     command: auth0 logs streams update http $(cat ./test/integration/identifiers/log-stream-http-id) --name integration-test-updated-http --endpoint "https://example.com/webhook/logs/v2" --format "JSONOBJECT" --type "application/xml" --authorization "KHEWXXXXXXXXXXXXXXXX" --json --no-input
     exit-code: 0
     stdout:
@@ -122,17 +110,14 @@ tests:
         sink.httpAuthorization: "KHEWXXXXXXXXXXXXXXXX"
 
   015 - given an http log stream, it successfully deletes the log stream:
-    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-http-id) --force --no-input
     exit-code: 0
 
   016 - it successfully creates a splunk log stream:
-    skip: true
     command: ./test/integration/scripts/create-log-stream-splunk-id.sh
     exit-code: 0
 
   017 - given a splunk log stream, it successfully updates the log stream's details:
-    skip: true
     command: auth0 logs streams update splunk $(cat ./test/integration/identifiers/log-stream-splunk-id) --name integration-test-updated-splunk --domain "example.splunk.com" --token "92a34ab5-c6d7-8901-23ef-456b7c89d0c1" --port 8000 --secure --json --no-input
     exit-code: 0
     stdout:
@@ -146,17 +131,14 @@ tests:
         sink.splunkSecure: "true"
 
   018 - given a splunk log stream, it successfully deletes the log stream:
-    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-splunk-id) --force --no-input
     exit-code: 0
 
   019 - it successfully creates a sumo log stream:
-    skip: true
     command: ./test/integration/scripts/create-log-stream-sumo-id.sh
     exit-code: 0
 
   020 - given a sumo log stream, it successfully updates the log stream's details:
-    skip: true
     command: auth0 logs streams update sumo $(cat ./test/integration/identifiers/log-stream-sumo-id) --name integration-test-updated-sumo --source "example.sumo.com" --json --no-input
     exit-code: 0
     stdout:
@@ -167,6 +149,5 @@ tests:
         sink.sumoSourceAddress: "example.sumo.com"
 
   021 - given a sumo log stream, it successfully deletes the log stream:
-    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-sumo-id) --force --no-input
     exit-code: 0

--- a/test/integration/logs-test-cases.yaml
+++ b/test/integration/logs-test-cases.yaml
@@ -22,10 +22,12 @@ tests:
         - Use 'auth0 logs streams create' to add one
 
   003 - it successfully creates a datadog log stream:
+    skip: true
     command: ./test/integration/scripts/create-log-stream-datadog-id.sh
     exit-code: 0
-  
+
   004 - it successfully lists all log streams with data:
+    skip: true
     command: auth0 logs streams list
     exit-code: 0
     stdout:
@@ -36,6 +38,7 @@ tests:
         - STATUS
 
   005 - given a datadog log stream, it successfully gets the log stream's details:
+    skip: true
     command: auth0 logs streams show $(cat ./test/integration/identifiers/log-stream-datadog-id)
     exit-code: 0
     stdout:
@@ -45,6 +48,7 @@ tests:
         - STATUS  active
 
   006 - given a datadog log stream, it successfully gets the log stream's details and outputs in json:
+    skip: true
     command: auth0 logs streams show $(cat ./test/integration/identifiers/log-stream-datadog-id) --json
     exit-code: 0
     stdout:
@@ -55,6 +59,7 @@ tests:
         sink.datadogRegion: "eu"
 
   007 - given a datadog log stream, it successfully updates the log stream's details:
+    skip: true
     command: auth0 logs streams update datadog $(cat ./test/integration/identifiers/log-stream-datadog-id) --name integration-test-updated-datadog --region us --api-key 123123123123123 --json
     exit-code: 0
     stdout:
@@ -65,6 +70,7 @@ tests:
         sink.datadogRegion: "us"
 
   008 - given a datadog log stream, it successfully opens the log stream's settings page:
+    skip: true
     command: auth0 logs streams open $(cat ./test/integration/identifiers/log-stream-datadog-id) --no-input
     exit-code: 0
     stderr:
@@ -72,14 +78,17 @@ tests:
         - "Open the following URL in a browser"
 
   009 - given a datadog log stream, it successfully deletes the log stream:
+    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-datadog-id) --force --no-input
     exit-code: 0
 
   010 - it successfully creates an eventbridge log stream:
+    skip: true
     command: ./test/integration/scripts/create-log-stream-eventbridge-id.sh
     exit-code: 0
 
   011 - given an eventbridge log stream, it successfully updates the log stream's details:
+    skip: true
     command: auth0 logs streams update eventbridge $(cat ./test/integration/identifiers/log-stream-eventbridge-id) --name integration-test-updated-eventbridge --json
     exit-code: 0
     stdout:
@@ -89,14 +98,17 @@ tests:
         status: "active"
 
   012 - given an eventbridge log stream, it successfully deletes the log stream:
+    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-eventbridge-id) --force --no-input
     exit-code: 0
 
   013 - it successfully creates an http log stream:
+    skip: true
     command: ./test/integration/scripts/create-log-stream-http-id.sh
     exit-code: 0
 
   014 - given an http log stream, it successfully updates the log stream's details:
+    skip: true
     command: auth0 logs streams update http $(cat ./test/integration/identifiers/log-stream-http-id) --name integration-test-updated-http --endpoint "https://example.com/webhook/logs/v2" --format "JSONOBJECT" --type "application/xml" --authorization "KHEWXXXXXXXXXXXXXXXX" --json --no-input
     exit-code: 0
     stdout:
@@ -110,14 +122,17 @@ tests:
         sink.httpAuthorization: "KHEWXXXXXXXXXXXXXXXX"
 
   015 - given an http log stream, it successfully deletes the log stream:
+    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-http-id) --force --no-input
     exit-code: 0
 
   016 - it successfully creates a splunk log stream:
+    skip: true
     command: ./test/integration/scripts/create-log-stream-splunk-id.sh
     exit-code: 0
 
   017 - given a splunk log stream, it successfully updates the log stream's details:
+    skip: true
     command: auth0 logs streams update splunk $(cat ./test/integration/identifiers/log-stream-splunk-id) --name integration-test-updated-splunk --domain "example.splunk.com" --token "92a34ab5-c6d7-8901-23ef-456b7c89d0c1" --port 8000 --secure --json --no-input
     exit-code: 0
     stdout:
@@ -131,14 +146,17 @@ tests:
         sink.splunkSecure: "true"
 
   018 - given a splunk log stream, it successfully deletes the log stream:
+    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-splunk-id) --force --no-input
     exit-code: 0
 
   019 - it successfully creates a sumo log stream:
+    skip: true
     command: ./test/integration/scripts/create-log-stream-sumo-id.sh
     exit-code: 0
 
   020 - given a sumo log stream, it successfully updates the log stream's details:
+    skip: true
     command: auth0 logs streams update sumo $(cat ./test/integration/identifiers/log-stream-sumo-id) --name integration-test-updated-sumo --source "example.sumo.com" --json --no-input
     exit-code: 0
     stdout:
@@ -149,5 +167,6 @@ tests:
         sink.sumoSourceAddress: "example.sumo.com"
 
   021 - given a sumo log stream, it successfully deletes the log stream:
+    skip: true
     command: auth0 logs streams delete $(cat ./test/integration/identifiers/log-stream-sumo-id) --force --no-input
     exit-code: 0

--- a/test/integration/scripts/create-log-stream-datadog-id.sh
+++ b/test/integration/scripts/create-log-stream-datadog-id.sh
@@ -6,6 +6,10 @@ if [ -f "$FILE" ]; then
 fi
 
 logStream=$( auth0 logs streams create datadog --name integration-test-datadog --region eu --api-key 123233123455 --json --no-input )
+if [ -z "$logStream" ]; then
+    # Log stream unable to be created
+    exit 1
+fi
 
 mkdir -p ./test/integration/identifiers
 echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-eventbridge-id.sh
+++ b/test/integration/scripts/create-log-stream-eventbridge-id.sh
@@ -6,6 +6,10 @@ if [ -f "$FILE" ]; then
 fi
 
 logStream=$( auth0 logs streams create eventbridge --name integration-test-eventbridge --aws-id 999999999999 --aws-region eu-west-1 --json --no-input )
+if [ -z "$logStream" ]; then
+    # Log stream unable to be created
+    exit 1
+fi
 
 mkdir -p ./test/integration/identifiers
 echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-http-id.sh
+++ b/test/integration/scripts/create-log-stream-http-id.sh
@@ -7,5 +7,10 @@ fi
 
 logStream=$( auth0 logs streams create http --name integration-test-http --endpoint "https://example.com/webhook/logs" --type "application/json" --format "JSONLINES" --authorization "AKIAXXXXXXXXXXXXXXXX" --json --no-input )
 
+if [ -z "$logStream" ]; then
+    # Log stream unable to be created
+    exit 1
+fi
+
 mkdir -p ./test/integration/identifiers
 echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-splunk-id.sh
+++ b/test/integration/scripts/create-log-stream-splunk-id.sh
@@ -6,6 +6,10 @@ if [ -f "$FILE" ]; then
 fi
 
 logStream=$( auth0 logs streams create splunk --name integration-test-splunk --domain "demo.splunk.com" --token "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" --port "8088" --secure --json --no-input )
+if [ -z "$logStream" ]; then
+    # Log stream unable to be created
+    exit 1
+fi
 
 mkdir -p ./test/integration/identifiers
 echo "$logStream" | jq -r '.["id"]' > $FILE

--- a/test/integration/scripts/create-log-stream-sumo-id.sh
+++ b/test/integration/scripts/create-log-stream-sumo-id.sh
@@ -6,6 +6,10 @@ if [ -f "$FILE" ]; then
 fi
 
 logStream=$( auth0 logs streams create sumo --name integration-test-sumo --source "demo.sumo.com" --json --no-input )
+if [ -z "$logStream" ]; then
+    # Log stream unable to be created
+    exit 1
+fi
 
 mkdir -p ./test/integration/identifiers
 echo "$logStream" | jq -r '.["id"]' > $FILE


### PR DESCRIPTION


### 🔧 Changes

Derived from #721, proposed simple checks in the log streams creation scripts that will exit code 1 if the creation was unsuccessful. This will prevent the setup test from falsely marking an unsuccessful create as successful, thereby providing more accurate output in the tests.

### 🔬 Testing

Integration tests against this PR will correct mark log stream creates as failures whereas previous PRs did not.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
