### PR TITLE
DXCDT-516: Adding branding resource export support

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_branding,auth0_client,auth0_connection,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -55,6 +55,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 
 	for _, resource := range i.Resources {
 		switch resource {
+		case "auth0_branding":
+			fetchers = append(fetchers, &brandingResourceFetcher{})
 		case "auth0_client":
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
-var defaultResources = []string{"auth0_client", "auth0_connection", "auth0_tenant"}
+var defaultResources = []string{"auth0_branding", "auth0_client", "auth0_connection", "auth0_tenant"}
 
 type (
 	importDataList []importDataItem
@@ -26,7 +26,8 @@ type (
 )
 
 type (
-	clientResourceFetcher struct {
+	brandingResourceFetcher struct{}
+	clientResourceFetcher   struct {
 		api *auth0.API
 	}
 
@@ -36,6 +37,15 @@ type (
 
 	tenantResourceFetcher struct{}
 )
+
+func (f *brandingResourceFetcher) FetchData(_ context.Context) (importDataList, error) {
+	return []importDataItem{
+		{
+			ResourceName: "auth0_branding.branding",
+			ImportID:     uuid.NewString(),
+		},
+	}, nil
+}
 
 func (f *clientResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
 	var data importDataList

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -141,6 +141,18 @@ func TestClientResourceFetcher_FetchData(t *testing.T) {
 	})
 }
 
+func TestBrandingResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully generates branding import data", func(t *testing.T) {
+		fetcher := brandingResourceFetcher{}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, data, 1)
+		assert.Equal(t, data[0].ResourceName, "auth0_branding.branding")
+		assert.Greater(t, len(data[0].ImportID), 0)
+	})
+}
+
 func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully retrieves connections data", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -242,7 +254,7 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 	})
 }
 
-func TestTeantResourceFetcher_FetchData(t *testing.T) {
+func TestTenantResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully generates tenant import data", func(t *testing.T) {
 		fetcher := tenantResourceFetcher{}
 


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_action` resource with the reverse terraform functionality.

The output will appear like this:

```
import {
  id = "ed6a0e70-0d0b-40a3-99eb-55d2acd3628f"
  to = auth0_branding.branding
}
```

### 📚 References

Related PRs: #808, #797, #810, #809 

### 🔬 Testing

Adding unit tests, manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
