### PR TITLE
Fix logs tail issue when there are no logs

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -9,9 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Pagination max out at 1000 entries in total
+// Besides the limitation of 100 log events per request to retrieve logs,
+// we may only paginate through up to 1000 search results.
 // https://auth0.com/docs/logs/retrieve-log-events-using-mgmt-api#limitations
-const logsPerPageLimit = 1000
+const logsPerPageLimit = 100
 
 var (
 	logsFilter = Flag{

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,15 +1,143 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/auth0/go-auth0/management"
+	"github.com/golang/mock/gomock"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/auth0/mock"
+	"github.com/auth0/auth0-cli/internal/display"
 )
+
+func TestTailLogsCommand(t *testing.T) {
+	t.Run("it returns early with a message to generate logs when there are no logs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		logsAPI := mock.NewMockLogAPI(ctrl)
+		logsAPI.EXPECT().
+			List(gomock.Any()).
+			Return([]*management.Log{}, nil)
+
+		expectedResult := `No logs available.
+
+ ▸    To generate logs, run a test command like 'auth0 test login' or 'auth0 test token'
+`
+
+		stdout := &bytes.Buffer{}
+		cli := &cli{
+			renderer: &display.Renderer{
+				MessageWriter: stdout,
+				ResultWriter:  io.Discard,
+			},
+			api: &auth0.API{Log: logsAPI},
+		}
+
+		cmd := tailLogsCmd(cli)
+		cmd.SetArgs([]string{"--number", "9000", "--filter", "user_id:123"})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, stdout.String())
+	})
+
+	t.Run("it returns an error when it fails to get the logs on the first request", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		logsAPI := mock.NewMockLogAPI(ctrl)
+		logsAPI.EXPECT().
+			List(gomock.Any()).
+			Return(nil, fmt.Errorf("generic error"))
+
+		cli := &cli{
+			api: &auth0.API{Log: logsAPI},
+		}
+
+		cmd := tailLogsCmd(cli)
+		cmd.SetArgs([]string{"--number", "9000", "--filter", "user_id:123"})
+		err := cmd.Execute()
+
+		assert.EqualError(t, err, "failed to get logs: generic error")
+	})
+
+	t.Run("it returns an error when it fails to get the logs on the 3rd request", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		logsAPI := mock.NewMockLogAPI(ctrl)
+		logsAPI.EXPECT().
+			List(gomock.Any()).
+			Return(
+				[]*management.Log{
+					{
+						LogID:       auth0.String("354234"),
+						Type:        auth0.String("sapi"),
+						Description: auth0.String("Update branding settings"),
+					},
+				},
+				nil,
+			)
+
+		logsAPI.EXPECT().
+			List(gomock.Any()).
+			Return(
+				[]*management.Log{
+					{
+						LogID:       auth0.String("354234"),
+						Type:        auth0.String("sapi"),
+						Description: auth0.String("Update branding settings"),
+					},
+					{
+						LogID:       auth0.String("354236"),
+						Type:        auth0.String("sapi"),
+						Description: auth0.String("Update tenant settings"),
+					},
+				},
+				nil,
+			)
+
+		logsAPI.EXPECT().
+			List(gomock.Any()).
+			Return(nil, fmt.Errorf("generic error"))
+
+		expectedMessage := `
+=== auth0-cli-tests.eu.auth0.com logs
+
+ ▸    Failed to get latest logs: generic error
+`
+		expectedResult := `TYPE                       DESCRIPTION                                               DATE                    CONNECTION              CLIENT                  
+API Operation              Update branding settings                                  Jan 01 00:00:00.000     N/A                     N/A    
+`
+
+		message := &bytes.Buffer{}
+		result := &bytes.Buffer{}
+		cli := &cli{
+			renderer: &display.Renderer{
+				Tenant:        "auth0-cli-tests.eu.auth0.com",
+				MessageWriter: message,
+				ResultWriter:  result,
+			},
+			api: &auth0.API{Log: logsAPI},
+		}
+
+		cmd := tailLogsCmd(cli)
+		cmd.SetArgs([]string{"--number", "9000", "--filter", "user_id:123"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedMessage, message.String())
+		assert.Equal(t, expectedResult, result.String())
+	})
+}
 
 func TestDedupeLogs(t *testing.T) {
 	t.Run("removes duplicate logs and sorts by date asc", func(t *testing.T) {

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"testing"
 	"time"
 
@@ -18,33 +17,6 @@ import (
 )
 
 func TestTailLogsCommand(t *testing.T) {
-	t.Run("it returns early with a message to generate logs when there are no logs", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		logsAPI := mock.NewMockLogAPI(ctrl)
-		logsAPI.EXPECT().
-			List(gomock.Any()).
-			Return([]*management.Log{}, nil)
-
-		stdout := &bytes.Buffer{}
-		cli := &cli{
-			renderer: &display.Renderer{
-				MessageWriter: stdout,
-				ResultWriter:  io.Discard,
-			},
-			api: &auth0.API{Log: logsAPI},
-		}
-
-		cmd := tailLogsCmd(cli)
-		cmd.SetArgs([]string{"--number", "90", "--filter", "user_id:123"})
-		err := cmd.Execute()
-
-		assert.NoError(t, err)
-		assert.Contains(t, stdout.String(), "No logs available.")
-		assert.Contains(t, stdout.String(), "To generate logs, run a test command like 'auth0 test login' or 'auth0 test token'")
-	})
-
 	t.Run("it returns an error when it fails to get the logs on the first request", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes an issue with the `auth0 logs tail` command when there are no logs returned in the first api call, due to the fact that we're trying to send an empty lastLogID in the query params. 

```
An unexpected error occurred while getting logs: 400 Bad Request: The query 'log_id:[ TO *]' cannot be parsed. Please revise the query or visit https://auth0.com/docs/logs/log-search-query-syntax for help.
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
