### PR TITLE
DXCDT-514: Roles resource export support

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -28,7 +28,7 @@ auth0 terraform generate [flags]
 ```
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
-  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_tenant])
+  -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_client,auth0_connection,auth0_role,auth0_tenant])
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -59,6 +59,8 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API) ([]resourceDataF
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_connection":
 			fetchers = append(fetchers, &connectionResourceFetcher{api})
+		case "auth0_role":
+			fetchers = append(fetchers, &roleResourceFetcher{api})
 		case "auth0_tenant":
 			fetchers = append(fetchers, &tenantResourceFetcher{})
 		default:

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -242,6 +242,107 @@ func TestConnectionResourceFetcher_FetchData(t *testing.T) {
 	})
 }
 
+func TestRoleResourceFetcher_FetchData(t *testing.T) {
+	t.Run("it successfully retrieves roles data", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		roleAPI := mock.NewMockRoleAPI(ctrl)
+		roleAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.RoleList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 4,
+					},
+					Roles: []*management.Role{
+						{
+							ID:   auth0.String("rol_1"),
+							Name: auth0.String("Role 1"),
+						},
+						{
+							ID:   auth0.String("rol_2"),
+							Name: auth0.String("Role 2"),
+						},
+					},
+				},
+				nil,
+			)
+		roleAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.RoleList{
+					List: management.List{
+						Start: 2,
+						Limit: 4,
+						Total: 4,
+					},
+					Roles: []*management.Role{
+						{
+							ID:   auth0.String("rol_3"),
+							Name: auth0.String("Role 3"),
+						},
+						{
+							ID:   auth0.String("rol_4"),
+							Name: auth0.String("Role 4"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := roleResourceFetcher{
+			api: &auth0.API{
+				Role: roleAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_role.Role1",
+				ImportID:     "rol_1",
+			},
+			{
+				ResourceName: "auth0_role.Role2",
+				ImportID:     "rol_2",
+			},
+			{
+				ResourceName: "auth0_role.Role3",
+				ImportID:     "rol_3",
+			},
+			{
+				ResourceName: "auth0_role.Role4",
+				ImportID:     "rol_4",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
+	t.Run("it returns an error if api call fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		roleAPI := mock.NewMockRoleAPI(ctrl)
+		roleAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("failed to list roles"))
+
+		fetcher := roleResourceFetcher{
+			api: &auth0.API{
+				Role: roleAPI,
+			},
+		}
+
+		_, err := fetcher.FetchData(context.Background())
+		assert.EqualError(t, err, "failed to list roles")
+	})
+}
+
 func TestTeantResourceFetcher_FetchData(t *testing.T) {
 	t.Run("it successfully generates tenant import data", func(t *testing.T) {
 		fetcher := tenantResourceFetcher{}


### PR DESCRIPTION
### 🔧 Changes

Introducing support for exporting the `auth0_role` resource with the reverse terraform functionality.

The output will appear like this:

```
import {
  id = "rol_0NSBA28994D6DOxh"
  to = auth0_role.Role1
}
```

### 📚 References

Related PRs: #808, #797, #810, #809 #812 

### 🔬 Testing

Adding unit tests, manually verified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
