### PR TITLE
DXCDT-400: Allowing piped-in templates into `auth0 ul templates update`

### DIFF
--- a/docs/auth0_universal-login_templates_update.md
+++ b/docs/auth0_universal-login_templates_update.md
@@ -17,6 +17,8 @@ auth0 universal-login templates update [flags]
 ```
   auth0 universal-login templates update
   auth0 ul templates update
+  cat login.liquid | auth0 ul templates update
+  echo "<html>{%- auth0:head -%}{%- auth0:widget -%}</html>" | auth0 ul templates update
 ```
 
 

--- a/internal/cli/universal_login_templates.go
+++ b/internal/cli/universal_login_templates.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/iostream"
 	"github.com/auth0/auth0-cli/internal/prompt"
 )
 
@@ -136,7 +137,9 @@ func updateBrandingTemplateCmd(cli *cli) *cobra.Command {
 		Short: "Update the custom template for Universal Login",
 		Long:  "Update the custom template for the New Universal Login Experience.",
 		Example: `  auth0 universal-login templates update
-  auth0 ul templates update`,
+  auth0 ul templates update
+  cat login.liquid | auth0 ul templates update
+  echo "<html>{%- auth0:head -%}{%- auth0:widget -%}</html>" | auth0 ul templates update`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -159,6 +162,11 @@ func updateBrandingTemplateCmd(cli *cli) *cobra.Command {
 					return fmt.Errorf("failed to select the desired template: %w", err)
 				}
 				templateData.Body = templateOptions.getValue(templateData.Body)
+			}
+
+			pipedTemplateHTML := iostream.PipedInput()
+			if len(pipedTemplateHTML) > 0 {
+				templateData.Body = string(pipedTemplateHTML)
 			}
 
 			if err := cli.editTemplateAndPreviewChanges(ctx, cmd, templateData); err != nil {


### PR DESCRIPTION
### 🔧 Changes

Adds support for piping-in liquid templates for the `auth0 ul templates update` command. This is somewhat inspired by #548 which asked for a way to preview templates data. 

### 📚 References

Related (somewhat) issue: #548 

### 🔬 Testing

Manually verified. Unfortunately, this cannot be tested through our commander tests because the testing tenant does not have a custom domain which is required for updating universal login templates.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
