### PR TITLE
Fix validation to authorize audience only for M2M apps in test commands

### DIFF
--- a/docs/auth0_test.md
+++ b/docs/auth0_test.md
@@ -6,6 +6,7 @@ has_children: true
 # auth0 test
 
 Try your Universal Login box or get a token.
+This command uses the client credentials grant for machine-to-machine applications and the authorization code grant (with Universal Login) for other application types, such as regular, web or native apps.
 
 ## Commands
 

--- a/docs/auth0_test_login.md
+++ b/docs/auth0_test_login.md
@@ -33,7 +33,7 @@ auth0 test login [flags]
 ## Flags
 
 ```
-  -a, --audience string          The unique identifier of the target API you want to access. For Machine to Machine and Regular Web Applications, only the enabled APIs will be shown within the interactive prompt.
+  -a, --audience string          The unique identifier of the target API you want to access. For Machine to Machine Applications, only the enabled APIs will be shown within the interactive prompt.
   -c, --connection-name string   The connection name to test during login.
   -d, --domain string            One of your custom domains.
       --force                    Skip confirmation.

--- a/docs/auth0_test_token.md
+++ b/docs/auth0_test_token.md
@@ -29,7 +29,7 @@ auth0 test token [flags]
 ## Flags
 
 ```
-  -a, --audience string         The unique identifier of the target API you want to access. For Machine to Machine and Regular Web Applications, only the enabled APIs will be shown within the interactive prompt.
+  -a, --audience string         The unique identifier of the target API you want to access. For Machine to Machine Applications, only the enabled APIs will be shown within the interactive prompt.
       --force                   Skip confirmation.
       --json                    Output in json format.
   -o, --organization string     organization-id to use for the login. Can use organization-name if allow_organization_name_in_authentication_api is enabled for tenant

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -38,7 +38,7 @@ var (
 		Name:      "Audience",
 		LongForm:  "audience",
 		ShortForm: "a",
-		Help:      "The unique identifier of the target API you want to access. For Machine to Machine and Regular Web Applications, only the enabled APIs will be shown within the interactive prompt.",
+		Help:      "The unique identifier of the target API you want to access. For Machine to Machine Applications, only the enabled APIs will be shown within the interactive prompt.",
 	}
 
 	testAudienceRequired = Flag{
@@ -94,7 +94,7 @@ func testCmd(cli *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Try your Universal Login box or get a token",
-		Long:  "Try your Universal Login box or get a token.",
+		Long:  "Try your Universal Login box or get a token.\n" + "This command uses the client credentials grant for machine-to-machine applications and the authorization code grant (with Universal Login) for other application types, such as regular, web or native apps.",
 	}
 
 	cmd.SetUsageTemplate(resourceUsageTemplate())
@@ -148,7 +148,7 @@ func testLoginCmd(cli *cli) *cobra.Command {
 				return nil
 			}
 
-			if inputs.Audience != "" {
+			if inputs.Audience != "" && (client.GetAppType() == appTypeNonInteractive) {
 				if err := checkClientIsAuthorizedForAPI(cmd.Context(), cli, client, inputs.Audience); err != nil {
 					return err
 				}
@@ -416,7 +416,7 @@ func (c *cli) audiencePickerOptions(client *management.Client) func(ctx context.
 		var opts pickerOptions
 
 		switch client.GetAppType() {
-		case "regular_web", "non_interactive":
+		case "non_interactive":
 			clientGrants, err := c.api.ClientGrant.List(
 				ctx,
 				management.PerPage(100),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Update docs for auth0 test command
- Fix validation to authorize audience only for M2M apps


<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
