### PR TITLE
DXCDT-504: Add resources flag to terraform cmd

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,6 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -27,28 +28,43 @@ var tfFlags = terraformFlags{
 		Help: "Output directory for the generated Terraform config files. If not provided, the files will be " +
 			"saved in the current working directory.",
 	},
+	Resources: Flag{
+		Name:      "Resource Types",
+		LongForm:  "resources",
+		ShortForm: "r",
+		Help: "Resource types to generate Terraform config for. If not provided, config files for all " +
+			"available resources will be generated.",
+	},
 }
 
 type (
 	terraformFlags struct {
 		OutputDIR Flag
+		Resources Flag
 	}
 
 	terraformInputs struct {
 		OutputDIR string
+		Resources []string
 	}
 )
 
-func (i *terraformInputs) parseResourceFetchers(api *auth0.API) []resourceDataFetcher {
-	// Hard coding this for now until we add support for the `--resources` flag.
-	return []resourceDataFetcher{
-		&clientResourceFetcher{
-			api: api,
-		},
-		&connectionResourceFetcher{
-			api: api,
-		},
+func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataFetcher, error) {
+	fetchers := make([]resourceDataFetcher, 0)
+	var err error
+
+	for _, resource := range i.Resources {
+		switch resource {
+		case "auth0_client":
+			fetchers = append(fetchers, &clientResourceFetcher{api})
+		case "auth0_connection":
+			fetchers = append(fetchers, &connectionResourceFetcher{api})
+		default:
+			err = errors.Join(err, fmt.Errorf("unsupported resource type: %s", resource))
+		}
 	}
+
+	return fetchers, err
 }
 
 func terraformCmd(cli *cli) *cobra.Command {
@@ -82,13 +98,19 @@ func generateTerraformCmd(cli *cli) *cobra.Command {
 
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 	tfFlags.OutputDIR.RegisterString(cmd, &inputs.OutputDIR, "./")
+	tfFlags.Resources.RegisterStringSlice(cmd, &inputs.Resources, defaultResources)
 
 	return cmd
 }
 
 func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		data, err := fetchImportData(cmd.Context(), inputs.parseResourceFetchers(cli.api)...)
+		resources, err := inputs.parseResourceFetchers(cli.api)
+		if err != nil {
+			return err
+		}
+
+		data, err := fetchImportData(cmd.Context(), resources...)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -9,6 +9,8 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
+var defaultResources = []string{"auth0_client", "auth0_connection"}
+
 type (
 	importDataList []importDataItem
 

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/display"
 )
 
@@ -347,4 +348,70 @@ func TestCleanOutputDirectory(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestTerraformInputs_ParseResourceFetchers(t *testing.T) {
+	api := &auth0.API{}
+
+	var testCases = []struct {
+		name                 string
+		input                terraformInputs
+		expectedError        string
+		expectedDataFetchers []resourceDataFetcher
+	}{
+		{
+			name: "it can successfully parse resources: auth0_client",
+			input: terraformInputs{
+				Resources: []string{"auth0_client"},
+			},
+			expectedDataFetchers: []resourceDataFetcher{
+				&clientResourceFetcher{api},
+			},
+		},
+		{
+			name: "it can successfully parse resources: auth0_client, auth0_connection",
+			input: terraformInputs{
+				Resources: []string{"auth0_client", "auth0_connection"},
+			},
+			expectedDataFetchers: []resourceDataFetcher{
+				&clientResourceFetcher{api},
+				&connectionResourceFetcher{api},
+			},
+		},
+		{
+			name: "it fails to parse unsupported resources: auth0_technology",
+			input: terraformInputs{
+				Resources: []string{"auth0_technology"},
+			},
+			expectedError: "unsupported resource type: auth0_technology",
+		},
+		{
+			name: "it fails to parse unsupported resources even if combined with supported resources: auth0_client, auth0_technology",
+			input: terraformInputs{
+				Resources: []string{"auth0_client", "auth0_technology"},
+			},
+			expectedError: "unsupported resource type: auth0_technology",
+		},
+		{
+			name: "it fails to parse unsupported resources and raises the error for all of them: auth0_metrics, auth0_technology",
+			input: terraformInputs{
+				Resources: []string{"auth0_metrics", "auth0_technology"},
+			},
+			expectedError: "unsupported resource type: auth0_metrics\nunsupported resource type: auth0_technology",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := testCase.input.parseResourceFetchers(api)
+
+			if testCase.expectedError != "" {
+				assert.EqualError(t, err, testCase.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedDataFetchers, actual)
+		})
+	}
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds support for a `--resources` flag for the auth0 terraform generate command.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
