### PR TITLE
Prevent panic in fetchBrandingSettingsOrUseDefaults

### DIFF
--- a/internal/cli/universal_login_templates.go
+++ b/internal/cli/universal_login_templates.go
@@ -275,17 +275,18 @@ func ensureCustomDomainIsEnabled(ctx context.Context, api *auth0.API) error {
 }
 
 func fetchBrandingSettingsOrUseDefaults(ctx context.Context, api *auth0.API) *management.Branding {
-	brandingSettings, err := api.Branding.Read(management.Context(ctx))
-	if err != nil {
-		brandingSettings = &management.Branding{} // If we error we'll provide defaults.
+	brandingSettings, _ := api.Branding.Read(management.Context(ctx))
+	if brandingSettings == nil {
+		brandingSettings = &management.Branding{}
 	}
 
-	if brandingSettings.GetColors() == nil {
+	if brandingSettings.Colors == nil {
 		brandingSettings.Colors = &management.BrandingColors{
 			Primary:        auth0.String(defaultPrimaryColor),
 			PageBackground: auth0.String(defaultBackgroundColor),
 		}
 	}
+
 	if brandingSettings.LogoURL == nil {
 		brandingSettings.LogoURL = auth0.String(defaultLogoURL)
 	}

--- a/internal/cli/universal_login_templates_test.go
+++ b/internal/cli/universal_login_templates_test.go
@@ -116,6 +116,17 @@ func TestFetchBrandingSettingsOrUseDefaults(t *testing.T) {
 		},
 		{
 			name:     "no branding settings",
+			branding: nil,
+			assertOutput: func(t testing.TB, branding *management.Branding) {
+				assert.NotNil(t, branding)
+				assert.NotNil(t, branding.Colors)
+				assert.Equal(t, branding.Colors.GetPrimary(), defaultPrimaryColor)
+				assert.Equal(t, branding.Colors.GetPageBackground(), defaultBackgroundColor)
+				assert.Equal(t, branding.GetLogoURL(), defaultLogoURL)
+			},
+		},
+		{
+			name:     "empty branding settings",
 			branding: &management.Branding{},
 			assertOutput: func(t testing.TB, branding *management.Branding) {
 				assert.NotNil(t, branding)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As pointed out in https://github.com/auth0/auth0-cli/issues/515#issuecomment-1500943147, the ul templates update command panics in case there are no branding settings returned by the API and no error.

This PR prevents that from occuring. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
