### PR TITLE
Fix: mapping of multiple action secrets

### DIFF
--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -560,8 +561,8 @@ func inputSecretsToActionSecrets(secrets map[string]string) *[]management.Action
 
 	for name, value := range secrets {
 		actionSecrets = append(actionSecrets, management.ActionSecret{
-			Name:  &name,
-			Value: &value,
+			Name:  auth0.String(name),
+			Value: auth0.String(value),
 		})
 	}
 

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -210,3 +210,37 @@ func TestActionsPickerOptions(t *testing.T) {
 		})
 	}
 }
+func TestActionsInputSecretsToActionSecrets(t *testing.T) {
+	t.Run("Should map input secrets to action payload", func(t *testing.T) {
+		input := map[string]string{
+			"secret1": "value1",
+			"secret2": "value2",
+			"secret3": "value3",
+		}
+		res := inputSecretsToActionSecrets(input)
+		expected := []management.ActionSecret{
+			{
+				Name:  auth0.String("secret1"),
+				Value: auth0.String("value1"),
+			},
+			{
+				Name:  auth0.String("secret2"),
+				Value: auth0.String("value2"),
+			},
+			{
+				Name:  auth0.String("secret3"),
+				Value: auth0.String("value3"),
+			},
+		}
+		assert.Len(t, *res, 3)
+		assert.Equal(t, res, &expected)
+	})
+
+	t.Run("Should handle empty input secrets", func(t *testing.T) {
+		emptyInput := map[string]string{}
+		res := inputSecretsToActionSecrets(emptyInput)
+		expected := []management.ActionSecret{}
+		assert.Len(t, *res, 0)
+		assert.Equal(t, res, &expected)
+	})
+}

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -211,7 +211,7 @@ func TestActionsPickerOptions(t *testing.T) {
 	}
 }
 func TestActionsInputSecretsToActionSecrets(t *testing.T) {
-	t.Run("Should map input secrets to action payload", func(t *testing.T) {
+	t.Run("it should map input secrets to action payload", func(t *testing.T) {
 		input := map[string]string{
 			"secret1": "value1",
 			"secret2": "value2",
@@ -236,7 +236,7 @@ func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 		assert.Equal(t, res, &expected)
 	})
 
-	t.Run("Should handle empty input secrets", func(t *testing.T) {
+	t.Run("it should handle empty input secrets", func(t *testing.T) {
 		emptyInput := map[string]string{}
 		res := inputSecretsToActionSecrets(emptyInput)
 		expected := []management.ActionSecret{}


### PR DESCRIPTION
### 🔧 Changes

As noted by #841, when providing multiple secrets to the `auth0 actions` commands through the `--secrets` flag, only the final secret value is registered. 

This can be easily observed by running the following two commands:

```sh
auth0 actions create -n multiple-secrets-test -t post-login -c "test" -s "secret1=1" -s "secret=2"
auth0 actions show <ID_FROM_CREATED_ACTION> --json
```

This is due to a late-binding issue when using a pointer of the loop range index and range value. 

### 📚 References

- [Related Github Issue](https://github.com/auth0/auth0-cli/issues/841)

### 🔬 Testing

Added unit tests. Manual verification from 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
