### PR TITLE
DXCDT-511: Adding support for auth0_tenant resource import

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -60,7 +60,7 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 		case "auth0_connection":
 			fetchers = append(fetchers, &connectionResourceFetcher{api})
 		case "auth0_tenant":
-			fetchers = append(fetchers, &tenantResourceFetcher{api})
+			fetchers = append(fetchers, &tenantResourceFetcher{})
 		default:
 			err = errors.Join(err, fmt.Errorf("unsupported resource type: %s", resource))
 		}

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -59,6 +59,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":
 			fetchers = append(fetchers, &connectionResourceFetcher{api})
+		case "auth0_tenant":
+			fetchers = append(fetchers, &tenantResourceFetcher{api})
 		default:
 			err = errors.Join(err, fmt.Errorf("unsupported resource type: %s", resource))
 		}

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -5,11 +5,12 @@ import (
 	"regexp"
 
 	"github.com/auth0/go-auth0/management"
+	"github.com/google/uuid"
 
 	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
-var defaultResources = []string{"auth0_client", "auth0_connection"}
+var defaultResources = []string{"auth0_client", "auth0_connection", "auth0_tenant"}
 
 type (
 	importDataList []importDataItem
@@ -22,12 +23,18 @@ type (
 	resourceDataFetcher interface {
 		FetchData(ctx context.Context) (importDataList, error)
 	}
+)
 
+type (
 	clientResourceFetcher struct {
 		api *auth0.API
 	}
 
 	connectionResourceFetcher struct {
+		api *auth0.API
+	}
+
+	tenantResourceFetcher struct {
 		api *auth0.API
 	}
 )
@@ -93,6 +100,15 @@ func (f *connectionResourceFetcher) FetchData(ctx context.Context) (importDataLi
 	}
 
 	return data, nil
+}
+
+func (f *tenantResourceFetcher) FetchData(_ context.Context) (importDataList, error) {
+	return []importDataItem{
+		{
+			ResourceName: "auth0_tenant.tenant",
+			ImportID:     uuid.NewString(),
+		},
+	}, nil
 }
 
 // sanitizeResourceName will return a valid terraform resource name.

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -34,9 +34,7 @@ type (
 		api *auth0.API
 	}
 
-	tenantResourceFetcher struct {
-		api *auth0.API
-	}
+	tenantResourceFetcher struct{}
 )
 
 func (f *clientResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -241,3 +241,17 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 		assert.EqualError(t, err, "failed to list connections")
 	})
 }
+
+func TestTeantResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully generates tenant import data", func(t *testing.T) {
+		fetcher := tenantResourceFetcher{
+			api: &auth0.API{},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, data, 1)
+		assert.Equal(t, data[0].ResourceName, "auth0_tenant.tenant")
+		assert.Greater(t, len(data[0].ImportID), 0)
+	})
+}

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -244,9 +244,7 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 
 func TestTeantResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully generates tenant import data", func(t *testing.T) {
-		fetcher := tenantResourceFetcher{
-			api: &auth0.API{},
-		}
+		fetcher := tenantResourceFetcher{}
 
 		data, err := fetcher.FetchData(context.Background())
 		assert.NoError(t, err)


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_tenant` resource with the reverse terraform functionality.

This one was pretty straightforward, lacking an API request because tenants are ID-less singletons.

### 🔬 Testing

Added unit test + manual verification.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
