### PR TITLE
Updating Auth0 TF provider version to minimum 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ There are two ways to authenticate:
 - [auth0 rules](https://auth0.github.io/auth0-cli/auth0_rules.html) - Manage resources for rules
 - [auth0 tenants](https://auth0.github.io/auth0-cli/auth0_tenants.html) - Manage configured tenants
 - [auth0 test](https://auth0.github.io/auth0-cli/auth0_test.html) - Try your Universal Login box or get a token
+- [auth0 terraform generate](https://auth0.github.io/auth0-cli/auth0_terraform_generate.html) - Generate terraform configuration for your Auth0 Tenant
 - [auth0 universal-login](https://auth0.github.io/auth0-cli/auth0_universal-login.html) - Manage the Universal Login experience
 - [auth0 users](https://auth0.github.io/auth0-cli/auth0_users.html) - Manage resources for users
 
@@ -136,7 +137,7 @@ export EDITOR="code --wait"
 
 # Uses sublime text with the --wait flag.
 export EDITOR="subl --wait"
- 
+
 # Uses nano, a terminal based editor.
 export EDITOR="nano"
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -268,7 +268,7 @@ func createMainFile(outputDIR string) error {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "1.0.0-beta.4"
+      version = ">= 1.0.0"
     }
   }
 }

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -197,7 +197,7 @@ func assertTerraformMainFileWasGeneratedCorrectly(t *testing.T, outputDIR string
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "1.0.0-beta.4"
+      version = ">= 1.0.0"
     }
   }
 }


### PR DESCRIPTION
### 🔧 Changes

Updating the version for the [Auth0 Terrafrom Provider](https://github.com/auth0/terraform-provider-auth0) ahead of its v1.0.0 GA release. This will ensure that Terraform will pull the latest version but at least v1.0.0.

Also, added a reference to the `auth0 tf generate` command in the README.

### 🔬 Testing

Tested locally. Will pass integration tests once Auth0 TF Provider v1 GA gets released.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
