### PR TITLE
 Automate PR Creation in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # This ensures all history and tags are fetched
+          path: auth0-cli
 
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version-file: auth0-cli/go.mod
           check-latest: true
 
       - name: Import GPG key
@@ -40,6 +41,7 @@ jobs:
         with:
           version: "2.7.0"
           args: release --clean
+          workdir: 'auth0-cli'
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -54,7 +56,7 @@ jobs:
 
       - name: Copy Brew Formula
         run: |
-          cp dist/homebrew/*.rb homebrew-auth0-cli/
+          cp auth0-cli/dist/homebrew/*.rb homebrew-auth0-cli/
 
       - name: Create Homebrew Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@7.0.8
@@ -77,7 +79,7 @@ jobs:
 
       - name: Copy Scoop Manifest
         run: |
-          cp dist/scoop/*.json scoop-auth0-cli/
+          cp auth0-cli/dist/scoop/*.json scoop-auth0-cli/
 
       - name: Create Scoop Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@7.0.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_tag_gpgsign: true
+          git_committer_email: auth0-cli-cd-sa@okta.com
+          git_committer_name: auth0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # pin@6.2.1
@@ -41,3 +43,49 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      # Homebrew Tap Process
+      - name: Checkout Homebrew Tap Repo
+        uses: actions/checkout@v3
+        with:
+          repository: auth0/homebrew-auth0-cli
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          path: homebrew-auth0-cli
+
+      - name: Copy Brew Formula
+        run: |
+          cp dist/homebrew/*.rb homebrew-auth0-cli/
+
+      - name: Create Homebrew Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@7.0.8
+        with:
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          commit-message: "Brew formula update for auth0-cli version ${{ github.ref_name }}"
+          branch: ${{ github.ref_name }}
+          title: "Brew formula update for auth0-cli version ${{ github.ref_name }}"
+          body: "This PR updates the Homebrew formula for version ${{ github.ref_name }}."
+          base: main
+          committer: auth0 <auth0-cli-cd-sa@okta.com>
+
+      # Scoop Manifest Process
+      - name: Checkout Scoop Repo
+        uses: actions/checkout@v3
+        with:
+          repository: auth0/scoop-auth0-cli
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          path: scoop-auth0-cli
+
+      - name: Copy Scoop Manifest
+        run: |
+          cp dist/scoop/*.json scoop-auth0-cli/
+
+      - name: Create Scoop Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@7.0.8
+        with:
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          commit-message: "Scoop manifest update for auth0-cli version ${{ github.ref_name }}"
+          branch: ${{ github.ref_name }}
+          title: "Scoop manifest update for auth0-cli version ${{ github.ref_name }}"
+          body: "This PR updates the Scoop manifest for version ${{ github.ref_name }}."
+          base: main
+          committer: auth0 <auth0-cli-cd-sa@okta.com>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           body: "This PR updates the Homebrew formula for version ${{ github.ref_name }}."
           base: main
           committer: auth0 <auth0-cli-cd-sa@okta.com>
+          path: homebrew-auth0-cli
 
       # Scoop Manifest Process
       - name: Checkout Scoop Repo
@@ -80,7 +81,6 @@ jobs:
       - name: Copy Scoop Manifest
         run: |
           cp auth0-cli/dist/scoop/*.json scoop-auth0-cli/
-
       - name: Create Scoop Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@7.0.8
         with:
@@ -91,3 +91,4 @@ jobs:
           body: "This PR updates the Scoop manifest for version ${{ github.ref_name }}."
           base: main
           committer: auth0 <auth0-cli-cd-sa@okta.com>
+          path: scoop-auth0-cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,13 +37,6 @@ brews:
     repository:
       owner: auth0
       name: homebrew-auth0-cli
-      branch: main
-      pull_request:
-        enabled: true
-        base:
-          owner: auth0
-          name: homebrew-auth0-cli
-          branch: main
       token: "{{ .Env.GITHUB_TOKEN }}"
     commit_author:
       name: auth0
@@ -52,7 +45,7 @@ brews:
     homepage: https://auth0.github.io/auth0-cli
     description: Build, manage and test your Auth0 integrations from the command line
     license: MIT
-    skip_upload: auto
+    skip_upload: true
     install: |
       bin.install "auth0"
 
@@ -66,13 +59,6 @@ scoops:
     repository:
       owner: auth0
       name: scoop-auth0-cli
-      branch: main
-      pull_request:
-        enabled: true
-        base:
-          owner: auth0
-          name: scoop-auth0-cli
-          branch: main
       token: "{{ .Env.GITHUB_TOKEN }}"
     commit_author:
       name: auth0
@@ -81,5 +67,5 @@ scoops:
     homepage: https://auth0.github.io/auth0-cli
     description: Build, manage and test your Auth0 integrations from the command line
     license: MIT
-    skip_upload: auto
+    skip_upload: true
     post_install: ["Write-Host 'Thanks for installing the Auth0 CLI'"]


### PR DESCRIPTION

This update enhances the release workflow by automating the creation of pull requests for Homebrew and Scoop package updates.  

### Key Changes:  
- Integrated `peter-evans/create-pull-request` to automate PR creation for both Homebrew and Scoop updates.  
- Ensured consistent commit messages and branch naming for package updates.  
- Reduced manual steps and improved release efficiency.  
- Maintained security by using pinned action versions and secure secrets.  
