### PR TITLE
Add changelog for v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+# [v.1.14.0](https://github.com/auth0/auth0-cli/tree/v1.14.0) (May 22, 2025))
+
+[Full Changelog](https://github.com/auth0/auth0-cli/compare/v1.13.0...v1.14.0)
+
+### Added
+- New command to manage tenant flags via `auth0 tenant-settings show/update` [#1203]
+- Support for new screens in Advanced Customization for Universal Login [#1225]
+- Subcommand `search-by-email` on `auth0 users` along with --picker flag [#1209]
+
+### Fixed
+- Respect --screen flag for `auth0 ul customize` [#1228]
+- Replace package `mholt/archiver` with custom implementation of unzip [#1218]
+
+
 # [v.1.13.0](https://github.com/auth0/auth0-cli/tree/v1.13.0) (May 7, 2025))
 
 [Full Changelog](https://github.com/auth0/auth0-cli/compare/v1.12.0...v1.13.0)
@@ -484,8 +498,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updating of action triggers which inevitably results in error [#597]
 
 
-[unreleased]: https://github.com/auth0/auth0-cli/compare/v1.13.0...HEAD
+[unreleased]: https://github.com/auth0/auth0-cli/compare/v1.14.0...HEAD
 
+[#1228]:https://github.com/auth0/auth0-cli/issues/1228
+[#1225]:https://github.com/auth0/auth0-cli/issues/1225
+[#1218]:https://github.com/auth0/auth0-cli/issues/1218
+[#1209]:https://github.com/auth0/auth0-cli/issues/1209
+[#1203]:https://github.com/auth0/auth0-cli/issues/1203
 [#1197]:https://github.com/auth0/auth0-cli/issues/1197
 [#1195]:https://github.com/auth0/auth0-cli/issues/1195
 [#1192]:https://github.com/auth0/auth0-cli/issues/1192


### PR DESCRIPTION
### Added
- New command to manage tenant flags via `auth0 tenant-settings show/update` [#1203]
- Support for new screens in Advanced Customization for Universal Login [#1225]
- Subcommand `search-by-email` on `auth0 users` along with --picker flag [#1209]

### Fixed
- Respect --screen flag for `auth0 ul customize` [#1228]
- Replace package `mholt/archiver` with custom implementation of unzip [#1218]
