### PR TITLE
DXCDT-499: Add abstractions to fetch client resource data in tf cmd

### DIFF
--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/auth0/go-auth0/management"
+
+	"github.com/auth0/auth0-cli/internal/auth0"
+)
+
+type (
+	importDataList []importDataItem
+
+	importDataItem struct {
+		ResourceName string
+		ImportID     string
+	}
+
+	resourceDataFetcher interface {
+		FetchData(ctx context.Context) (importDataList, error)
+	}
+
+	clientResourceFetcher struct {
+		api *auth0.API
+	}
+)
+
+func (f *clientResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
+	var data importDataList
+
+	var page int
+	for {
+		clients, err := f.api.Client.List(
+			ctx,
+			management.Page(page),
+			management.Parameter("is_global", "false"),
+			management.IncludeFields("client_id", "name"),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, client := range clients.Clients {
+			data = append(data, importDataItem{
+				ResourceName: "auth0_client." + sanitizeResourceName(client.GetName()),
+				ImportID:     client.GetClientID(),
+			})
+		}
+
+		if !clients.HasNext() {
+			break
+		}
+
+		page++
+	}
+
+	return data, nil
+}
+
+// sanitizeResourceName will return a valid terraform resource name.
+//
+// A name must start with a letter or underscore and may
+// contain only letters, digits, underscores, and dashes.
+func sanitizeResourceName(name string) string {
+	// Regular expression pattern to remove invalid characters.
+	namePattern := "[^a-zA-Z0-9_-]+"
+	re := regexp.MustCompile(namePattern)
+
+	sanitizedName := re.ReplaceAllString(name, "")
+
+	// Regular expression pattern to remove leading digits or dashes.
+	namePattern = "^[0-9-]+"
+	re = regexp.MustCompile(namePattern)
+
+	sanitizedName = re.ReplaceAllString(sanitizedName, "")
+
+	return sanitizedName
+}

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/auth0/mock"
+)
+
+func TestSanitizeResourceName(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// Test cases with valid names
+		{"ValidName123", "ValidName123"},
+		{"_Another_Valid-Name", "_Another_Valid-Name"},
+		{"name_with_123", "name_with_123"},
+		{"_start_with_underscore", "_start_with_underscore"},
+
+		// Test cases with invalid names to be sanitized
+		{"Invalid@Name", "InvalidName"},
+		{"Invalid Name", "InvalidName"},
+		{"123StartWithNumber", "StartWithNumber"},
+		{"-StartWithDash", "StartWithDash"},
+		{"", ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.input, func(t *testing.T) {
+			sanitized := sanitizeResourceName(testCase.input)
+			assert.Equal(t, testCase.expected, sanitized)
+		})
+	}
+}
+
+func TestClientResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully retrieves client data", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clientAPI := mock.NewMockClientAPI(ctrl)
+		clientAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.ClientList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 4,
+					},
+					Clients: []*management.Client{
+						{
+							ClientID: auth0.String("clientID_1"),
+							Name:     auth0.String("My Test Client 1"),
+						},
+						{
+							ClientID: auth0.String("clientID_2"),
+							Name:     auth0.String("My Test Client 2"),
+						},
+					},
+				},
+				nil,
+			)
+		clientAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.ClientList{
+					List: management.List{
+						Start: 2,
+						Limit: 4,
+						Total: 4,
+					},
+					Clients: []*management.Client{
+						{
+							ClientID: auth0.String("clientID_3"),
+							Name:     auth0.String("My Test Client 3"),
+						},
+						{
+							ClientID: auth0.String("clientID_4"),
+							Name:     auth0.String("My Test Client 4"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := clientResourceFetcher{
+			api: &auth0.API{
+				Client: clientAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_client.MyTestClient1",
+				ImportID:     "clientID_1",
+			},
+			{
+				ResourceName: "auth0_client.MyTestClient2",
+				ImportID:     "clientID_2",
+			},
+			{
+				ResourceName: "auth0_client.MyTestClient3",
+				ImportID:     "clientID_3",
+			},
+			{
+				ResourceName: "auth0_client.MyTestClient4",
+				ImportID:     "clientID_4",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
+	t.Run("it returns an error if api call fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clientAPI := mock.NewMockClientAPI(ctrl)
+		clientAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("failed to list clients"))
+
+		fetcher := clientResourceFetcher{
+			api: &auth0.API{
+				Client: clientAPI,
+			},
+		}
+
+		_, err := fetcher.FetchData(context.Background())
+		assert.EqualError(t, err, "failed to list clients")
+	})
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR adds the ability to fetch the Auth0 Client import data for the `auth0 terraform generate` command.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
