### PR TITLE
Return empty array when using --json flag for list commands

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -89,6 +89,7 @@ func (r *Renderer) JSONResult(data interface{}) {
 
 func (r *Renderer) Results(data []View) {
 	if len(data) == 0 {
+		r.JSONResult([]interface{}{})
 		return
 	}
 

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -89,7 +89,9 @@ func (r *Renderer) JSONResult(data interface{}) {
 
 func (r *Renderer) Results(data []View) {
 	if len(data) == 0 {
-		r.JSONResult([]interface{}{})
+		if r.Format == OutputFormatJSON {
+			r.JSONResult([]interface{}{})
+		}
 		return
 	}
 

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -3,14 +3,10 @@ package display
 import (
 	"bytes"
 	"io"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/auth0/go-auth0/management"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
 func TestTimeAgo(t *testing.T) {
@@ -44,68 +40,72 @@ func TestTimeAgo(t *testing.T) {
 	}
 }
 
-func TestStream(t *testing.T) {
+func TestIndent(t *testing.T) {
+	assert.Equal(t, "foo", indent("foo", ""))
+	assert.Equal(t, " foo", indent("foo", " "))
+	assert.Equal(t, " line1\n line2\n line3", indent("line1\nline2\nline3", " "))
+}
+
+func TestRenderer_Results(t *testing.T) {
 	var stdout bytes.Buffer
 	mockRender := &Renderer{
 		MessageWriter: io.Discard,
 		ResultWriter:  &stdout,
 	}
 
-	results := []View{
-		&logView{
-			Log: &management.Log{
-				LogID:       auth0.String("354234"),
-				Type:        auth0.String("sapi"),
-				Description: auth0.String("Update branding settings"),
+	var testCases = []struct {
+		name            string
+		givenData       []View
+		givenFormat     string
+		expectedResults string
+	}{
+		{
+			name: "it can correctly output members as a table",
+			givenData: []View{
+				&membersView{
+					ID:    "123",
+					Name:  "John",
+					Email: "john@example.com",
+				},
 			},
+			expectedResults: "  ID   NAME  EMAIL             PICTURE  \n  123  John  john@example.com           \n",
+		},
+		{
+			name: "it can correctly output members as json",
+			givenData: []View{
+				&membersView{
+					ID:    "123",
+					Name:  "John",
+					Email: "john@example.com",
+					raw: struct {
+						ID    string
+						Name  string
+						Email string
+					}{
+						ID:    "123",
+						Name:  "John",
+						Email: "john@example.com",
+					},
+				},
+			},
+			givenFormat:     string(OutputFormatJSON),
+			expectedResults: "[\n    {\n        \"ID\": \"123\",\n        \"Name\": \"John\",\n        \"Email\": \"john@example.com\"\n    }\n]",
+		},
+		{
+			name:            "it can correctly output an empty json array when no data",
+			givenData:       []View{},
+			givenFormat:     string(OutputFormatJSON),
+			expectedResults: "[]",
 		},
 	}
 
-	t.Run("Stream correctly handles nil channel", func(t *testing.T) {
-		mockRender.Stream(results, nil)
-		expectedResult := `TYPE                       DESCRIPTION                                               DATE                    CONNECTION              CLIENT                  
-API Operation              Update branding settings                                  Jan 01 00:00:00.000     N/A                     N/A    
-`
-		assert.Equal(t, expectedResult, stdout.String())
-		stdout.Reset()
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockRender.Format = OutputFormat(testCase.givenFormat)
+			mockRender.Results(testCase.givenData)
 
-	t.Run("Stream successfully", func(t *testing.T) {
-		viewChan := make(chan View)
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			mockRender.Stream(results, viewChan)
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			viewChan <- &logView{
-				Log: &management.Log{
-					LogID:       auth0.String("354236"),
-					Type:        auth0.String("sapi"),
-					Description: auth0.String("Update tenant settings"),
-				},
-			}
-			close(viewChan)
-		}()
-
-		wg.Wait()
-
-		expectedResult := `TYPE                       DESCRIPTION                                               DATE                    CONNECTION              CLIENT                  
-API Operation              Update branding settings                                  Jan 01 00:00:00.000     N/A                     N/A    
-API Operation              Update tenant settings                                    Jan 01 00:00:00.000     N/A                     N/A    
-`
-		assert.Equal(t, expectedResult, stdout.String())
-		stdout.Reset()
-	})
-}
-
-func TestIndent(t *testing.T) {
-	assert.Equal(t, "foo", indent("foo", ""))
-	assert.Equal(t, " foo", indent("foo", " "))
-	assert.Equal(t, " line1\n line2\n line3", indent("line1\nline2\nline3", " "))
+			assert.Equal(t, testCase.expectedResults, stdout.String())
+			stdout.Reset()
+		})
+	}
 }

--- a/internal/display/logs_test.go
+++ b/internal/display/logs_test.go
@@ -1,0 +1,73 @@
+package display
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+func TestStream(t *testing.T) {
+	var stdout bytes.Buffer
+	mockRender := &Renderer{
+		MessageWriter: io.Discard,
+		ResultWriter:  &stdout,
+	}
+
+	results := []View{
+		&logView{
+			Log: &management.Log{
+				LogID:       auth0.String("354234"),
+				Type:        auth0.String("sapi"),
+				Description: auth0.String("Update branding settings"),
+			},
+		},
+	}
+
+	t.Run("Stream correctly handles nil channel", func(t *testing.T) {
+		mockRender.Stream(results, nil)
+		expectedResult := `TYPE                       DESCRIPTION                                               DATE                    CONNECTION              CLIENT                  
+API Operation              Update branding settings                                  Jan 01 00:00:00.000     N/A                     N/A    
+`
+		assert.Equal(t, expectedResult, stdout.String())
+		stdout.Reset()
+	})
+
+	t.Run("Stream successfully", func(t *testing.T) {
+		viewChan := make(chan View)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mockRender.Stream(results, viewChan)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			viewChan <- &logView{
+				Log: &management.Log{
+					LogID:       auth0.String("354236"),
+					Type:        auth0.String("sapi"),
+					Description: auth0.String("Update tenant settings"),
+				},
+			}
+			close(viewChan)
+		}()
+
+		wg.Wait()
+
+		expectedResult := `TYPE                       DESCRIPTION                                               DATE                    CONNECTION              CLIENT                  
+API Operation              Update branding settings                                  Jan 01 00:00:00.000     N/A                     N/A    
+API Operation              Update tenant settings                                    Jan 01 00:00:00.000     N/A                     N/A    
+`
+		assert.Equal(t, expectedResult, stdout.String())
+		stdout.Reset()
+	})
+}

--- a/test/integration/organizations-test-cases.yaml
+++ b/test/integration/organizations-test-cases.yaml
@@ -107,11 +107,18 @@ tests:
         - "Open the following URL in a browser: https://manage.auth0.com/dashboard/"
         - "/organizations/org_"
 
-  013 - add organization members:
+  013 - list organization members should return an empty array if no members found:
+    command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh)
+    exit-code: 0
+    stdout:
+      contains:
+        - "[]"
+
+  014 - add organization members:
     command: auth0 api POST "organizations/$(./test/integration/scripts/get-org-id.sh)/members" --data "{\"members\":[\"$(./test/integration/scripts/get-user-id.sh)\"]}"
     exit-code: 0
 
-  014 - list organization members:
+  015 - list organization members:
     command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh)
     exit-code: 0
     stdout:
@@ -123,7 +130,7 @@ tests:
     config:
       retries: 3
 
-  015 - list organization members as json:
+  016 - list organization members as json:
     command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh) --json
     exit-code: 0
     stdout:
@@ -133,7 +140,7 @@ tests:
     config:
       retries: 3
 
-  016 - list organization members with invalid number:
+  017 - list organization members with invalid number:
     command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh) --number 1001
     exit-code: 1
     stderr:
@@ -142,22 +149,22 @@ tests:
     config:
       retries: 3
 
-  017 - list organization roles:
+  018 - list organization roles:
     command: auth0 orgs roles list $(./test/integration/scripts/get-org-id.sh)
     exit-code: 0
 
-  018 - list organization roles with invalid number:
+  019 - list organization roles with invalid number:
     command: auth0 orgs roles list $(./test/integration/scripts/get-org-id.sh) --number 1001
     exit-code: 1
     stderr:
       contains:
         - number flag invalid, please pass a number between 1 and 1000
 
-  019 - list organization roles members:
+  020 - list organization roles members:
     command: auth0 orgs roles members list $(./test/integration/scripts/get-org-id.sh)
     exit-code: 0
 
-  020 - list organization roles members with invalid number:
+  021 - list organization roles members with invalid number:
     command: auth0 orgs roles members list $(./test/integration/scripts/get-org-id.sh) --number 1001
     exit-code: 1
     stderr:

--- a/test/integration/organizations-test-cases.yaml
+++ b/test/integration/organizations-test-cases.yaml
@@ -108,7 +108,7 @@ tests:
         - "/organizations/org_"
 
   013 - list organization members should return an empty array if no members found:
-    command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh)
+    command: auth0 orgs members list $(./test/integration/scripts/get-org-id.sh) --json
     exit-code: 0
     stdout:
       contains:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

When returning the output of a list command in combination with the --json flag, if there are no elements to display we should still return an empty array.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
