### PR TITLE
Remove Apps and first run logic from Tenant struct

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -152,37 +152,14 @@ func testLoginCmd(cli *cli) *cobra.Command {
 			}
 
 			var userInfo *authutil.UserInfo
-			if err := ansi.Spinner("Fetching user metadata", func() error {
-				// Use the access token to fetch user information from the /userinfo endpoint.
+			if err := ansi.Spinner("Fetching user metadata", func() (err error) {
 				userInfo, err = authutil.FetchUserInfo(http.DefaultClient, tenant.Domain, tokenResponse.AccessToken)
 				return err
 			}); err != nil {
 				return fmt.Errorf("failed to fetch user info: %w", err)
 			}
 
-			cli.renderer.Newline()
-			cli.renderer.TestLogin(userInfo, tokenResponse)
-			cli.renderer.Newline()
-
-			const commandKey = "test_login"
-			isFirstRun, err := cli.isFirstCommandRun(inputs.ClientID, commandKey)
-			if err != nil {
-				return err
-			}
-
-			if isFirstRun {
-				cli.renderer.Infof("Login flow is working!")
-				cli.renderer.Infof(
-					"%s Consider downloading and running a quickstart next by running `auth0 quickstarts download %s`",
-					ansi.Faint("Hint:"),
-					inputs.ClientID,
-				)
-
-				if err := cli.setFirstCommandRun(inputs.ClientID, commandKey); err != nil {
-					return err
-				}
-			}
-
+			cli.renderer.TestLogin(userInfo, tokenResponse, inputs.ClientID)
 			return nil
 		},
 	}

--- a/internal/display/test.go
+++ b/internal/display/test.go
@@ -15,12 +15,20 @@ type userInfoAndTokens struct {
 	Tokens   *authutil.TokenResponse `json:"tokens"`
 }
 
-func (r *Renderer) TestLogin(u *authutil.UserInfo, t *authutil.TokenResponse) {
-	r.Heading("/userinfo")
+func (r *Renderer) TestLogin(u *authutil.UserInfo, t *authutil.TokenResponse, clientID string) {
+	r.Heading("user metadata and token")
 
 	data := &userInfoAndTokens{UserInfo: u, Tokens: t}
-
 	r.JSONResult(data)
+
+	r.Newline()
+	r.Newline()
+	r.Infof(
+		"%s Login flow is working! If this is the first time you are testing the login flow for this "+
+			"application, consider downloading and running a quickstart next by running %s",
+		ansi.Faint("Hint:"),
+		fmt.Sprintf("`auth0 quickstarts download %s`", clientID),
+	)
 }
 
 func (r *Renderer) TestToken(client *management.Client, t *authutil.TokenResponse) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The ability to track when an application is used for the first time in a command was introduced in https://github.com/auth0/auth0-cli/pull/199, however https://github.com/auth0/auth0-cli/pull/302 erroneously removes the func call to actually persist that to the config, thus right now we always show the hint, regardless if we used the application multiple times with the same cli command.

Due to the fact that this was used only within `auth0 test login `command and it is now effectively broken and the fact that it adds unnecessary logic at the moment, in this PR we're removing it completely and always displaying the hint at the end.

This PR aids as well simplifying the work for a follow up PR that will refactor the Config logic into its own package. 

### 📚 References

- https://github.com/auth0/auth0-cli/pull/199
- https://github.com/auth0/auth0-cli/pull/302

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
