### PR TITLE
DXCDT-587: Warn if deleting client used to authenticate

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -330,6 +330,9 @@ func deleteAppCmd(cli *cli) *cobra.Command {
 			}
 
 			if !cli.force && canPrompt(cmd) {
+				if tenant, _ := cli.Config.GetTenant(cli.tenant); tenant.ClientID == inputs.ID {
+					cli.renderer.Warnf("Warning: You're about to delete the client used to authenticate the CLI. If deleted, the CLI will cease to operate once the access token has expired.", inputs.ID)
+				}
 				if confirmed := prompt.Confirm("Are you sure you want to proceed?"); !confirmed {
 					return nil
 				}


### PR DESCRIPTION
### 🔧 Changes

This PR adds a warning message communicating to the user that they're about to delete the client used to authenticate the CLI. This doesn't have immediate ramifications for the CLI but will prevent the CLI from being able to re-authenticate once the access token eventually expires.

We had considered preventing the user from deleting the application altogether, but there are some valid use-cases for this behavior.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
