### PR TITLE
DXCDT-582: Convert audience into a drop down in interactive mode in test token cmd

### DIFF
--- a/docs/auth0_test_login.md
+++ b/docs/auth0_test_login.md
@@ -30,7 +30,7 @@ auth0 test login [flags]
 ## Flags
 
 ```
-  -a, --audience string          The unique identifier of the target API you want to access.
+  -a, --audience string          The unique identifier of the target API you want to access. For Machine to Machine and Regular Web Applications, only the enabled APIs will be shown within the interactive prompt.
   -c, --connection-name string   The connection name to test during login.
   -d, --domain string            One of your custom domains.
       --force                    Skip confirmation.

--- a/docs/auth0_test_token.md
+++ b/docs/auth0_test_token.md
@@ -27,7 +27,7 @@ auth0 test token [flags]
 ## Flags
 
 ```
-  -a, --audience string   The unique identifier of the target API you want to access.
+  -a, --audience string   The unique identifier of the target API you want to access. For Machine to Machine and Regular Web Applications, only the enabled APIs will be shown within the interactive prompt.
       --force             Skip confirmation.
       --json              Output in json format.
   -s, --scopes strings    The list of scopes you want to use.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR converts the audience flag into a picker when in interactive mode for the `auth0 test token` command.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing


https://github.com/auth0/auth0-cli/assets/28300158/a809d29b-f363-4966-b5dd-711234b95d34



### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
