### PR TITLE
Rename flag connection to connection name in users commands

### DIFF
--- a/docs/auth0_users_create.md
+++ b/docs/auth0_users_create.md
@@ -22,7 +22,7 @@ auth0 users create [flags]
   auth0 users create 
   auth0 users create --name "John Doe" 
   auth0 users create --name "John Doe" --email john@example.com
-  auth0 users create --name "John Doe" --email john@example.com --connection "Username-Password-Authentication" --username "example"
+  auth0 users create --name "John Doe" --email john@example.com --connection-name "Username-Password-Authentication" --username "example"
   auth0 users create -n "John Doe" -e john@example.com -c "Username-Password-Authentication" -u "example" --json
 ```
 
@@ -30,12 +30,12 @@ auth0 users create [flags]
 ## Flags
 
 ```
-  -c, --connection string   Name of the database connection this user should be created in.
-  -e, --email string        The user's email.
-      --json                Output in json format.
-  -n, --name string         The user's full name.
-  -p, --password string     Initial password for this user (mandatory for non-SMS connections).
-  -u, --username string     The user's username. Only valid if the connection requires a username.
+  -c, --connection-name string   Name of the database connection this user should be created in.
+  -e, --email string             The user's email.
+      --json                     Output in json format.
+  -n, --name string              The user's full name.
+  -p, --password string          Initial password for this user (mandatory for non-SMS connections).
+  -u, --username string          The user's username. Only valid if the connection requires a username.
 ```
 
 

--- a/docs/auth0_users_import.md
+++ b/docs/auth0_users_import.md
@@ -36,11 +36,11 @@ auth0 users import [flags]
 ## Flags
 
 ```
-  -c, --connection string   Name of the database connection this user should be created in.
-      --email-results       When true, sends a completion email to all tenant owners when the job is finished. The default is true, so you must explicitly set this parameter to false if you do not want emails sent. (default true)
-  -t, --template string     Name of JSON example to be used. Cannot be used if the '--users' flag is passed. Options include: 'Empty', 'Basic Example', 'Custom Password Hash Example' and 'MFA Factors Example'.
-      --upsert              When set to false, pre-existing users that match on email address, user ID, or username will fail. When set to true, pre-existing users that match on any of these fields will be updated, but only with upsertable attributes.
-  -u, --users string        JSON payload that contains an array of user(s) to be imported. Cannot be used if the '--template' flag is passed.
+  -c, --connection-name string   Name of the database connection this user should be created in.
+      --email-results            When true, sends a completion email to all tenant owners when the job is finished. The default is true, so you must explicitly set this parameter to false if you do not want emails sent. (default true)
+  -t, --template string          Name of JSON example to be used. Cannot be used if the '--users' flag is passed. Options include: 'Empty', 'Basic Example', 'Custom Password Hash Example' and 'MFA Factors Example'.
+      --upsert                   When set to false, pre-existing users that match on email address, user ID, or username will fail. When set to true, pre-existing users that match on any of these fields will be updated, but only with upsertable attributes.
+  -u, --users string             JSON payload that contains an array of user(s) to be imported. Cannot be used if the '--template' flag is passed.
 ```
 
 

--- a/docs/auth0_users_update.md
+++ b/docs/auth0_users_update.md
@@ -29,11 +29,11 @@ auth0 users update [flags]
 ## Flags
 
 ```
-  -c, --connection string   Name of the database connection this user should be created in.
-  -e, --email string        The user's email.
-      --json                Output in json format.
-  -n, --name string         The user's full name.
-  -p, --password string     Initial password for this user (mandatory for non-SMS connections).
+  -c, --connection-name string   Name of the database connection this user should be created in.
+  -e, --email string             The user's email.
+      --json                     Output in json format.
+  -n, --name string              The user's full name.
+  -p, --password string          Initial password for this user (mandatory for non-SMS connections).
 ```
 
 

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -22,9 +22,9 @@ var (
 		Help: "Id of the user.",
 	}
 
-	userConnection = Flag{
-		Name:       "Connection",
-		LongForm:   "connection",
+	userConnectionName = Flag{
+		Name:       "Connection Name",
+		LongForm:   "connection-name",
 		ShortForm:  "c",
 		Help:       "Name of the database connection this user should be created in.",
 		IsRequired: true,
@@ -209,11 +209,11 @@ func searchUsersCmd(cli *cli) *cobra.Command {
 
 func createUserCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Connection string
-		Email      string
-		Password   string
-		Username   string
-		Name       string
+		ConnectionName string
+		Email          string
+		Password       string
+		Username       string
+		Name           string
 	}
 
 	cmd := &cobra.Command{
@@ -226,7 +226,7 @@ func createUserCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 users create 
   auth0 users create --name "John Doe" 
   auth0 users create --name "John Doe" --email john@example.com
-  auth0 users create --name "John Doe" --email john@example.com --connection "Username-Password-Authentication" --username "example"
+  auth0 users create --name "John Doe" --email john@example.com --connection-name "Username-Password-Authentication" --username "example"
   auth0 users create -n "John Doe" -e john@example.com -c "Username-Password-Authentication" -u "example" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Users API currently only supports database connections.
@@ -235,7 +235,7 @@ func createUserCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			if err := userConnection.Select(cmd, &inputs.Connection, options, nil); err != nil {
+			if err := userConnectionName.Select(cmd, &inputs.ConnectionName, options, nil); err != nil {
 				return err
 			}
 
@@ -249,20 +249,20 @@ func createUserCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			// //Prompt for user password
+			// Prompt for user password
 			if err := userPassword.AskPassword(cmd, &inputs.Password); err != nil {
 				return err
 			}
 
 			// The getConnReqUsername returns the value for the requires_username field for the selected connection
 			// The result will be used to determine whether to prompt for username
-			conn := cli.getConnReqUsername(auth0.StringValue(&inputs.Connection))
+			conn := cli.getConnReqUsername(auth0.StringValue(&inputs.ConnectionName))
 			requireUsername := auth0.BoolValue(conn)
 
 			// Prompt for username if the requireUsername is set to true
 			// Load values including the username's field into a fresh users instance
 			a := &management.User{
-				Connection: &inputs.Connection,
+				Connection: &inputs.ConnectionName,
 				Email:      &inputs.Email,
 				Name:       &inputs.Name,
 				Password:   &inputs.Password,
@@ -290,7 +290,7 @@ func createUserCmd(cli *cli) *cobra.Command {
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
 	userName.RegisterString(cmd, &inputs.Name, "")
-	userConnection.RegisterString(cmd, &inputs.Connection, "")
+	userConnectionName.RegisterString(cmd, &inputs.ConnectionName, "")
 	userPassword.RegisterString(cmd, &inputs.Password, "")
 	userEmail.RegisterString(cmd, &inputs.Email, "")
 	userUsername.RegisterString(cmd, &inputs.Username, "")
@@ -399,11 +399,11 @@ func deleteUserCmd(cli *cli) *cobra.Command {
 
 func updateUserCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID         string
-		Email      string
-		Password   string
-		Name       string
-		Connection string
+		ID             string
+		Email          string
+		Password       string
+		Name           string
+		ConnectionName string
 	}
 
 	cmd := &cobra.Command{
@@ -473,10 +473,10 @@ func updateUserCmd(cli *cli) *cobra.Command {
 				user.Password = &inputs.Password
 			}
 
-			if len(inputs.Connection) == 0 {
+			if len(inputs.ConnectionName) == 0 {
 				user.Connection = current.Connection
 			} else {
-				user.Connection = &inputs.Connection
+				user.Connection = &inputs.ConnectionName
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -495,7 +495,7 @@ func updateUserCmd(cli *cli) *cobra.Command {
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
 	userName.RegisterStringU(cmd, &inputs.Name, "")
-	userConnection.RegisterStringU(cmd, &inputs.Connection, "")
+	userConnectionName.RegisterStringU(cmd, &inputs.ConnectionName, "")
 	userPassword.RegisterStringU(cmd, &inputs.Password, "")
 	userEmail.RegisterStringU(cmd, &inputs.Email, "")
 
@@ -533,7 +533,7 @@ func openUserCmd(cli *cli) *cobra.Command {
 
 func importUsersCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Connection          string
+		ConnectionName      string
 		ConnectionID        string
 		Template            string
 		UsersBody           string
@@ -567,13 +567,13 @@ The file size limit for a bulk import is 500KB. You will need to start multiple 
 				return err
 			}
 
-			if err := userConnection.Select(cmd, &inputs.Connection, dbConnectionOptions, nil); err != nil {
+			if err := userConnectionName.Select(cmd, &inputs.ConnectionName, dbConnectionOptions, nil); err != nil {
 				return err
 			}
 
-			connection, err := cli.api.Connection.ReadByName(inputs.Connection)
+			connection, err := cli.api.Connection.ReadByName(inputs.ConnectionName)
 			if err != nil {
-				return fmt.Errorf("failed to find connection with name %q: %w", inputs.Connection, err)
+				return fmt.Errorf("failed to find connection with name %q: %w", inputs.ConnectionName, err)
 			}
 
 			inputs.ConnectionID = connection.GetID()
@@ -640,7 +640,7 @@ The file size limit for a bulk import is 500KB. You will need to start multiple 
 		},
 	}
 
-	userConnection.RegisterString(cmd, &inputs.Connection, "")
+	userConnectionName.RegisterString(cmd, &inputs.ConnectionName, "")
 	userImportTemplate.RegisterString(cmd, &inputs.Template, "")
 	userImportBody.RegisterString(cmd, &inputs.UsersBody, "")
 	userEmailResults.RegisterBool(cmd, &inputs.SendCompletionEmail, true)

--- a/test/integration/users-test-cases.yaml
+++ b/test/integration/users-test-cases.yaml
@@ -4,7 +4,7 @@ config:
 
 tests:
   001 - users create and check data:
-    command: auth0 users create --name integration-test-user-new --connection Username-Password-Authentication --email testuser@example.com --password testUser12 --username testuser1 --json --no-input
+    command: auth0 users create --name integration-test-user-new --connection-name Username-Password-Authentication --email testuser@example.com --password testUser12 --username testuser1 --json --no-input
     exit-code: 0
     stdout:
       json:
@@ -12,7 +12,7 @@ tests:
         connection: "Username-Password-Authentication"
 
   002 - users create and check output:
-    command: auth0 users create --name integration-test-user-new2 --connection Username-Password-Authentication --email testuser2@example.com --password testUser12 --username testuser2 --no-input
+    command: auth0 users create --name integration-test-user-new2 --connection-name Username-Password-Authentication --email testuser2@example.com --password testUser12 --username testuser2 --no-input
     exit-code: 0
     stdout:
       contains:
@@ -67,7 +67,7 @@ tests:
     exit-code: 0
 
   009 - users update maximal flags:
-    command: auth0 users update $(./test/integration/scripts/get-user-id.sh)  --email betteruser@example.com  --connection Username-Password-Authentication --name integration-test-user-bettername --json --no-input
+    command: auth0 users update $(./test/integration/scripts/get-user-id.sh)  --email betteruser@example.com  --connection-name Username-Password-Authentication --name integration-test-user-bettername --json --no-input
     stdout:
       json:
         email: betteruser@example.com


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Rename flag `connection` to `connection-name` in users commands for consistency as the `auth0 test` commands have it named as `connection-name` for clarity. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
