### PR TITLE
Prevent access token writen to config file if stored in keyring

### DIFF
--- a/internal/config/tenant.go
+++ b/internal/config/tenant.go
@@ -151,7 +151,7 @@ func (t *Tenant) RegenerateAccessToken(ctx context.Context) error {
 		t.ExpiresAt = time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
 	}
 
-	if err := keyring.StoreAccessToken(t.Domain, t.AccessToken); err != nil {
+	if err := keyring.StoreAccessToken(t.Domain, t.AccessToken); err == nil {
 		t.AccessToken = ""
 	}
 


### PR DESCRIPTION
### 🔧 Changes

This PR corrects a fairly innocuous, yet faulty error check when storing access token to the keyring. We want to write the access token to the config file as a backup if we're unable to successfully write to the keyring. As it exists now, the token will be written to the config file only if the keyring storage succeeds.  

### 🔬 Testing

Manual verification; unable to adequately test the token regeneration function at this time.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
