### PR TITLE
DXCDT-564: Ensure new ul experience is active when customizing ul

### DIFF
--- a/internal/cli/universal_login_customize.go
+++ b/internal/cli/universal_login_customize.go
@@ -111,7 +111,7 @@ func ensureNewUniversalLoginExperienceIsActive(ctx context.Context, api *auth0.A
 
 	return fmt.Errorf(
 		"this feature requires the new Universal Login experience to be enabled for the tenant, " +
-			"use `auth0 api patch prompts --data '{\"universal_login_experience\":\"new\"}'` to have it enabled",
+			"use `auth0 api patch prompts --data '{\"universal_login_experience\":\"new\"}'` to enable it",
 	)
 }
 

--- a/internal/cli/universal_login_customize.go
+++ b/internal/cli/universal_login_customize.go
@@ -29,12 +29,11 @@ const (
 
 type (
 	universalLoginBrandingData struct {
-		AuthenticationProfile *management.Prompt                 `json:"auth_profile"`
-		Settings              *management.Branding               `json:"settings"`
-		Template              *management.BrandingUniversalLogin `json:"template"`
-		Theme                 *management.BrandingTheme          `json:"theme"`
-		Tenant                *tenantData                        `json:"tenant"`
-		Prompt                *promptData                        `json:"prompt"`
+		Settings *management.Branding               `json:"settings"`
+		Template *management.BrandingUniversalLogin `json:"template"`
+		Theme    *management.BrandingTheme          `json:"theme"`
+		Tenant   *tenantData                        `json:"tenant"`
+		Prompt   *promptData                        `json:"prompt"`
 	}
 
 	tenantData struct {
@@ -80,6 +79,10 @@ func customizeUniversalLoginCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
+			if err := ensureNewUniversalLoginExperienceIsActive(ctx, cli.api); err != nil {
+				return err
+			}
+
 			var universalLoginBrandingData *universalLoginBrandingData
 
 			if err := ansi.Spinner("Fetching Universal Login branding data", func() (err error) {
@@ -96,18 +99,28 @@ func customizeUniversalLoginCmd(cli *cli) *cobra.Command {
 	return cmd
 }
 
+func ensureNewUniversalLoginExperienceIsActive(ctx context.Context, api *auth0.API) error {
+	authenticationProfile, err := api.Prompt.Read(ctx)
+	if err != nil {
+		return err
+	}
+
+	if authenticationProfile.UniversalLoginExperience == "new" {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"this feature requires the new Universal Login experience to be enabled for the tenant, " +
+			"use `auth0 api patch prompts --data '{\"universal_login_experience\":\"new\"}'` to have it enabled",
+	)
+}
+
 func fetchUniversalLoginBrandingData(
 	ctx context.Context,
 	api *auth0.API,
 	tenantDomain string,
 ) (*universalLoginBrandingData, error) {
 	group, ctx := errgroup.WithContext(ctx)
-
-	var authenticationProfile *management.Prompt
-	group.Go(func() (err error) {
-		authenticationProfile, err = api.Prompt.Read(ctx)
-		return err
-	})
 
 	var brandingSettings *management.Branding
 	group.Go(func() (err error) {
@@ -147,10 +160,9 @@ func fetchUniversalLoginBrandingData(
 	}
 
 	return &universalLoginBrandingData{
-		AuthenticationProfile: authenticationProfile,
-		Settings:              brandingSettings,
-		Template:              currentTemplate,
-		Theme:                 currentTheme,
+		Settings: brandingSettings,
+		Template: currentTemplate,
+		Theme:    currentTheme,
 		Tenant: &tenantData{
 			FriendlyName:   tenant.GetFriendlyName(),
 			EnabledLocales: tenant.GetEnabledLocales(),

--- a/internal/cli/universal_login_customize_test.go
+++ b/internal/cli/universal_login_customize_test.go
@@ -79,7 +79,7 @@ func TestEnsureNewUniversalLoginExperienceIsActive(t *testing.T) {
 					Prompt: mockPromptAPI,
 				}
 			},
-			expectedError: "this feature requires the new Universal Login experience to be enabled for the tenant, use `auth0 api patch prompts --data '{\"universal_login_experience\":\"new\"}'` to have it enabled",
+			expectedError: "this feature requires the new Universal Login experience to be enabled for the tenant, use `auth0 api patch prompts --data '{\"universal_login_experience\":\"new\"}'` to enable it",
 		},
 	}
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

For the MVP we'll only allow customizing the new universal login experience so we're adding a check to ensure that is active on the tenant.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
