### PR TITLE
DXCDT-548: Serve prompt data on demand

### DIFF
--- a/internal/cli/universal_login_customize.go
+++ b/internal/cli/universal_login_customize.go
@@ -20,7 +20,12 @@ import (
 	"github.com/auth0/auth0-cli/internal/display"
 )
 
-const webAppURL = "http://localhost:5173"
+const (
+	webAppURL               = "http://localhost:5173"
+	loadBrandingMessageType = "LOAD_BRANDING"
+	fetchPromptMessageType  = "FETCH_PROMPT"
+	saveBrandingMessageType = "SAVE_BRANDING"
+)
 
 type (
 	universalLoginBrandingData struct {
@@ -41,7 +46,7 @@ type (
 	promptData struct {
 		Language   string                            `json:"language"`
 		Prompt     string                            `json:"prompt"`
-		CustomText map[string]map[string]interface{} `json:"custom_tex,omitempty"`
+		CustomText map[string]map[string]interface{} `json:"custom_text,omitempty"`
 	}
 
 	webSocketHandler struct {
@@ -320,15 +325,27 @@ func (h *webSocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	connection, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		h.display.Errorf("error accepting WebSocket connection: %v", err)
+		h.display.Errorf("failed to upgrade the connection to the WebSocket protocol: %v", err)
 		h.shutdown()
 		return
 	}
 
 	connection.SetReadLimit(1e+6) // 1 MB.
 
-	if err = connection.WriteJSON(h.brandingData); err != nil {
-		h.display.Errorf("failed to write json message: %v", err)
+	payload, err := json.Marshal(&h.brandingData)
+	if err != nil {
+		h.display.Errorf("failed to encode the branding data to json: %v", err)
+		h.shutdown()
+		return
+	}
+
+	loadBrandingMsg := webSocketMessage{
+		Type:    loadBrandingMessageType,
+		Payload: payload,
+	}
+
+	if err = connection.WriteJSON(loadBrandingMsg); err != nil {
+		h.display.Errorf("failed to send branding data message: %v", err)
 		h.shutdown()
 		return
 	}
@@ -341,10 +358,10 @@ func (h *webSocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		switch message.Type {
-		case "fetch_prompt":
+		case fetchPromptMessageType:
 			var promptToFetch promptData
 			if err := json.Unmarshal(message.Payload, &promptToFetch); err != nil {
-				h.display.Errorf("failed to unmarshal %q payload: %v", message.Type, err)
+				h.display.Errorf("failed to unmarshal fetch prompt payload: %v", err)
 				continue
 			}
 
@@ -359,11 +376,23 @@ func (h *webSocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			if err = connection.WriteJSON(promptToSend); err != nil {
+			payload, err := json.Marshal(promptToSend)
+			if err != nil {
+				h.display.Errorf("failed to encode the branding data to json: %v", err)
+				h.shutdown()
+				return
+			}
+
+			fetchPromptMsg := webSocketMessage{
+				Type:    fetchPromptMessageType,
+				Payload: payload,
+			}
+
+			if err = connection.WriteJSON(fetchPromptMsg); err != nil {
 				h.display.Errorf("failed to send prompt data message: %v", err)
 				continue
 			}
-		case "save_branding":
+		case saveBrandingMessageType:
 			h.display.Warnf("not yet implemented")
 		}
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In this PR we accept websocket messages sent from the web app to fetch prompt data and serve it back with defaults in, if custom text is not set on them. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

More e2e tests will follow in future PRs. 

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
