### PR TITLE
PATCH: Add resource server scopes to terraform import

### DIFF
--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -390,7 +390,7 @@ func (f *resourceServerResourceFetcher) FetchData(ctx context.Context) (importDa
 		apis, err := f.api.ResourceServer.List(
 			ctx,
 			management.Page(page),
-			management.IncludeFields("id", "name"),
+			management.IncludeFields("id", "name", "scopes"),
 			management.PerPage(100),
 		)
 		if err != nil {


### PR DESCRIPTION
The response that fetches resource servers included only 2 fields: `id` and `name`
Because of this, the scopes filed was always an empty slice and thus never populated during a terraform import.



<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Included `scopes` while fetching. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
