### PR TITLE
DXCDT-538: Adding progress spinner to `tf generate` command

### DIFF
--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/spf13/cobra"
 
+	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/prompt"
 )
@@ -144,7 +145,11 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			return err
 		}
 
-		data, err := fetchImportData(cmd.Context(), resources...)
+		var data importDataList
+		err = ansi.Spinner("Fetching data from Auth0", func() error {
+			data, err = fetchImportData(cmd.Context(), resources...)
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -162,7 +167,11 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 		}
 
 		if terraformProviderCredentialsAreAvailable() {
-			if err := generateTerraformResourceConfig(cmd.Context(), inputs.OutputDIR); err == nil {
+			err = ansi.Spinner("Generating Terraform configuration", func() error {
+				return generateTerraformResourceConfig(cmd.Context(), inputs.OutputDIR)
+			})
+
+			if err == nil {
 				cli.renderer.Infof("Terraform resource config files generated successfully in: %q", inputs.OutputDIR)
 				cli.renderer.Infof(
 					"Review the config and generate the terraform state by running: \n\n	cd %s && ./terraform apply",


### PR DESCRIPTION
### 🔧 Changes

The `auth0 tf generate` command has the potential to take quite a long time. There are two main steps that are the culprits: fetching relevant data from Auth0 and then facilitating the generation/import with Terraform itself. This PR adds two spinners for these two steps to indicate to the user that progress is being made.

### 🔬 Testing

Manual verification. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
