### PR TITLE
Add new flag to specify terraform version in `auth0 tf generate` command

### DIFF
--- a/docs/auth0_terraform_generate.md
+++ b/docs/auth0_terraform_generate.md
@@ -34,6 +34,7 @@ auth0 terraform generate [flags]
       --force               Skip confirmation.
   -o, --output-dir string   Output directory for the generated Terraform config files. If not provided, the files will be saved in the current working directory. (default "./")
   -r, --resources strings   Resource types to generate Terraform config for. If not provided, config files for all available resources will be generated. (default [auth0_action,auth0_attack_protection,auth0_branding,auth0_client,auth0_client_grant,auth0_connection,auth0_custom_domain,auth0_flow,auth0_flow_vault_connection,auth0_form,auth0_email_provider,auth0_email_template,auth0_guardian,auth0_organization,auth0_pages,auth0_prompt,auth0_prompt_custom_text,auth0_resource_server,auth0_role,auth0_tenant,auth0_trigger_actions])
+  -v, --tf-version string   Terraform version that ought to be used while generating the terraform files for resources. If not provided, 1.5.0 is used by default (default "1.5.0")
 ```
 
 

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -38,17 +38,26 @@ var tfFlags = terraformFlags{
 		Help: "Resource types to generate Terraform config for. If not provided, config files for all " +
 			"available resources will be generated.",
 	},
+	TerraformVersion: Flag{
+		Name:      "Terraform Version",
+		LongForm:  "tf-version",
+		ShortForm: "v",
+		Help: "Terraform version that ought to be used while generating the terraform files for resources. " +
+			"If not provided, 1.5.0 is used by default",
+	},
 }
 
 type (
 	terraformFlags struct {
-		OutputDIR Flag
-		Resources Flag
+		OutputDIR        Flag
+		Resources        Flag
+		TerraformVersion Flag
 	}
 
 	terraformInputs struct {
-		OutputDIR string
-		Resources []string
+		OutputDIR        string
+		Resources        []string
+		TerraformVersion string
 	}
 )
 
@@ -147,6 +156,7 @@ func generateTerraformCmd(cli *cli) *cobra.Command {
 	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
 	tfFlags.OutputDIR.RegisterString(cmd, &inputs.OutputDIR, "./")
 	tfFlags.Resources.RegisterStringSlice(cmd, &inputs.Resources, defaultResources)
+	tfFlags.TerraformVersion.RegisterString(cmd, &inputs.TerraformVersion, "1.5.0")
 
 	return cmd
 }
@@ -175,7 +185,7 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			return err
 		}
 
-		if err := generateTerraformImportConfig(inputs.OutputDIR, data); err != nil {
+		if err := generateTerraformImportConfig(inputs, data); err != nil {
 			return err
 		}
 
@@ -191,7 +201,7 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			}
 
 			err = ansi.Spinner("Generating Terraform configuration", func() error {
-				return generateTerraformResourceConfig(cmd.Context(), inputs.OutputDIR)
+				return generateTerraformResourceConfig(cmd.Context(), inputs)
 			})
 
 			if err != nil {
@@ -241,20 +251,20 @@ func fetchImportData(ctx context.Context, fetchers ...resourceDataFetcher) (impo
 	return deduplicateResourceNames(importData), nil
 }
 
-func generateTerraformImportConfig(outputDIR string, data importDataList) error {
+func generateTerraformImportConfig(inputs *terraformInputs, data importDataList) error {
 	if len(data) == 0 {
 		return errors.New("no import data available")
 	}
 
-	if err := createOutputDirectory(outputDIR); err != nil {
+	if err := createOutputDirectory(inputs.OutputDIR); err != nil {
 		return err
 	}
 
-	if err := createMainFile(outputDIR); err != nil {
+	if err := createMainFile(inputs); err != nil {
 		return err
 	}
 
-	return createImportFile(outputDIR, data)
+	return createImportFile(inputs.OutputDIR, data)
 }
 
 func createOutputDirectory(outputDIR string) error {
@@ -267,8 +277,8 @@ func createOutputDirectory(outputDIR string) error {
 	return nil
 }
 
-func createMainFile(outputDIR string) error {
-	filePath := path.Join(outputDIR, "auth0_main.tf")
+func createMainFile(input *terraformInputs) error {
+	filePath := path.Join(input.OutputDIR, "auth0_main.tf")
 
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -279,7 +289,7 @@ func createMainFile(outputDIR string) error {
 	}()
 
 	fileContent := `terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= ` + input.TerraformVersion + `"
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
@@ -327,15 +337,15 @@ import {
 	return t.Execute(file, data)
 }
 
-func generateTerraformResourceConfig(ctx context.Context, outputDIR string) error {
-	absoluteOutputPath, err := filepath.Abs(outputDIR)
+func generateTerraformResourceConfig(ctx context.Context, input *terraformInputs) error {
+	absoluteOutputPath, err := filepath.Abs(input.OutputDIR)
 	if err != nil {
 		return err
 	}
 
 	installer := &releases.ExactVersion{
 		Product:    product.Terraform,
-		Version:    version.Must(version.NewVersion("1.5.0")),
+		Version:    version.Must(version.NewVersion(input.TerraformVersion)),
 		InstallDir: absoluteOutputPath,
 	}
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
Auth0-cli used 1.5.0 terraform version while generating the terraform files duing `auth0 tf generate`
Among multiple limitations of this version, one was that during the use of `terraform import` if a resource attribute contains a json, it is treated as a escaped strings.


### Example:

```auth0 tf generate --output-dir tmp-auth0-tf --resources auth0_flow_vault_connection,auth0_form,auth0_flow --tf-version 1.9.1```

Would generate below format:
```
nodes = jsonencode([{
    config = {
      flow_id   = "af_rmhb8CRNFydAikyW6WJohs"
      next_node = "$ending"
    }
    coordinates = {
      x = 1835
      y = 35
    }
}])
```

On versions lower than 1.8.0 it'd look like below:
```
  start        = "{\"coordinates\":{\"x\":-131,\"y\":-14},\"next_node\":\"step_JCbi\"}"

```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
