### PR TITLE
TF Generate - Handling unsupported custom domains error

### DIFF
--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/google/uuid"
@@ -202,6 +203,10 @@ func (f *customDomainResourceFetcher) FetchData(ctx context.Context) (importData
 
 	customDomains, err := f.api.CustomDomain.List(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), "The account is not allowed to perform this operation, please contact our support team") {
+			return data, nil
+		}
+
 		return nil, err
 	}
 

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -524,6 +524,26 @@ func TestCustomDomainResourceFetcher_FetchData(t *testing.T) {
 		_, err := fetcher.FetchData(context.Background())
 		assert.EqualError(t, err, "failed to list custom domains")
 	})
+
+	t.Run("it returns empty set error if unsupported feature error occurs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
+		customDomainAPI.EXPECT().
+			List(gomock.Any()).
+			Return(nil, fmt.Errorf("403 Forbidden: The account is not allowed to perform this operation, please contact our support team"))
+
+		fetcher := customDomainResourceFetcher{
+			api: &auth0.API{
+				CustomDomain: customDomainAPI,
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, data, 0)
+	})
 }
 
 func TestGuardianResourceFetcher_FetchData(t *testing.T) {


### PR DESCRIPTION
### 🔧 Changes

For certain lower-tiered tenants, making a GET request for custom domains will return the following 403 error:

```
The account is not allowed to perform this operation, please contact our support team
```

In these cases, we should not let the entire process fail but simply skip the generation of custom domains. The Deploy CLI implements a [similar check](https://github.com/auth0/auth0-deploy-cli/blob/eb1db6339c9c93fec1fb7548bfc429f3b64015f4/src/tools/auth0/handlers/customDomains.ts#L60).

### 📚 References

[Related Auth0 Deploy CLI Code](https://github.com/auth0/auth0-deploy-cli/blob/eb1db6339c9c93fec1fb7548bfc429f3b64015f4/src/tools/auth0/handlers/customDomains.ts#L60)

### 🔬 Testing

Added unit test case.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
