### PR TITLE
Fix logic that permits some commands to run without auth

### DIFF
--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandRequiresAuthentication(t *testing.T) {
+	var testCases = []struct {
+		givenCommand                    string
+		expectedToRequireAuthentication bool
+	}{
+		{"auth0 user list", true},
+		{"auth0 user create", true},
+		{"auth0 api", true},
+		{"auth0 apps list", true},
+		{"auth0 apps create", true},
+		{"auth0 orgs members list", true},
+		{"auth0 completion", false},
+		{"auth0 help", false},
+		{"auth0 login", false},
+		{"auth0 logout", false},
+		{"auth0 tenants use", false},
+		{"auth0 tenants list", false},
+	}
+
+	for index, testCase := range testCases {
+		t.Run(fmt.Sprintf("TestCase #%d Command: %s", index, testCase.givenCommand), func(t *testing.T) {
+			actualAuth := commandRequiresAuthentication(testCase.givenCommand)
+			assert.Equal(t, testCase.expectedToRequireAuthentication, actualAuth)
+		})
+	}
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes erronousely requiring authentication for the completion command.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
