### PR TITLE
Updating boolean flag doc examples

### DIFF
--- a/docs/auth0_apis_create.md
+++ b/docs/auth0_apis_create.md
@@ -23,8 +23,8 @@ auth0 apis create [flags]
   auth0 apis create --name myapi
   auth0 apis create --name myapi --identifier http://my-api
   auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100
-  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access
-  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access false --scopes "letter:write,letter:read"
+  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access=true
+  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read"
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --json
 ```
 

--- a/docs/auth0_apis_update.md
+++ b/docs/auth0_apis_update.md
@@ -23,8 +23,8 @@ auth0 apis update [flags]
   auth0 apis update <api-id|api-audience>
   auth0 apis update <api-id|api-audience> --name myapi
   auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100
-  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access false
-  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access false --scopes "letter:write,letter:read"
+  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access=false
+  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read"
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --json
 ```
 

--- a/docs/auth0_email_templates_update.md
+++ b/docs/auth0_email_templates_update.md
@@ -22,13 +22,13 @@ auth0 email templates update [flags]
   auth0 email templates update
   auth0 email templates update <template>
   auth0 email templates update <template> --json
-  auth0 email templates update welcome --enabled true
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome" --url "https://example.com"
-  auth0 email templates update welcome -e true -b "$(cat path/to/body.html)" -f "welcome@example.com" -l 6100 -s "Welcome" -u "https://example.com" --json
+  auth0 email templates update welcome --enabled=true
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)"
+  auth0 email templates update welcome --enabled=false --body "$(cat path/to/body.html)" --from "welcome@example.com"
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100
+  auth0 email templates update welcome --enabled=false --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome"
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome" --url "https://example.com"
+  auth0 email templates update welcome -e=true -b "$(cat path/to/body.html)" -f "welcome@example.com" -l 6100 -s "Welcome" -u "https://example.com" --json
 ```
 
 

--- a/docs/auth0_logs_streams_create_splunk.md
+++ b/docs/auth0_logs_streams_create_splunk.md
@@ -24,7 +24,7 @@ auth0 logs streams create splunk [flags]
   auth0 log streams create splunk --name <name> --domain <domain>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
-  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
   auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json
 ```

--- a/docs/auth0_logs_streams_update_splunk.md
+++ b/docs/auth0_logs_streams_update_splunk.md
@@ -24,9 +24,9 @@ auth0 logs streams update splunk [flags]
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
-  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
-  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json
+  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s=false --json
 ```
 
 

--- a/docs/auth0_protection_breached-password-detection_update.md
+++ b/docs/auth0_protection_breached-password-detection_update.md
@@ -16,11 +16,11 @@ auth0 protection breached-password-detection update [flags]
 
 ```
   auth0 protection breached-password-detection update
-  auth0 ap bpd update --enabled true
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly --method enhanced
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly --method enhanced --shields admin_notification
-  auth0 ap bpd update -e true -f weekly -m enhanced -s admin_notification --json
+  auth0 ap bpd update --enabled=true
+  auth0 ap bpd update --enabled=true --admin-notification-frequency weekly
+  auth0 ap bpd update --enabled=false --admin-notification-frequency weekly --method enhanced
+  auth0 ap bpd update --enabled=true --admin-notification-frequency weekly --method enhanced --shields admin_notification
+  auth0 ap bpd update -e=true -f weekly -m enhanced -s admin_notification --json
 ```
 
 

--- a/docs/auth0_protection_brute-force-protection_update.md
+++ b/docs/auth0_protection_brute-force-protection_update.md
@@ -16,12 +16,12 @@ auth0 protection brute-force-protection update [flags]
 
 ```
   auth0 protection brute-force-protection update
-  auth0 ap bfp update --enabled true
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175"
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip --shields user_notification 
-  auth0 ap bfp update -e true -l "156.156.156.156,175.175.175.175" -a 3 -m count_per_identifier_and_ip -s user_notification --json
+  auth0 ap bfp update --enabled=true
+  auth0 ap bfp update --enabled=true --allowlist "156.156.156.156,175.175.175.175"
+  auth0 ap bfp update --enabled=false --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3
+  auth0 ap bfp update --enabled=true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip
+  auth0 ap bfp update --enabled=false --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip --shields user_notification 
+  auth0 ap bfp update -e=true -l "156.156.156.156,175.175.175.175" -a 3 -m count_per_identifier_and_ip -s user_notification --json
 ```
 
 

--- a/docs/auth0_protection_suspicious-ip-throttling_update.md
+++ b/docs/auth0_protection_suspicious-ip-throttling_update.md
@@ -16,10 +16,10 @@ auth0 protection suspicious-ip-throttling update [flags]
 
 ```
   auth0 protection suspicious-ip-throttling update
-  auth0 ap sit update --enabled true
-  auth0 ap sit update --enabled true --allowlist "178.178.178.178"
-  auth0 ap sit update --enabled true --allowlist "178.178.178.178" --shields block
-  auth0 ap sit update -e true -l "178.178.178.178" -s block --json
+  auth0 ap sit update --enabled=true
+  auth0 ap sit update --enabled=true --allowlist "178.178.178.178"
+  auth0 ap sit update --enabled=false --allowlist "178.178.178.178" --shields block
+  auth0 ap sit update -e=true -l "178.178.178.178" -s block --json
 ```
 
 

--- a/docs/auth0_rules_create.md
+++ b/docs/auth0_rules_create.md
@@ -20,11 +20,11 @@ auth0 rules create [flags]
 
 ```
   auth0 rules create
-  auth0 rules create --enabled true
-  auth0 rules create --enabled true --name "My Rule" 
-  auth0 rules create --enabled true --name "My Rule" --template "Empty rule"
-  auth0 rules create --enabled true --name "My Rule" --template "Empty rule" --script "$(cat path/to/script.js)"
-  auth0 rules create -e true -n "My Rule" -t "Empty rule" -s "$(cat path/to/script.js)" --json
+  auth0 rules create --enabled=true
+  auth0 rules create --enabled=true --name "My Rule" 
+  auth0 rules create --enabled=false --name "My Rule" --template "Empty rule"
+  auth0 rules create --enabled=true --name "My Rule" --template "Empty rule" --script "$(cat path/to/script.js)"
+  auth0 rules create -e=true -n "My Rule" -t "Empty rule" -s "$(cat path/to/script.js)" --json
   echo "{\"name\":\"piping-name\",\"script\":\"console.log('test')\"}" | auth0 rules create
 ```
 

--- a/docs/auth0_rules_update.md
+++ b/docs/auth0_rules_update.md
@@ -20,10 +20,10 @@ auth0 rules update [flags]
 
 ```
   auth0 rules update <id>
-  auth0 rules update <rule-id> --enabled true
-  auth0 rules update <rule-id> --enabled true --name "My Updated Rule"
-  auth0 rules update <rule-id> --enabled true --name "My Updated Rule" --script "$(cat path/to/script.js)"
-  auth0 rules update <rule-id> -e true -n "My Updated Rule" -s "$(cat path/to/script.js)" --json
+  auth0 rules update <rule-id> --enabled=true
+  auth0 rules update <rule-id> --enabled=false --name "My Updated Rule"
+  auth0 rules update <rule-id> --enabled=true --name "My Updated Rule" --script "$(cat path/to/script.js)"
+  auth0 rules update <rule-id> -e=true -n "My Updated Rule" -s "$(cat path/to/script.js)" --json
   echo "{\"id\":\"rul_ks3dUazcU3b6PqkH\",\"name\":\"piping-name\"}" | auth0 rules update
 ```
 

--- a/docs/auth0_users_import.md
+++ b/docs/auth0_users_import.md
@@ -19,8 +19,8 @@ auth0 users import [flags]
   auth0 users import
   auth0 users import --connection "Username-Password-Authentication"
   auth0 users import -c "Username-Password-Authentication" --template "Basic Example"
-  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert true
-  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert true --email-results false
+  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert
+  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert --email-results=false
 ```
 
 

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -218,8 +218,8 @@ func createAPICmd(cli *cli) *cobra.Command {
   auth0 apis create --name myapi
   auth0 apis create --name myapi --identifier http://my-api
   auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100
-  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access
-  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access false --scopes "letter:write,letter:read"
+  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access=true
+  auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read"
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := apiName.Ask(cmd, &inputs.Name, nil); err != nil {
@@ -303,8 +303,8 @@ func updateAPICmd(cli *cli) *cobra.Command {
   auth0 apis update <api-id|api-audience>
   auth0 apis update <api-id|api-audience> --name myapi
   auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100
-  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access false
-  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access false --scopes "letter:write,letter:read"
+  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access=false
+  auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read"
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.ResourceServer

--- a/internal/cli/attack_protection_breached_password_detection.go
+++ b/internal/cli/attack_protection_breached_password_detection.go
@@ -102,11 +102,11 @@ func updateBreachedPasswordDetectionCmd(cli *cli) *cobra.Command {
 		Short: "Update breached password detection settings",
 		Long:  "Update the breached password detection settings.",
 		Example: `  auth0 protection breached-password-detection update
-  auth0 ap bpd update --enabled true
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly --method enhanced
-  auth0 ap bpd update --enabled true --admin-notification-frequency weekly --method enhanced --shields admin_notification
-  auth0 ap bpd update -e true -f weekly -m enhanced -s admin_notification --json`,
+  auth0 ap bpd update --enabled=true
+  auth0 ap bpd update --enabled=true --admin-notification-frequency weekly
+  auth0 ap bpd update --enabled=false --admin-notification-frequency weekly --method enhanced
+  auth0 ap bpd update --enabled=true --admin-notification-frequency weekly --method enhanced --shields admin_notification
+  auth0 ap bpd update -e=true -f weekly -m enhanced -s admin_notification --json`,
 		RunE: updateBreachedPasswordDetectionCmdRun(cli, &inputs),
 	}
 

--- a/internal/cli/attack_protection_brute_force_protection.go
+++ b/internal/cli/attack_protection_brute_force_protection.go
@@ -111,12 +111,12 @@ func updateBruteForceProtectionCmd(cli *cli) *cobra.Command {
 		Short: "Update brute force protection settings",
 		Long:  "Update the brute force protection settings.",
 		Example: `  auth0 protection brute-force-protection update
-  auth0 ap bfp update --enabled true
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175"
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip
-  auth0 ap bfp update --enabled true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip --shields user_notification 
-  auth0 ap bfp update -e true -l "156.156.156.156,175.175.175.175" -a 3 -m count_per_identifier_and_ip -s user_notification --json`,
+  auth0 ap bfp update --enabled=true
+  auth0 ap bfp update --enabled=true --allowlist "156.156.156.156,175.175.175.175"
+  auth0 ap bfp update --enabled=false --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3
+  auth0 ap bfp update --enabled=true --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip
+  auth0 ap bfp update --enabled=false --allowlist "156.156.156.156,175.175.175.175" --max-attempts 3 --mode count_per_identifier_and_ip --shields user_notification 
+  auth0 ap bfp update -e=true -l "156.156.156.156,175.175.175.175" -a 3 -m count_per_identifier_and_ip -s user_notification --json`,
 		RunE: updateBruteForceDetectionCmdRun(cli, &inputs),
 	}
 

--- a/internal/cli/attack_protection_suspicious_ip_throttling.go
+++ b/internal/cli/attack_protection_suspicious_ip_throttling.go
@@ -134,10 +134,10 @@ func updateSuspiciousIPThrottlingCmd(cli *cli) *cobra.Command {
 		Short: "Update suspicious ip throttling settings",
 		Long:  "Update the suspicious ip throttling settings.",
 		Example: `  auth0 protection suspicious-ip-throttling update
-  auth0 ap sit update --enabled true
-  auth0 ap sit update --enabled true --allowlist "178.178.178.178"
-  auth0 ap sit update --enabled true --allowlist "178.178.178.178" --shields block
-  auth0 ap sit update -e true -l "178.178.178.178" -s block --json`,
+  auth0 ap sit update --enabled=true
+  auth0 ap sit update --enabled=true --allowlist "178.178.178.178"
+  auth0 ap sit update --enabled=false --allowlist "178.178.178.178" --shields block
+  auth0 ap sit update -e=true -l "178.178.178.178" -s block --json`,
 		RunE: updateSuspiciousIPThrottlingCmdRun(cli, &inputs),
 	}
 

--- a/internal/cli/email_templates.go
+++ b/internal/cli/email_templates.go
@@ -174,13 +174,13 @@ func updateEmailTemplateCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 email templates update
   auth0 email templates update <template>
   auth0 email templates update <template> --json
-  auth0 email templates update welcome --enabled true
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome"
-  auth0 email templates update welcome --enabled true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome" --url "https://example.com"
-  auth0 email templates update welcome -e true -b "$(cat path/to/body.html)" -f "welcome@example.com" -l 6100 -s "Welcome" -u "https://example.com" --json`,
+  auth0 email templates update welcome --enabled=true
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)"
+  auth0 email templates update welcome --enabled=false --body "$(cat path/to/body.html)" --from "welcome@example.com"
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100
+  auth0 email templates update welcome --enabled=false --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome"
+  auth0 email templates update welcome --enabled=true --body "$(cat path/to/body.html)" --from "welcome@example.com" --lifetime 6100 --subject "Welcome" --url "https://example.com"
+  auth0 email templates update welcome -e=true -b "$(cat path/to/body.html)" -f "welcome@example.com" -l 6100 -s "Welcome" -u "https://example.com" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				inputs.Template = args[0]

--- a/internal/cli/log_streams_splunk.go
+++ b/internal/cli/log_streams_splunk.go
@@ -60,7 +60,7 @@ func createLogStreamsSplunkCmd(cli *cli) *cobra.Command {
   auth0 log streams create splunk --name <name> --domain <domain>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
-  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
   auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -142,9 +142,9 @@ func updateLogStreamsSplunkCmd(cli *cli) *cobra.Command {
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
-  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
-  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json`,
+  auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s=false --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeSplunk))

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -132,11 +132,11 @@ func createRuleCmd(cli *cli) *cobra.Command {
 			"To create interactively, use `auth0 rules create` with no arguments.\n\n" +
 			"To create non-interactively, supply the name, template and other information through the flags.",
 		Example: `  auth0 rules create
-  auth0 rules create --enabled true
-  auth0 rules create --enabled true --name "My Rule" 
-  auth0 rules create --enabled true --name "My Rule" --template "Empty rule"
-  auth0 rules create --enabled true --name "My Rule" --template "Empty rule" --script "$(cat path/to/script.js)"
-  auth0 rules create -e true -n "My Rule" -t "Empty rule" -s "$(cat path/to/script.js)" --json
+  auth0 rules create --enabled=true
+  auth0 rules create --enabled=true --name "My Rule" 
+  auth0 rules create --enabled=false --name "My Rule" --template "Empty rule"
+  auth0 rules create --enabled=true --name "My Rule" --template "Empty rule" --script "$(cat path/to/script.js)"
+  auth0 rules create -e=true -n "My Rule" -t "Empty rule" -s "$(cat path/to/script.js)" --json
   echo "{\"name\":\"piping-name\",\"script\":\"console.log('test')\"}" | auth0 rules create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rule := &management.Rule{}
@@ -307,10 +307,10 @@ func updateRuleCmd(cli *cli) *cobra.Command {
 			"To update interactively, use `auth0 rules update` with no arguments.\n\n" +
 			"To update non-interactively, supply the rule id and other information through the flags.",
 		Example: `  auth0 rules update <id>
-  auth0 rules update <rule-id> --enabled true
-  auth0 rules update <rule-id> --enabled true --name "My Updated Rule"
-  auth0 rules update <rule-id> --enabled true --name "My Updated Rule" --script "$(cat path/to/script.js)"
-  auth0 rules update <rule-id> -e true -n "My Updated Rule" -s "$(cat path/to/script.js)" --json
+  auth0 rules update <rule-id> --enabled=true
+  auth0 rules update <rule-id> --enabled=false --name "My Updated Rule"
+  auth0 rules update <rule-id> --enabled=true --name "My Updated Rule" --script "$(cat path/to/script.js)"
+  auth0 rules update <rule-id> -e=true -n "My Updated Rule" -s "$(cat path/to/script.js)" --json
   echo "{\"id\":\"rul_ks3dUazcU3b6PqkH\",\"name\":\"piping-name\"}" | auth0 rules update`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			updatedRule := &management.Rule{}

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -550,8 +550,8 @@ The file size limit for a bulk import is 500KB. You will need to start multiple 
 		Example: `  auth0 users import
   auth0 users import --connection "Username-Password-Authentication"
   auth0 users import -c "Username-Password-Authentication" --template "Basic Example"
-  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert true
-  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert true --email-results false`,
+  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert
+  auth0 users import -c "Username-Password-Authentication" -t "Basic Example" --upsert --email-results=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Select from the available connection types
 			// Users API currently support database connections


### PR DESCRIPTION
### 🔧 Changes

Example usage of boolean flags had very subtle errors where it would advise `--flag true` instead of `--flag=true` or simply `--flag`. Similarly with setting the values of these flags as false, would advise `--flag false` instead of `--flag=false`. This PR corrects these errors and where appropriate, provides examples of how to set certain boolean flags to false.


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
