### PR TITLE
Adding custom JSON deserializer for UserInfo type

### DIFF
--- a/internal/auth/authutil/user_info.go
+++ b/internal/auth/authutil/user_info.go
@@ -2,7 +2,6 @@ package authutil
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func (u *UserInfo) UnmarshalJSON(b []byte) error {
 				return err
 			}
 		default:
-			return errors.New(fmt.Sprintf("unable to unmarshal JSON for email_verified field. Expected bool or string, got: %s", reflect.TypeOf(rawEmailVerified)))
+			return fmt.Errorf("unable to unmarshal JSON for email_verified field. Expected bool or string, got: %s", reflect.TypeOf(rawEmailVerified))
 		}
 		alias.EmailVerified = &emailVerified
 	}

--- a/internal/auth/authutil/user_info.go
+++ b/internal/auth/authutil/user_info.go
@@ -60,7 +60,7 @@ func (u *UserInfo) UnmarshalJSON(b []byte) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("unable to unmarshal JSON for email_verified field. Expected bool or string, got: %s", reflect.TypeOf(rawEmailVerified))
+			return fmt.Errorf("email_verified field expected to be bool or string, got: %s", reflect.TypeOf(rawEmailVerified))
 		}
 		alias.EmailVerified = &emailVerified
 	}

--- a/internal/auth/authutil/user_info.go
+++ b/internal/auth/authutil/user_info.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -29,6 +31,41 @@ type UserInfo struct {
 	ZoneInfo          *string    `json:"zoneinfo,omitempty"`
 	Locale            *string    `json:"locale,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+}
+
+// UnmarshalJSON is a custom deserializer for the UserInfo type.
+// A custom solution is necessary due to possible inconsistencies in value types.
+func (u *UserInfo) UnmarshalJSON(b []byte) error {
+	type userInfo UserInfo
+	type userAlias struct {
+		*userInfo
+		RawEmailVerified interface{} `json:"email_verified,omitempty"`
+	}
+
+	alias := &userAlias{(*userInfo)(u), nil}
+
+	err := json.Unmarshal(b, alias)
+	if err != nil {
+		return err
+	}
+
+	if alias.RawEmailVerified != nil {
+		var emailVerified bool
+		switch rawEmailVerified := alias.RawEmailVerified.(type) {
+		case bool:
+			emailVerified = rawEmailVerified
+		case string:
+			emailVerified, err = strconv.ParseBool(rawEmailVerified)
+			if err != nil {
+				return err
+			}
+		default:
+			panic(reflect.TypeOf(rawEmailVerified))
+		}
+		alias.EmailVerified = &emailVerified
+	}
+
+	return nil
 }
 
 // FetchUserInfo fetches and parses user information with the provided access token.

--- a/internal/auth/authutil/user_info.go
+++ b/internal/auth/authutil/user_info.go
@@ -2,6 +2,7 @@ package authutil
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -60,7 +61,7 @@ func (u *UserInfo) UnmarshalJSON(b []byte) error {
 				return err
 			}
 		default:
-			panic(reflect.TypeOf(rawEmailVerified))
+			return errors.New(fmt.Sprintf("unable to unmarshal JSON for email_verified field. Expected bool or string, got: %s", reflect.TypeOf(rawEmailVerified)))
 		}
 		alias.EmailVerified = &emailVerified
 	}

--- a/internal/auth/authutil/user_info_test.go
+++ b/internal/auth/authutil/user_info_test.go
@@ -65,6 +65,12 @@ func TestUserInfo(t *testing.T) {
 			httpStatus: http.StatusOK,
 			response:   `{ "foo": "bar" `,
 		},
+		{
+			name:       "Email verified field not string or bool",
+			expect:     "cannot decode response: unable to unmarshal JSON for email_verified field. Expected bool or string, got: float64",
+			httpStatus: http.StatusOK,
+			response:   `{ "email_verified": 0 }`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/auth/authutil/user_info_test.go
+++ b/internal/auth/authutil/user_info_test.go
@@ -67,7 +67,7 @@ func TestUserInfo(t *testing.T) {
 		},
 		{
 			name:       "Email verified field not string or bool",
-			expect:     "cannot decode response: unable to unmarshal JSON for email_verified field. Expected bool or string, got: float64",
+			expect:     "cannot decode response: email_verified field expected to be bool or string, got: float64",
 			httpStatus: http.StatusOK,
 			response:   `{ "email_verified": 0 }`,
 		},

--- a/internal/auth/authutil/user_info_test.go
+++ b/internal/auth/authutil/user_info_test.go
@@ -16,7 +16,7 @@ func TestUserInfo(t *testing.T) {
 			assert.Equal(t, "Bearer token", r.Header.Get("authorization"))
 
 			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{"name": "Joe Bloggs"}`)
+			io.WriteString(w, `{"name": "Joe Bloggs","email_verified":true}`)
 		}))
 
 		defer ts.Close()
@@ -27,6 +27,25 @@ func TestUserInfo(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, "Joe Bloggs", *user.Name)
+		assert.Equal(t, true, *user.EmailVerified)
+	})
+
+	t.Run("Successfully call user info endpoint with string encoded email verified field", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer token", r.Header.Get("authorization"))
+
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"email_verified":"true"}`)
+		}))
+
+		defer ts.Close()
+		parsedURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+
+		user, err := FetchUserInfo(ts.Client(), parsedURL.Host, "token")
+
+		assert.NoError(t, err)
+		assert.Equal(t, true, *user.EmailVerified)
 	})
 
 	testCases := []struct {


### PR DESCRIPTION
### 🔧 Changes

As reported by #840, when testing sign-in with an Apple through the `auth0 test login` command, users will incur this error:

```
 failed to fetch user info: cannot decode response: json: cannot unmarshal string into Go struct field UserInfo.email_verified of type bool
 ```

This is caused by the `/userinfo` Authentication endpoint returning a string-encoded boolean value for Apple social connections; all other IdPs return a standard boolean value.

The solution here is to implement a custom JSON deserializer for the `UserInfo` type. The logic is largely ripped from the [Auth0 Go SDK](https://github.com/auth0/go-auth0/blob/main/management/user.go#L123-L173).

### 📚 References

- [Go SDK User custom unmarshaler](https://github.com/auth0/go-auth0/blob/main/management/user.go#L123-L173)

### 🔬 Testing

Added unit test cases for normal boolean value, string-encoded boolean and error case.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
