### PR TITLE
DXCDT-498: Add terraform generate command skeleton

### DIFF
--- a/docs/auth0_terraform.md
+++ b/docs/auth0_terraform.md
@@ -1,0 +1,13 @@
+---
+layout: default
+has_toc: false
+has_children: true
+---
+# auth0 terraform
+
+This command facilitates the integration of Auth0 with [Terraform](https://www.terraform.io/), an infrastructure as code tool.
+
+## Commands
+
+- [auth0 terraform generate](auth0_terraform_generate.md) - Generate terraform configuration for your Auth0 Tenant
+

--- a/docs/auth0_terraform.md
+++ b/docs/auth0_terraform.md
@@ -5,7 +5,7 @@ has_children: true
 ---
 # auth0 terraform
 
-This command facilitates the integration of Auth0 with [Terraform](https://www.terraform.io/), an infrastructure as code tool.
+This command facilitates the integration of Auth0 with [Terraform](https://www.terraform.io/), an Infrastructure as Code tool.
 
 ## Commands
 

--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -7,7 +7,7 @@ has_toc: false
 
 This command is designed to streamline the process of generating Terraform configuration files for your Auth0 resources, serving as a bridge between the two.
 
- It automatically scans your Auth0 Tenant and compiles a set of Terraform configuration files based on the existing resources and configurations.
+It automatically scans your Auth0 Tenant and compiles a set of Terraform configuration files based on the existing resources and configurations.
 
 The generated Terraform files are written in HashiCorp Configuration Language (HCL).
 

--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -1,0 +1,47 @@
+---
+layout: default
+parent: auth0 terraform
+has_toc: false
+---
+# auth0 terraform generate
+
+This command is designed to streamline the process of generating Terraform configuration files for your Auth0 resources, serving as a bridge between the two.
+
+ It automatically scans your Auth0 Tenant and compiles a set of Terraform configuration files based on the existing resources and configurations.
+
+The generated Terraform files are written in HashiCorp Configuration Language (HCL).
+
+## Usage
+```
+auth0 terraform generate [flags]
+```
+
+## Examples
+
+```
+
+```
+
+
+## Flags
+
+```
+  -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
+```
+
+
+## Inherited Flags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 terraform generate](auth0_terraform_generate.md) - Generate terraform configuration for your Auth0 Tenant
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ Authenticating as a user is not supported for **private cloud** tenants. Instead
 - [auth0 roles](auth0_roles.md) - Manage resources for roles
 - [auth0 rules](auth0_rules.md) - Manage resources for rules
 - [auth0 tenants](auth0_tenants.md) - Manage configured tenants
+- [auth0 terraform](auth0_terraform.md) - Manage terraform configuration for your Auth0 Tenant
 - [auth0 test](auth0_test.md) - Try your Universal Login box or get a token
 - [auth0 universal-login](auth0_universal-login.md) - Manage the Universal Login experience
 - [auth0 users](auth0_users.md) - Manage resources for users

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -168,6 +168,7 @@ func addSubCommands(rootCmd *cobra.Command, cli *cli) {
 	rootCmd.AddCommand(testCmd(cli))
 	rootCmd.AddCommand(logsCmd(cli))
 	rootCmd.AddCommand(apiCmd(cli))
+	rootCmd.AddCommand(terraformCmd(cli))
 
 	// keep completion at the bottom:
 	rootCmd.AddCommand(completionCmd(cli))

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -12,7 +12,8 @@ var tfFlags = terraformFlags{
 		Name:      "Output Dir",
 		LongForm:  "output-dir",
 		ShortForm: "o",
-		Help:      "Output directory for the generated Terraform config files.",
+		Help: "Output directory for the generated Terraform config files. If not provided, the files will be " +
+			"saved in the current working directory.",
 	},
 }
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -33,7 +33,7 @@ func terraformCmd(cli *cli) *cobra.Command {
 		Aliases: []string{"tf"},
 		Short:   "Manage terraform configuration for your Auth0 Tenant",
 		Long: "This command facilitates the integration of Auth0 with [Terraform](https://www.terraform.io/), an " +
-			"infrastructure as code tool.",
+			"Infrastructure as Code tool.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
@@ -47,10 +47,10 @@ func generateTerraformCmd(cli *cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "generate",
-		Aliases: []string{"gen", "export"},
+		Aliases: []string{"gen", "export"}, // Reconsider aliases and command name before releasing.
 		Short:   "Generate terraform configuration for your Auth0 Tenant",
 		Long: "This command is designed to streamline the process of generating Terraform configuration files for " +
-			"your Auth0 resources, serving as a bridge between the two.\n\n It automatically scans your Auth0 Tenant " +
+			"your Auth0 resources, serving as a bridge between the two.\n\nIt automatically scans your Auth0 Tenant " +
 			"and compiles a set of Terraform configuration files based on the existing resources and configurations." +
 			"\n\nThe generated Terraform files are written in HashiCorp Configuration Language (HCL).",
 		RunE: generateTerraformCmdRun(cli, &inputs),

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+var tfFlags = terraformFlags{
+	OutputDIR: Flag{
+		Name:      "Output Dir",
+		LongForm:  "output-dir",
+		ShortForm: "o",
+		Help:      "Output directory for the generated Terraform config files.",
+	},
+}
+
+type (
+	terraformFlags struct {
+		OutputDIR Flag
+	}
+
+	terraformInputs struct {
+		OutputDIR string
+	}
+)
+
+func terraformCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "terraform",
+		Aliases: []string{"tf"},
+		Short:   "Manage terraform configuration for your Auth0 Tenant",
+		Long: "This command facilitates the integration of Auth0 with [Terraform](https://www.terraform.io/), an " +
+			"infrastructure as code tool.",
+	}
+
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(generateTerraformCmd(cli))
+
+	return cmd
+}
+
+func generateTerraformCmd(cli *cli) *cobra.Command {
+	var inputs terraformInputs
+
+	cmd := &cobra.Command{
+		Use:     "generate",
+		Aliases: []string{"gen", "export"},
+		Short:   "Generate terraform configuration for your Auth0 Tenant",
+		Long: "This command is designed to streamline the process of generating Terraform configuration files for " +
+			"your Auth0 resources, serving as a bridge between the two.\n\n It automatically scans your Auth0 Tenant " +
+			"and compiles a set of Terraform configuration files based on the existing resources and configurations." +
+			"\n\nThe generated Terraform files are written in HashiCorp Configuration Language (HCL).",
+		RunE: generateTerraformCmdRun(cli, &inputs),
+	}
+
+	tfFlags.OutputDIR.RegisterString(cmd, &inputs.OutputDIR, "./")
+
+	return cmd
+}
+
+func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := generateTerraformConfigFiles(inputs); err != nil {
+			return err
+		}
+
+		cli.renderer.Infof("Terraform config files generated successfully.")
+		cli.renderer.Infof(
+			"Follow this " +
+				"[quickstart](https://registry.terraform.io/providers/auth0/auth0/latest/docs/guides/quickstart) " +
+				"to go through setting up an Auth0 application for the provider to authenticate against and manage " +
+				"resources.",
+		)
+
+		return nil
+	}
+}
+
+func generateTerraformConfigFiles(inputs *terraformInputs) error {
+	const readWritePermission = 0755
+	if err := os.MkdirAll(inputs.OutputDIR, readWritePermission); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	mainTerraformConfigFile, err := os.Create(path.Join(inputs.OutputDIR, "main.tf"))
+	if err != nil {
+		return err
+	}
+	defer mainTerraformConfigFile.Close()
+
+	mainTerraformConfigFileContent := `terraform {
+  required_version = "~> 1.5.0"
+  required_providers {
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "1.0.0-beta.1"
+    }
+  }
+}
+
+provider "auth0" {
+  debug         = true
+}
+`
+
+	_, err = mainTerraformConfigFile.WriteString(mainTerraformConfigFileContent)
+	return err
+}

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateTerraformConfigFiles(t *testing.T) {
+	testInputs := terraformInputs{
+		OutputDIR: "./terraform/dev",
+	}
+	defer os.RemoveAll(testInputs.OutputDIR)
+
+	t.Run("it can correctly generate the terraform main config file", func(t *testing.T) {
+		assertTerraformConfigFilesWereGeneratedWithCorrectContent(t, &testInputs)
+	})
+
+	t.Run("it can correctly generate the terraform main config file even if the dir exists", func(t *testing.T) {
+		err := os.MkdirAll(testInputs.OutputDIR, 0755)
+		require.NoError(t, err)
+
+		assertTerraformConfigFilesWereGeneratedWithCorrectContent(t, &testInputs)
+	})
+
+	t.Run("it fails to create the directory if path is a read only location", func(t *testing.T) {
+		testInputs := terraformInputs{
+			OutputDIR: "/terraform/dev",
+		}
+
+		err := generateTerraformConfigFiles(&testInputs)
+		assert.EqualError(t, err, "mkdir /terraform: read-only file system")
+	})
+
+	t.Run("it fails to create the main.tf file if file is already created and read only", func(t *testing.T) {
+		err := os.MkdirAll(testInputs.OutputDIR, 0755)
+		require.NoError(t, err)
+
+		mainFilePath := path.Join(testInputs.OutputDIR, "main.tf")
+		_, err = os.Create(mainFilePath)
+		require.NoError(t, err)
+
+		err = os.Chmod(mainFilePath, 0444)
+		require.NoError(t, err)
+
+		err = generateTerraformConfigFiles(&testInputs)
+		assert.EqualError(t, err, "open terraform/dev/main.tf: permission denied")
+	})
+}
+
+func assertTerraformConfigFilesWereGeneratedWithCorrectContent(t *testing.T, testInputs *terraformInputs) {
+	err := generateTerraformConfigFiles(testInputs)
+	require.NoError(t, err)
+
+	// Assert that the directory was created.
+	_, err = os.Stat(testInputs.OutputDIR)
+	assert.NoError(t, err)
+
+	// Assert that the main.tf file was created with the correct content.
+	mainTerraformConfigFilePath := path.Join(testInputs.OutputDIR, "main.tf")
+	_, err = os.Stat(mainTerraformConfigFilePath)
+	assert.NoError(t, err)
+
+	expectedContent := `terraform {
+  required_version = "~> 1.5.0"
+  required_providers {
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "1.0.0-beta.1"
+    }
+  }
+}
+
+provider "auth0" {
+  debug         = true
+}
+`
+	// Read the file content and check if it matches the expected content
+	content, err := os.ReadFile(mainTerraformConfigFilePath)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedContent, string(content))
+}

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -13,7 +13,7 @@ func TestGenerateTerraformConfigFiles(t *testing.T) {
 	testInputs := terraformInputs{
 		OutputDIR: "./terraform/dev",
 	}
-	defer os.RemoveAll(testInputs.OutputDIR)
+	defer os.RemoveAll("./terraform")
 
 	t.Run("it can correctly generate the terraform main config file", func(t *testing.T) {
 		assertTerraformConfigFilesWereGeneratedWithCorrectContent(t, &testInputs)
@@ -26,13 +26,13 @@ func TestGenerateTerraformConfigFiles(t *testing.T) {
 		assertTerraformConfigFilesWereGeneratedWithCorrectContent(t, &testInputs)
 	})
 
-	t.Run("it fails to create the directory if path is a read only location", func(t *testing.T) {
+	t.Run("it fails to create the directory if path is empty", func(t *testing.T) {
 		testInputs := terraformInputs{
-			OutputDIR: "/terraform/dev",
+			OutputDIR: "",
 		}
 
 		err := generateTerraformConfigFiles(&testInputs)
-		assert.EqualError(t, err, "mkdir /terraform: read-only file system")
+		assert.EqualError(t, err, "mkdir : no such file or directory")
 	})
 
 	t.Run("it fails to create the main.tf file if file is already created and read only", func(t *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR adds the command skeleton for generating terraform config files for the Auth0 tenant.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
