### PR TITLE
Remove unsupported query params on list custom_domains.go

### DIFF
--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -109,7 +109,7 @@ func listCustomDomainsCmd(cli *cli) *cobra.Command {
 			var list []*management.CustomDomain
 
 			if err := ansi.Waiting(func() (err error) {
-				list, err = cli.api.CustomDomain.List(cmd.Context(), management.PerPage(defaultPageSize))
+				list, err = cli.api.CustomDomain.List(cmd.Context())
 				return err
 			}); err != nil {
 				return fmt.Errorf("failed to list custom domains: %w", err)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Currently, In `auth0 list domains` uses the query param `per_page` which is not being supported in GET call.
Updated to remove un-supported query param

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->



### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
