### PR TITLE
DXCDT-517: Custom domain resource export support

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_custom_domain,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -59,6 +59,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":
 			fetchers = append(fetchers, &connectionResourceFetcher{api})
+		case "auth0_custom_domain":
+			fetchers = append(fetchers, &customDomainResourceFetcher{api})
 		case "auth0_tenant":
 			fetchers = append(fetchers, &tenantResourceFetcher{})
 		default:

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/auth0/auth0-cli/internal/auth0"
 )
 
-var defaultResources = []string{"auth0_client", "auth0_connection", "auth0_tenant"}
+var defaultResources = []string{"auth0_client", "auth0_connection", "auth0_custom_domain", "auth0_tenant"}
 
 type (
 	importDataList []importDataItem
@@ -31,6 +31,10 @@ type (
 	}
 
 	connectionResourceFetcher struct {
+		api *auth0.API
+	}
+
+	customDomainResourceFetcher struct {
 		api *auth0.API
 	}
 
@@ -95,6 +99,24 @@ func (f *connectionResourceFetcher) FetchData(ctx context.Context) (importDataLi
 		}
 
 		page++
+	}
+
+	return data, nil
+}
+
+func (f *customDomainResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
+	var data importDataList
+
+	customDomains, err := f.api.CustomDomain.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, domain := range customDomains {
+		data = append(data, importDataItem{
+			ResourceName: "auth0_custom_domain." + sanitizeResourceName(domain.GetDomain()),
+			ImportID:     domain.GetID(),
+		})
 	}
 
 	return data, nil


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_custom_domain` resource with the reverse terraform functionality.

The output will appear like this:

```
import {
  id = "ed6a0e70-0d0b-40a3-99eb-55d2acd3628f"
  to = auth0_customdomain.travel0com
}
```

### 📚 References

Related PRs: #808, #797, #810, #809 

### 🔬 Testing

Adding unit tests, manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
