### PR TITLE
Support new screens for ACUL

### DIFF
--- a/internal/cli/universal_login_customize.go
+++ b/internal/cli/universal_login_customize.go
@@ -118,11 +118,16 @@ var ScreenPromptMap = map[string][]string{
 	"captcha":                     {"interstitial-captcha"},
 	"login":                       {"login"},
 	"signup":                      {"signup"},
-	"reset-password":              {"reset-password-request", "reset-password-email", "reset-password", "reset-password-success", "reset-password-error"},
+	"reset-password":              {"reset-password-request", "reset-password-email", "reset-password", "reset-password-success", "reset-password-error", "reset-password-mfa-email-challenge", "reset-password-mfa-otp-challenge", "reset-password-mfa-push-challenge-push", "reset-password-mfa-sms-challenge"},
 	"mfa":                         {"mfa-detect-browser-capabilities", "mfa-enroll-result", "mfa-begin-enroll-options", "mfa-login-options"},
 	"mfa-email":                   {"mfa-email-challenge", "mfa-email-list"},
 	"mfa-sms":                     {"mfa-country-codes", "mfa-sms-challenge", "mfa-sms-enrollment", "mfa-sms-list"},
 	"mfa-push":                    {"mfa-push-challenge-push", "mfa-push-enrollment-qr", "mfa-push-list", "mfa-push-welcome"},
+	"invitation":                  {"accept-invitation"},
+	"organizations":               {"organization-selection", "organization-picker"},
+	"consent":                     {"consent"},
+	"customized-consent":          {"customized-consent"},
+	"mfa-otp":                     {"mfa-otp-challenge", "mfa-otp-enrollment-code", "mfa-otp-enrollment-qr"},
 }
 
 type partialsData map[string]*management.PromptScreenPartials


### PR DESCRIPTION

### 🔧 Changes

Support new screens on ACUL as part of release-4:

Prompt-name | Screen-name
-- | --
invitation |  accept-invitation
organizations |  organization-selection
organizations |  organization-picker
consent | consent
customized-consent |  customized-consent
mfa-otp | mfa-otp-challenge
mfa-otp |  mfa-otp-enrollment-code
mfa-otp | mfa-otp-enrollment-qr
reset-password |  reset-password-mfa-email-challenge
reset-password | reset-password-mfa-otp-challenge
reset-password | reset-password-mfa-push-challenge-push
reset-password | reset-password-mfa-sms-challenge

