### PR TITLE
DXCDT-592: Adding lucene examples to `auth0 users search`

### DIFF
--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -30,7 +30,7 @@ auth0 users search [flags]
   -n, --number int     Number of users, that match the search criteria, to retrieve. Minimum 1, maximum 1000. If limit is hit, refine the search query. (default 50)
   -q, --query string   Search query in Lucene query syntax.
                        
-                       Ex: name:"Bob" OR (user_id:"user123" AND email:"user123@travel0.com") 
+                       Ex: email:"user123@*.com" OR (user_id:"user-id-123" AND name:"Bob") 
                        
                        More info: https://auth0.com/docs/users/user-search/user-search-query-syntax
   -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -26,14 +26,14 @@ auth0 users search [flags]
 ## Flags
 
 ```
-      --json           Output in json format.
-  -n, --number int     Number of users, that match the search criteria, to retrieve. Minimum 1, maximum 1000. If limit is hit, refine the search query. (default 50)
-  -q, --query string   Search query in Lucene query syntax.
-                       
-                       Ex: email:"user123@*.com" OR (user_id:"user-id-123" AND name:"Bob") 
-                       
-                       More info: https://auth0.com/docs/users/user-search/user-search-query-syntax
-  -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.
+      --json                                                                    Output in json format.
+  -n, --number int                                                              Number of users, that match the search criteria, to retrieve. Minimum 1, maximum 1000. If limit is hit, refine the search query. (default 50)
+  -q, --query email:"user123@*.com" OR (user_id:"user-id-123" AND name:"Bob")   Search query in Lucene query syntax.
+                                                                                
+                                                                                For example: email:"user123@*.com" OR (user_id:"user-id-123" AND name:"Bob")
+                                                                                
+                                                                                 For more info: https://auth0.com/docs/users/user-search/user-search-query-syntax.
+  -s, --sort string                                                             Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.
 ```
 
 

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -30,7 +30,7 @@ auth0 users search [flags]
   -n, --number int     Number of users, that match the search criteria, to retrieve. Minimum 1, maximum 1000. If limit is hit, refine the search query. (default 50)
   -q, --query string   Search query in Lucene query syntax.
                        
-                       Ex: name:"Bob" AND user_id:"user123" OR email:"user123@travel0.com" 
+                       Ex: name:"Bob" OR (user_id:"user123" AND email:"user123@travel0.com") 
                        
                        More info: https://auth0.com/docs/users/user-search/user-search-query-syntax
   -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.

--- a/docs/auth0_users_search.md
+++ b/docs/auth0_users_search.md
@@ -28,7 +28,11 @@ auth0 users search [flags]
 ```
       --json           Output in json format.
   -n, --number int     Number of users, that match the search criteria, to retrieve. Minimum 1, maximum 1000. If limit is hit, refine the search query. (default 50)
-  -q, --query string   Query in Lucene query syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.
+  -q, --query string   Search query in Lucene query syntax.
+                       
+                       Ex: name:"Bob" AND user_id:"user123" OR email:"user123@travel0.com" 
+                       
+                       More info: https://auth0.com/docs/users/user-search/user-search-query-syntax
   -s, --sort string    Field to sort by. Use 'field:order' where 'order' is '1' for ascending and '-1' for descending. e.g. 'created_at:1'.
 ```
 

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -62,7 +62,7 @@ var (
 		Name:       "Query",
 		LongForm:   "query",
 		ShortForm:  "q",
-		Help:       "Search query in Lucene query syntax.\n\nEx: name:\"Bob\" AND user_id:\"user123\" OR email:\"user123@travel0.com\" \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
+		Help:       "Search query in Lucene query syntax.\n\nEx: name:\"Bob\" OR (user_id:\"user123\" AND email:\"user123@travel0.com\") \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
 		IsRequired: true,
 	}
 	userSort = Flag{

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -62,7 +62,7 @@ var (
 		Name:       "Query",
 		LongForm:   "query",
 		ShortForm:  "q",
-		Help:       "Search query in Lucene query syntax.\n\nEx: name:\"Bob\" OR (user_id:\"user123\" AND email:\"user123@travel0.com\") \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
+		Help:       "Search query in Lucene query syntax.\n\nEx: email:\"user123@*.com\" OR (user_id:\"user-id-123\" AND name:\"Bob\") \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
 		IsRequired: true,
 	}
 	userSort = Flag{

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -62,7 +62,7 @@ var (
 		Name:       "Query",
 		LongForm:   "query",
 		ShortForm:  "q",
-		Help:       "Search query in Lucene query syntax.\n\nEx: email:\"user123@*.com\" OR (user_id:\"user-id-123\" AND name:\"Bob\") \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
+		Help:       "Search query in Lucene query syntax.\n\nFor example: `email:\"user123@*.com\" OR (user_id:\"user-id-123\" AND name:\"Bob\")`\n\n For more info: https://auth0.com/docs/users/user-search/user-search-query-syntax.",
 		IsRequired: true,
 	}
 	userSort = Flag{

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -62,7 +62,7 @@ var (
 		Name:       "Query",
 		LongForm:   "query",
 		ShortForm:  "q",
-		Help:       "Query in Lucene query syntax. See https://auth0.com/docs/users/user-search/user-search-query-syntax for more details.",
+		Help:       "Search query in Lucene query syntax.\n\nEx: name:\"Bob\" AND user_id:\"user123\" OR email:\"user123@travel0.com\" \n\nMore info: https://auth0.com/docs/users/user-search/user-search-query-syntax",
 		IsRequired: true,
 	}
 	userSort = Flag{


### PR DESCRIPTION
### 🔧 Changes

Adding example lucene queries to the `auth0 users search` command.  Some examples did exist as help text, but this change makes them even more visible. I selected this example somewhat arbitrarily but it seemed to cover several fields, parentheses, wildcard operator and logistcal AND/OR.

<img width="946" alt="Screenshot 2023-11-13 at 3 52 41 PM" src="https://github.com/auth0/auth0-cli/assets/4614315/c2e81c17-6950-4ce1-b4c6-e48d9e80dd16">

### 📚 References

- [Auth0 using Lucene syntax](https://auth0.com/docs/manage-users/user-search/user-search-query-syntax)

### 🔬 Testing

No functional changes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
