### PR TITLE
DXCDT-513: Organizations resource export support

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_organization,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -59,6 +59,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":
 			fetchers = append(fetchers, &connectionResourceFetcher{api})
+		case "auth0_organization":
+			fetchers = append(fetchers, &organizationResourceFetcher{api})
 		case "auth0_tenant":
 			fetchers = append(fetchers, &tenantResourceFetcher{})
 		default:

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -249,7 +249,7 @@ func TestOrganizationResourceFetcher_FetchData(t *testing.T) {
 
 		orgAPI := mock.NewMockOrganizationAPI(ctrl)
 		orgAPI.EXPECT().
-			List(gomock.Any()).
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(
 				&management.OrganizationList{
 					List: management.List{
@@ -271,7 +271,7 @@ func TestOrganizationResourceFetcher_FetchData(t *testing.T) {
 				nil,
 			)
 		orgAPI.EXPECT().
-			List(gomock.Any()).
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(
 				&management.OrganizationList{
 					List: management.List{
@@ -329,7 +329,7 @@ func TestOrganizationResourceFetcher_FetchData(t *testing.T) {
 
 		orgAPI := mock.NewMockOrganizationAPI(ctrl)
 		orgAPI.EXPECT().
-			List(gomock.Any()).
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, fmt.Errorf("failed to list organizations"))
 
 		fetcher := organizationResourceFetcher{

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -242,6 +242,107 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 	})
 }
 
+func TestOrganizationResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully retrieves organizations data", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		orgAPI := mock.NewMockOrganizationAPI(ctrl)
+		orgAPI.EXPECT().
+			List(gomock.Any()).
+			Return(
+				&management.OrganizationList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 4,
+					},
+					Organizations: []*management.Organization{
+						{
+							ID:   auth0.String("org_1"),
+							Name: auth0.String("Organization 1"),
+						},
+						{
+							ID:   auth0.String("org_2"),
+							Name: auth0.String("Organization 2"),
+						},
+					},
+				},
+				nil,
+			)
+		orgAPI.EXPECT().
+			List(gomock.Any()).
+			Return(
+				&management.OrganizationList{
+					List: management.List{
+						Start: 2,
+						Limit: 4,
+						Total: 4,
+					},
+					Organizations: []*management.Organization{
+						{
+							ID:   auth0.String("org_3"),
+							Name: auth0.String("Organization 3"),
+						},
+						{
+							ID:   auth0.String("org_4"),
+							Name: auth0.String("Organization 4"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := organizationResourceFetcher{
+			api: &auth0.API{
+				Organization: orgAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_organization.Organization1",
+				ImportID:     "org_1",
+			},
+			{
+				ResourceName: "auth0_organization.Organization2",
+				ImportID:     "org_2",
+			},
+			{
+				ResourceName: "auth0_organization.Organization3",
+				ImportID:     "org_3",
+			},
+			{
+				ResourceName: "auth0_organization.Organization4",
+				ImportID:     "org_4",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
+	t.Run("it returns an error if api call fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		orgAPI := mock.NewMockOrganizationAPI(ctrl)
+		orgAPI.EXPECT().
+			List(gomock.Any()).
+			Return(nil, fmt.Errorf("failed to list organizations"))
+
+		fetcher := organizationResourceFetcher{
+			api: &auth0.API{
+				Organization: orgAPI,
+			},
+		}
+
+		_, err := fetcher.FetchData(context.Background())
+		assert.EqualError(t, err, "failed to list organizations")
+	})
+}
+
 func TestTeantResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully generates tenant import data", func(t *testing.T) {
 		fetcher := tenantResourceFetcher{}


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_organization` resource with the reverse terraform functionality.

The output will appear like this:
```
import {
  id = "Fpq62OeDkIYMEx1I"
  to = auth0_organization.Org1
}

import {
  id = "org_Bun61OdHkIUME7zI"
  to = auth0_organization.Org2
}
```
### 📚 References

Related PRs: #808, #797, #809 

### 🔬 Testing

Adding unit tests, manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
