### PR TITLE
DXCDT-512: Actions resource export support

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_action,auth0_client,auth0_connection,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -55,6 +55,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 
 	for _, resource := range i.Resources {
 		switch resource {
+		case "auth0_action":
+			fetchers = append(fetchers, &actionResourceFetcher{api})
 		case "auth0_client":
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
-var defaultResources = []string{"auth0_client", "auth0_connection", "auth0_tenant"}
+var defaultResources = []string{"auth0_action", "auth0_client", "auth0_connection", "auth0_tenant"}
 
 type (
 	importDataList []importDataItem
@@ -26,6 +26,9 @@ type (
 )
 
 type (
+	actionResourceFetcher struct {
+		api *auth0.API
+	}
 	clientResourceFetcher struct {
 		api *auth0.API
 	}
@@ -107,6 +110,36 @@ func (f *tenantResourceFetcher) FetchData(_ context.Context) (importDataList, er
 			ImportID:     uuid.NewString(),
 		},
 	}, nil
+}
+
+func (f *actionResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
+	var data importDataList
+
+	var page int
+	for {
+		actions, err := f.api.Action.List(
+			ctx,
+			management.Page(page),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, action := range actions.Actions {
+			data = append(data, importDataItem{
+				ResourceName: "auth0_action." + sanitizeResourceName(action.GetName()),
+				ImportID:     action.GetID(),
+			})
+		}
+
+		if !actions.HasNext() {
+			break
+		}
+
+		page++
+	}
+
+	return data, nil
 }
 
 // sanitizeResourceName will return a valid terraform resource name.

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -242,6 +242,107 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 	})
 }
 
+func TestActionResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully retrieves actions data", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		actionAPI := mock.NewMockActionAPI(ctrl)
+		actionAPI.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(
+				&management.ActionList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 4,
+					},
+					Actions: []*management.Action{
+						{
+							ID:   auth0.String("07898b80-02ba-42ee-82ad-e5b224a9b450"),
+							Name: auth0.String("Action 1"),
+						},
+						{
+							ID:   auth0.String("24118aae-8022-4b94-80c1-e8e28511eb92"),
+							Name: auth0.String("Action 2"),
+						},
+					},
+				},
+				nil,
+			)
+		actionAPI.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(
+				&management.ActionList{
+					List: management.List{
+						Start: 2,
+						Limit: 4,
+						Total: 4,
+					},
+					Actions: []*management.Action{
+						{
+							ID:   auth0.String("fa04d1ff-fe8d-4662-b7c2-32d212719876"),
+							Name: auth0.String("Action 3"),
+						},
+						{
+							ID:   auth0.String("9cb897b9-c25c-47be-b5aa-e03e31af2e44"),
+							Name: auth0.String("Action 4"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := actionResourceFetcher{
+			api: &auth0.API{
+				Action: actionAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_action.Action1",
+				ImportID:     "07898b80-02ba-42ee-82ad-e5b224a9b450",
+			},
+			{
+				ResourceName: "auth0_action.Action2",
+				ImportID:     "24118aae-8022-4b94-80c1-e8e28511eb92",
+			},
+			{
+				ResourceName: "auth0_action.Action3",
+				ImportID:     "fa04d1ff-fe8d-4662-b7c2-32d212719876",
+			},
+			{
+				ResourceName: "auth0_action.Action4",
+				ImportID:     "9cb897b9-c25c-47be-b5aa-e03e31af2e44",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
+	t.Run("it returns an error if api call fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		actionAPI := mock.NewMockActionAPI(ctrl)
+		actionAPI.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("failed to list actions"))
+
+		fetcher := actionResourceFetcher{
+			api: &auth0.API{
+				Action: actionAPI,
+			},
+		}
+
+		_, err := fetcher.FetchData(context.Background())
+		assert.EqualError(t, err, "failed to list actions")
+	})
+}
+
 func TestTeantResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully generates tenant import data", func(t *testing.T) {
 		fetcher := tenantResourceFetcher{}


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_action` resource with the reverse terraform functionality.

The output will appear like this:
```
import {
  id = "e128ab1c-f1ef-47e3-bdd4-1348356f3ab7"
  to = auth0_action.Action1
}

import {
  id = "D1AD7CCF-7BAB-417F-91C0-563595A916D8"
  to = auth0_action.Action2
}
```
### 📚 References

Related PRs: #808 #797 

### 🔬 Testing

Adding unit tests, manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
