### PR TITLE
Fix list all tenants config test

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -523,13 +523,6 @@ func TestConfig_ListAllTenants(t *testing.T) {
 						"access_token": "eyfSaswe",
 						"expires_at": "2023-04-18T11:18:07.998809Z",
 						"client_id": "secret"
-					},
-					"auth0-mega-cli.eu.auth0.com": {
-						"name": "auth0-mega-cli",
-						"domain": "auth0-mega-cli.eu.auth0.com",
-						"access_token": "eyfSaswe",
-						"expires_at": "2023-04-18T11:18:07.998809Z",
-						"client_id": "secret"
 					}
 				}
 			}`))
@@ -542,20 +535,13 @@ func TestConfig_ListAllTenants(t *testing.T) {
 				ExpiresAt:   time.Date(2023, time.April, 18, 11, 18, 7, 998809000, time.UTC),
 				ClientID:    "secret",
 			},
-			{
-				Name:        "auth0-mega-cli",
-				Domain:      "auth0-mega-cli.eu.auth0.com",
-				AccessToken: "eyfSaswe",
-				ExpiresAt:   time.Date(2023, time.April, 18, 11, 18, 7, 998809000, time.UTC),
-				ClientID:    "secret",
-			},
 		}
 
 		config := &Config{path: tempFile}
 		actualTenants, err := config.ListAllTenants()
 
 		assert.NoError(t, err)
-		assert.Len(t, actualTenants, 2)
+		assert.Len(t, actualTenants, 1)
 		assert.Equal(t, expectedTenants, actualTenants)
 	})
 

--- a/internal/config/tenant.go
+++ b/internal/config/tenant.go
@@ -102,6 +102,8 @@ func (t *Tenant) GetAccessToken() string {
 	return t.AccessToken
 }
 
+// CheckAuthenticationStatus checks to see if the tenant in the config
+// has all the required scopes and that the access token is not expired.
 func (t *Tenant) CheckAuthenticationStatus() error {
 	if !t.HasAllRequiredScopes() && t.IsAuthenticatedWithDeviceCodeFlow() {
 		return ErrTokenMissingRequiredScopes


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In Go, maps are unordered collections of key/value pairs. When you range over a map, the order in which the key/value pairs are returned is not guaranteed and can vary between different runs of the program.

In this PR we're fixing the ListAllTenants test by only calling to list on a config that has 1 tenant, in order to remove uncertainty in the tests and making it stable.

This is so that we are not forced to add a sort algorithm to how we retrieve the tenants from the config.

### 📚 References

- [go.dev/blog/maps](http://go.dev/blog/maps) Iteration order

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
