### PR TITLE
Testing improvements for multiple action secrets, dependencies

### DIFF
--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -262,12 +262,17 @@ func sortActionDependencies(dependencies []management.ActionDependency) {
 func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
 	t.Run("it should map input dependencies to action payload", func(t *testing.T) {
 		input := map[string]string{
-			"lodash": "4.0.0",
-			"uuid":   "9.0.0",
+			"fs-extra": "11.1.1",
+			"lodash":   "4.0.0",
+			"uuid":     "9.0.0",
 		}
 		res := inputDependenciesToActionDependencies(input)
 		sortActionDependencies(*res)
 		expected := []management.ActionDependency{
+			{
+				Name:    auth0.String("fs-extra"),
+				Version: auth0.String("11.1.1"),
+			},
 			{
 				Name:    auth0.String("lodash"),
 				Version: auth0.String("4.0.0"),
@@ -278,7 +283,7 @@ func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
 			},
 		}
 
-		assert.Len(t, *res, 2)
+		assert.Len(t, *res, 3)
 		assert.Equal(t, *res, expected)
 	})
 

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 	"testing"
 
 	"github.com/auth0/go-auth0/management"
@@ -212,11 +211,6 @@ func TestActionsPickerOptions(t *testing.T) {
 	}
 }
 
-func sortActionSecrets(secrets []management.ActionSecret) {
-	sort.Slice(secrets, func(i, j int) bool {
-		return secrets[i].GetName() < secrets[j].GetName()
-	})
-}
 func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 	t.Run("it should map input secrets to action payload", func(t *testing.T) {
 		input := map[string]string{
@@ -225,24 +219,20 @@ func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 			"secret3": "value3",
 		}
 		res := inputSecretsToActionSecrets(input)
-		sortActionSecrets(*res)
 
-		expected := []management.ActionSecret{
-			{
-				Name:  auth0.String("secret1"),
-				Value: auth0.String("value1"),
-			},
-			{
-				Name:  auth0.String("secret2"),
-				Value: auth0.String("value2"),
-			},
-			{
-				Name:  auth0.String("secret3"),
-				Value: auth0.String("value3"),
-			},
-		}
 		assert.Len(t, *res, 3)
-		assert.Equal(t, *res, expected)
+		assert.Contains(t, *res, management.ActionSecret{
+			Name:  auth0.String("secret1"),
+			Value: auth0.String("value1"),
+		})
+		assert.Contains(t, *res, management.ActionSecret{
+			Name:  auth0.String("secret2"),
+			Value: auth0.String("value2"),
+		})
+		assert.Contains(t, *res, management.ActionSecret{
+			Name:  auth0.String("secret3"),
+			Value: auth0.String("value3"),
+		})
 	})
 
 	t.Run("it should handle empty input secrets", func(t *testing.T) {
@@ -253,12 +243,6 @@ func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 		assert.Equal(t, res, &expected)
 	})
 }
-
-func sortActionDependencies(dependencies []management.ActionDependency) {
-	sort.Slice(dependencies, func(i, j int) bool {
-		return dependencies[i].GetName() < dependencies[j].GetName()
-	})
-}
 func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
 	t.Run("it should map input dependencies to action payload", func(t *testing.T) {
 		input := map[string]string{
@@ -267,24 +251,20 @@ func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
 			"uuid":     "9.0.0",
 		}
 		res := inputDependenciesToActionDependencies(input)
-		sortActionDependencies(*res)
-		expected := []management.ActionDependency{
-			{
-				Name:    auth0.String("fs-extra"),
-				Version: auth0.String("11.1.1"),
-			},
-			{
-				Name:    auth0.String("lodash"),
-				Version: auth0.String("4.0.0"),
-			},
-			{
-				Name:    auth0.String("uuid"),
-				Version: auth0.String("9.0.0"),
-			},
-		}
 
 		assert.Len(t, *res, 3)
-		assert.Equal(t, *res, expected)
+		assert.Contains(t, *res, management.ActionDependency{
+			Name:    auth0.String("fs-extra"),
+			Version: auth0.String("11.1.1"),
+		})
+		assert.Contains(t, *res, management.ActionDependency{
+			Name:    auth0.String("lodash"),
+			Version: auth0.String("4.0.0"),
+		})
+		assert.Contains(t, *res, management.ActionDependency{
+			Name:    auth0.String("uuid"),
+			Version: auth0.String("9.0.0"),
+		})
 	})
 
 	t.Run("it should handle empty input dependencies", func(t *testing.T) {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"testing"
 
 	"github.com/auth0/go-auth0/management"
@@ -210,6 +211,12 @@ func TestActionsPickerOptions(t *testing.T) {
 		})
 	}
 }
+
+func sortActionSecrets(secrets []management.ActionSecret) {
+	sort.Slice(secrets, func(i, j int) bool {
+		return secrets[i].GetName() < secrets[j].GetName()
+	})
+}
 func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 	t.Run("it should map input secrets to action payload", func(t *testing.T) {
 		input := map[string]string{
@@ -218,6 +225,8 @@ func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 			"secret3": "value3",
 		}
 		res := inputSecretsToActionSecrets(input)
+		sortActionSecrets(*res)
+
 		expected := []management.ActionSecret{
 			{
 				Name:  auth0.String("secret1"),
@@ -242,5 +251,42 @@ func TestActionsInputSecretsToActionSecrets(t *testing.T) {
 		expected := []management.ActionSecret{}
 		assert.Len(t, *res, 0)
 		assert.Equal(t, res, &expected)
+	})
+}
+
+func sortActionDependencies(dependencies []management.ActionDependency) {
+	sort.Slice(dependencies, func(i, j int) bool {
+		return dependencies[i].GetName() < dependencies[j].GetName()
+	})
+}
+func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
+	t.Run("it should map input dependencies to action payload", func(t *testing.T) {
+		input := map[string]string{
+			"lodash": "4.0.0",
+			"uuid":   "9.0.0",
+		}
+		res := inputDependenciesToActionDependencies(input)
+		sortActionDependencies(*res)
+		expected := []management.ActionDependency{
+			{
+				Name:    auth0.String("lodash"),
+				Version: auth0.String("4.0.0"),
+			},
+			{
+				Name:    auth0.String("uuid"),
+				Version: auth0.String("9.0.0"),
+			},
+		}
+
+		assert.Len(t, *res, 2)
+		assert.Equal(t, *res, expected)
+	})
+
+	t.Run("it should handle empty input dependencies", func(t *testing.T) {
+		emptyInput := map[string]string{}
+		res := inputDependenciesToActionDependencies(emptyInput)
+		expected := []management.ActionDependency{}
+		assert.Len(t, *res, 0)
+		assert.Equal(t, expected, *res)
 	})
 }


### PR DESCRIPTION
### 🔧 Changes

As I mentioned in #850, unit tests needed to be added for the case of multiple action dependencies being passed-in. However, like the action secrets, the unit tests were quite flaky because of the non-deterministic sorting of `map[string]string` data, thereby making assertions more difficult in the tests. To combat this, we're introducing sorting functions to make the tests deterministic and reliable.

### 📚 References

Related PR: #850 

### 🔬 Testing

All testing changes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
