### PR TITLE
DXCDT-572: Add ability to fetch all applications in ul customize cmd

### DIFF
--- a/internal/cli/universal_login_customize_test.go
+++ b/internal/cli/universal_login_customize_test.go
@@ -168,7 +168,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 						nil,
 					)
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,
@@ -178,6 +194,14 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 				return mockAPI
 			},
 			expectedData: &universalLoginBrandingData{
+				Applications: []*applicationData{
+					{
+						ID:       "1",
+						Name:     "My App",
+						LogoURL:  "https://my-app.example.com/image.png",
+						Metadata: map[string]interface{}{"meta": "meta"},
+					},
+				},
 				Settings: &management.Branding{
 					Colors: &management.BrandingColors{
 						Primary:        auth0.String("#334455"),
@@ -292,7 +316,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 						nil,
 					)
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,
@@ -302,6 +342,14 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 				return mockAPI
 			},
 			expectedData: &universalLoginBrandingData{
+				Applications: []*applicationData{
+					{
+						ID:       "1",
+						Name:     "My App",
+						LogoURL:  "https://my-app.example.com/image.png",
+						Metadata: map[string]interface{}{"meta": "meta"},
+					},
+				},
 				Settings: &management.Branding{
 					Colors: &management.BrandingColors{
 						Primary:        auth0.String(defaultPrimaryColor),
@@ -420,7 +468,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 						nil,
 					)
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,
@@ -430,6 +494,14 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 				return mockAPI
 			},
 			expectedData: &universalLoginBrandingData{
+				Applications: []*applicationData{
+					{
+						ID:       "1",
+						Name:     "My App",
+						LogoURL:  "https://my-app.example.com/image.png",
+						Metadata: map[string]interface{}{"meta": "meta"},
+					},
+				},
 				Settings: &management.Branding{
 					Colors: &management.BrandingColors{
 						Primary:        auth0.String("#334455"),
@@ -551,7 +623,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 						nil,
 					)
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,
@@ -561,6 +649,14 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 				return mockAPI
 			},
 			expectedData: &universalLoginBrandingData{
+				Applications: []*applicationData{
+					{
+						ID:       "1",
+						Name:     "My App",
+						LogoURL:  "https://my-app.example.com/image.png",
+						Metadata: map[string]interface{}{"meta": "meta"},
+					},
+				},
 				Settings: &management.Branding{
 					Colors: &management.BrandingColors{
 						Primary:        auth0.String("#334455"),
@@ -740,7 +836,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 					Read(gomock.Any()).
 					Return(nil, fmt.Errorf("failed to fetch tenant data"))
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,
@@ -803,7 +915,23 @@ func TestFetchUniversalLoginBrandingData(t *testing.T) {
 					CustomText(gomock.Any(), "login", "en").
 					Return(nil, fmt.Errorf("failed to fetch custom text"))
 
+				mockClientAPI := mock.NewMockClientAPI(ctrl)
+				mockClientAPI.
+					EXPECT().
+					List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&management.ClientList{
+						Clients: []*management.Client{
+							{
+								ClientID:       auth0.String("1"),
+								Name:           auth0.String("My App"),
+								LogoURI:        auth0.String("https://my-app.example.com/image.png"),
+								ClientMetadata: &map[string]interface{}{"meta": "meta"},
+							},
+						},
+					}, nil)
+
 				mockAPI := &auth0.API{
+					Client:        mockClientAPI,
 					Branding:      mockBrandingAPI,
 					BrandingTheme: mockBrandingThemeAPI,
 					Prompt:        mockPromptAPI,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add ability to fetch all applications in ul customize cmd in order to serve the data to the ULP Template https://auth0.com/docs/customize/universal-login-pages/universal-login-page-templates#available-variables.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
