### PR TITLE
Adding Retry Mechanism to Auth0 Client

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/auth0/go-auth0/management"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -114,6 +114,7 @@ func (c *cli) setupWithAuthentication(ctx context.Context) error {
 		management.WithStaticToken(tenant.GetAccessToken()),
 		management.WithUserAgent(userAgent),
 		management.WithAuth0ClientEnvEntry("Auth0-CLI", strings.TrimPrefix(buildinfo.Version, "v")),
+		management.WithRetries(5, []int{http.StatusTooManyRequests, http.StatusInternalServerError}),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
### 🔧 Changes

We've been seeing a drastic uptick in integration test failures. We suspect that this is to do with the Go SDK's v1 change in handling retries no longer being by default but user-defined when instantiating the client. This PR adds the line of code necessary to perform retries on behalf of the user when 429 and 500 status codes are experienced, up to five retries.

### 📚 References

- [Similar addition to Auth0 Terraform Provider](https://github.com/auth0/terraform-provider-auth0/commit/c0bb5c8ab0dc78179f52c21cade5131ae1695a12#diff-7a0b4bba956f7f07d7f1b0b1b3f83f28dda76464bf8a7bc0c98d406a1029efdbR69)

### 🔬 Testing

Manually tested for now.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
