### PR TITLE
Add csv format to user search results

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,8 +26,9 @@ const userAgent = "Auth0 CLI"
 // In addition, it stores a reference to all the flags passed, e.g.:
 //
 // 1. --json
-// 2. --tenant
-// 3. --debug.
+// 2. --csv
+// 3. --tenant
+// 4. --debug.
 type cli struct {
 	// Core primitives exposed to command builders.
 	api      *auth0.API
@@ -38,6 +39,7 @@ type cli struct {
 	debug   bool
 	tenant  string
 	json    bool
+	csv     bool
 	force   bool
 	noInput bool
 	noColor bool
@@ -118,6 +120,10 @@ func (c *cli) configureRenderer() {
 
 	if c.json {
 		c.renderer.Format = display.OutputFormatJSON
+	}
+
+	if c.csv {
+		c.renderer.Format = display.OutputFormatCSV
 	}
 }
 

--- a/internal/cli/users.go
+++ b/internal/cli/users.go
@@ -154,7 +154,8 @@ func searchUsersCmd(cli *cli) *cobra.Command {
   auth0 users search --query user_id:"<user-id>"
   auth0 users search --query name:"Bob" --sort "name:1"
   auth0 users search -q name:"Bob" -s "name:1" --number 200
-  auth0 users search -q name:"Bob" -s "name:1" -n 200 --json`,
+  auth0 users search -q name:"Bob" -s "name:1" -n 200 --json
+  auth0 users search -q name:"Bob" -s "name:1" -n 200 --csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := userQuery.Ask(cmd, &inputs.query, nil); err != nil {
 				return err
@@ -205,6 +206,7 @@ func searchUsersCmd(cli *cli) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.csv, "csv", false, "Output in csv format.")
 	userQuery.RegisterString(cmd, &inputs.query, "")
 	userSort.RegisterString(cmd, &inputs.sort, "")
 	userNumber.RegisterInt(cmd, &inputs.number, defaultPageSize)


### PR DESCRIPTION


<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Adds csv as a general format cli wide
- Uses csv flag for user search

### 📚 References

- Supports use case for #475 by adding the `--csv` flag to `auth0 users search`
- Could be leveraged to support #954 with one line to the logs command

### 🔬 Testing

Manually verify that you get a csv back of your search results via `auth0 users search --csv`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
