### PR TITLE
DXCDT-602: Add help text to api cmd when no args passed

### DIFF
--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -72,7 +72,7 @@ func apiCmd(cli *cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "api <method> <url-path>",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.RangeArgs(0, 2),
 		Short: "Makes an authenticated HTTP request to the Auth0 Management API",
 		Long: fmt.Sprintf(
 			`Makes an authenticated HTTP request to the [Auth0 Management API](%s) and returns the response as JSON.
@@ -117,6 +117,10 @@ func apiUsageTemplate() string {
 
 func apiCmdRun(cli *cli, inputs *apiCmdInputs) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
 		if err := inputs.fromArgs(args, cli.tenant); err != nil {
 			return fmt.Errorf("failed to parse command inputs: %w", err)
 		}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Returns the help text when invoking the api cmd with no args.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
