### PR TITLE
DXCDT-508: Prevent overwriting already existing files

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -26,6 +26,7 @@ auth0 terraform generate [flags]
 ## Flags
 
 ```
+      --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
 ```
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -90,7 +90,7 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			return err
 		}
 
-		if !checkOutputDirectoryIsEmpty(cli, inputs.OutputDIR) {
+		if !checkOutputDirectoryIsEmpty(cli, cmd, inputs.OutputDIR) {
 			return nil
 		}
 
@@ -279,7 +279,7 @@ func terraformProviderCredentialsAreAvailable() bool {
 	return (domain != "" && clientID != "" && clientSecret != "") || (domain != "" && apiToken != "")
 }
 
-func checkOutputDirectoryIsEmpty(cli *cli, outputDIR string) bool {
+func checkOutputDirectoryIsEmpty(cli *cli, cmd *cobra.Command, outputDIR string) bool {
 	_, err := os.Stat(outputDIR)
 	if os.IsNotExist(err) {
 		return true
@@ -298,7 +298,7 @@ func checkOutputDirectoryIsEmpty(cli *cli, outputDIR string) bool {
 		outputDIR,
 	)
 
-	if !cli.force && !cli.noInput {
+	if !cli.force && canPrompt(cmd) {
 		if confirmed := prompt.Confirm("Are you sure you want to proceed?"); !confirmed {
 			return false
 		}

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -128,7 +128,7 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 		)
 		cli.renderer.Infof(
 			"After setting up the provider credentials, run: \n\n"+
-				"	cd %s && terraform init && terraform plan -generate-config-out=generated.tf && terraform apply",
+				"	cd %s && terraform init && terraform plan -generate-config-out=auth0_generated.tf && terraform apply",
 			inputs.OutputDIR,
 		)
 		cli.renderer.Newline()
@@ -183,7 +183,7 @@ func createOutputDirectory(outputDIR string) error {
 }
 
 func createMainFile(outputDIR string) error {
-	filePath := path.Join(outputDIR, "main.tf")
+	filePath := path.Join(outputDIR, "auth0_main.tf")
 
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -265,7 +265,7 @@ func generateTerraformResourceConfig(ctx context.Context, outputDIR string) erro
 	}
 
 	// -generate-config-out flag is not supported by terraform-exec, so we do this through exec.Command.
-	cmd := exec.CommandContext(ctx, execPath, "plan", "-generate-config-out=generated.tf")
+	cmd := exec.CommandContext(ctx, execPath, "plan", "-generate-config-out=auth0_generated.tf")
 	cmd.Dir = absoluteOutputPath
 	return cmd.Run()
 }
@@ -285,16 +285,16 @@ func checkOutputDirectoryIsEmpty(cli *cli, outputDIR string) bool {
 		return true
 	}
 
-	_, mainFileErr := os.Stat(path.Join(outputDIR, "main.tf"))
+	_, mainFileErr := os.Stat(path.Join(outputDIR, "auth0_main.tf"))
 	_, importFileErr := os.Stat(path.Join(outputDIR, "auth0_import.tf"))
-	_, generatedFileErr := os.Stat(path.Join(outputDIR, "generated.tf"))
+	_, generatedFileErr := os.Stat(path.Join(outputDIR, "auth0_generated.tf"))
 	if os.IsNotExist(mainFileErr) && os.IsNotExist(importFileErr) && os.IsNotExist(generatedFileErr) {
 		return true
 	}
 
 	cli.renderer.Warnf(
 		"Output directory %q is not empty. "+
-			"Proceeding will overwrite the main.tf, auth0_import.tf and generated.tf files.",
+			"Proceeding will overwrite the auth0_main.tf, auth0_import.tf and auth0_generated.tf files.",
 		outputDIR,
 	)
 
@@ -310,7 +310,7 @@ func checkOutputDirectoryIsEmpty(cli *cli, outputDIR string) bool {
 func cleanOutputDirectory(outputDIR string) error {
 	var joinedErrors error
 
-	if err := os.Remove(path.Join(outputDIR, "main.tf")); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(path.Join(outputDIR, "auth0_main.tf")); err != nil && !os.IsNotExist(err) {
 		joinedErrors = errors.Join(err)
 	}
 
@@ -318,7 +318,7 @@ func cleanOutputDirectory(outputDIR string) error {
 		joinedErrors = errors.Join(err)
 	}
 
-	if err := os.Remove(path.Join(outputDIR, "generated.tf")); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(path.Join(outputDIR, "auth0_generated.tf")); err != nil && !os.IsNotExist(err) {
 		joinedErrors = errors.Join(err)
 	}
 

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -99,7 +99,7 @@ func TestGenerateTerraformImportConfig(t *testing.T) {
 		err := os.MkdirAll(outputDIR, 0755)
 		require.NoError(t, err)
 
-		mainFilePath := path.Join(outputDIR, "main.tf")
+		mainFilePath := path.Join(outputDIR, "auth0_main.tf")
 		_, err = os.Create(mainFilePath)
 		require.NoError(t, err)
 
@@ -158,7 +158,7 @@ func assertTerraformMainFileWasGeneratedCorrectly(t *testing.T, outputDIR string
 	assert.NoError(t, err)
 
 	// Assert that the main.tf file was created with the correct content.
-	filePath := path.Join(outputDIR, "main.tf")
+	filePath := path.Join(outputDIR, "auth0_main.tf")
 	_, err = os.Stat(filePath)
 	assert.NoError(t, err)
 
@@ -277,7 +277,7 @@ func TestCheckOutputDirectoryIsEmpty(t *testing.T) {
 
 	t.Run("it returns true if the directory is not empty but we're forcing the command", func(t *testing.T) {
 		tempDIR := t.TempDir()
-		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+		files := []string{"auth0_main.tf", "auth0_import.tf", "auth0_generated.tf"}
 
 		for _, file := range files {
 			filePath := path.Join(tempDIR, file)
@@ -297,14 +297,14 @@ func TestCheckOutputDirectoryIsEmpty(t *testing.T) {
 
 		isEmpty := checkOutputDirectoryIsEmpty(cli, tempDIR)
 		assert.True(t, isEmpty)
-		assert.Contains(t, stdout.String(), "Proceeding will overwrite the main.tf, auth0_import.tf and generated.tf files.")
+		assert.Contains(t, stdout.String(), "Proceeding will overwrite the auth0_main.tf, auth0_import.tf and auth0_generated.tf files.")
 	})
 }
 
 func TestCleanOutputDirectory(t *testing.T) {
 	t.Run("it can successfully clean the output directory from all generated files", func(t *testing.T) {
 		tempDIR := t.TempDir()
-		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+		files := []string{"auth0_main.tf", "auth0_import.tf", "auth0_generated.tf"}
 
 		for _, file := range files {
 			filePath := path.Join(tempDIR, file)
@@ -323,7 +323,7 @@ func TestCleanOutputDirectory(t *testing.T) {
 	})
 
 	t.Run("it returns an error if it can't remove a file", func(t *testing.T) {
-		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+		files := []string{"auth0_main.tf", "auth0_import.tf", "auth0_generated.tf"}
 
 		for _, file := range files {
 			t.Run(file, func(t *testing.T) {

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -266,12 +267,12 @@ func TestCheckOutputDirectoryIsEmpty(t *testing.T) {
 	t.Run("it returns true if the directory is empty", func(t *testing.T) {
 		tempDIR := t.TempDir()
 
-		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, tempDIR)
+		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, &cobra.Command{}, tempDIR)
 		assert.True(t, isEmpty)
 	})
 
 	t.Run("it returns true if the directory doesn't exist", func(t *testing.T) {
-		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, "")
+		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, &cobra.Command{}, "")
 		assert.True(t, isEmpty)
 	})
 
@@ -295,7 +296,7 @@ func TestCheckOutputDirectoryIsEmpty(t *testing.T) {
 			noInput: true,
 		}
 
-		isEmpty := checkOutputDirectoryIsEmpty(cli, tempDIR)
+		isEmpty := checkOutputDirectoryIsEmpty(cli, &cobra.Command{}, tempDIR)
 		assert.True(t, isEmpty)
 		assert.Contains(t, stdout.String(), "Proceeding will overwrite the auth0_main.tf, auth0_import.tf and auth0_generated.tf files.")
 	})

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/auth0/auth0-cli/internal/display"
 )
 
 type mockFetcher struct {
@@ -258,4 +260,90 @@ func TestTerraformProviderCredentialsAreAvailable(t *testing.T) {
 			assert.Equal(t, testCase.expected, terraformProviderCredentialsAreAvailable())
 		})
 	}
+}
+
+func TestCheckOutputDirectoryIsEmpty(t *testing.T) {
+	t.Run("it returns true if the directory is empty", func(t *testing.T) {
+		tempDIR := t.TempDir()
+
+		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, tempDIR)
+		assert.True(t, isEmpty)
+	})
+
+	t.Run("it returns true if the directory doesn't exist", func(t *testing.T) {
+		isEmpty := checkOutputDirectoryIsEmpty(&cli{}, "")
+		assert.True(t, isEmpty)
+	})
+
+	t.Run("it returns true if the directory is not empty but we're forcing the command", func(t *testing.T) {
+		tempDIR := t.TempDir()
+		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+
+		for _, file := range files {
+			filePath := path.Join(tempDIR, file)
+			_, err := os.Create(filePath)
+			require.NoError(t, err)
+		}
+
+		stdout := &bytes.Buffer{}
+		cli := &cli{
+			renderer: &display.Renderer{
+				MessageWriter: stdout,
+				ResultWriter:  stdout,
+			},
+			force:   true,
+			noInput: true,
+		}
+
+		isEmpty := checkOutputDirectoryIsEmpty(cli, tempDIR)
+		assert.True(t, isEmpty)
+		assert.Contains(t, stdout.String(), "Proceeding will overwrite the main.tf, auth0_import.tf and generated.tf files.")
+	})
+}
+
+func TestCleanOutputDirectory(t *testing.T) {
+	t.Run("it can successfully clean the output directory from all generated files", func(t *testing.T) {
+		tempDIR := t.TempDir()
+		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+
+		for _, file := range files {
+			filePath := path.Join(tempDIR, file)
+			_, err := os.Create(filePath)
+			require.NoError(t, err)
+		}
+
+		err := cleanOutputDirectory(tempDIR)
+		assert.NoError(t, err)
+
+		for _, file := range files {
+			filePath := path.Join(tempDIR, file)
+			_, err := os.Stat(filePath)
+			assert.ErrorContains(t, err, "no such file or directory")
+		}
+	})
+
+	t.Run("it returns an error if it can't remove a file", func(t *testing.T) {
+		files := []string{"main.tf", "auth0_import.tf", "generated.tf"}
+
+		for _, file := range files {
+			t.Run(file, func(t *testing.T) {
+				tempDIR := t.TempDir()
+
+				filePath := path.Join(tempDIR, file)
+				_, err := os.Create(filePath)
+				require.NoError(t, err)
+
+				err = os.Chmod(tempDIR, 0444)
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					err = os.Chmod(tempDIR, 0755)
+					require.NoError(t, err)
+				})
+
+				err = cleanOutputDirectory(tempDIR)
+				assert.ErrorContains(t, err, "permission denied")
+			})
+		}
+	})
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds a check to ensure the output dir is empty, if it's not it prompts the user to proceed in overwriting the files. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
