### PR TITLE
DXCDT-509: Adding `auth0_connections` export support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vendor
 
 # Binary output folder
 out/
+
+# Terraform export command artifacts
+*.tf

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -38,6 +38,9 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) []resourceDataFe
 		&clientResourceFetcher{
 			api: api,
 		},
+		&connectionResourceFetcher{
+			api: api,
+		},
 	}
 }
 


### PR DESCRIPTION
### 🔧 Changes

Adding support for exporting connection Terraform resources when running the `auth0 tf generate` command. The output will appear like this:

```hcl
import {
  id = "con_ZEPofWWVD0hkBcSP"
  to = auth0_connection.google-oauth2
}

import {
  id = "con_SOAPB8ZiGrIDDyh4"
  to = auth0_connection.Username-Password-Authentication
}
```


### 🔬 Testing

Adding unit tests. Manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
