### PR TITLE
Add new PIIConfig flag on logStreams

### DIFF
--- a/docs/auth0_logs_streams_create_datadog.md
+++ b/docs/auth0_logs_streams_create_datadog.md
@@ -23,6 +23,7 @@ auth0 logs streams create datadog [flags]
   auth0 logs streams create datadog --name <name>
   auth0 logs streams create datadog --name <name> --region <region>
   auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create datadog -n <name> -r <region> -k <api-key>
   auth0 logs streams create datadog -n mylogstream -r eu -k 121233123455 --json
 ```
@@ -31,11 +32,15 @@ auth0 logs streams create datadog [flags]
 ## Flags
 
 ```
-  -k, --api-key string   Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
-      --json             Output in json format.
-  -n, --name string      The name of the log stream.
-  -r, --region string    The region in which the datadog dashboard is created.
-                         If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+  -k, --api-key string      Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
+  -r, --region string       The region in which the datadog dashboard is created.
+                            If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
 ```
 
 

--- a/docs/auth0_logs_streams_create_eventbridge.md
+++ b/docs/auth0_logs_streams_create_eventbridge.md
@@ -23,6 +23,7 @@ auth0 logs streams create eventbridge [flags]
   auth0 logs streams create eventbridge --name <name>
   auth0 logs streams create eventbridge --name <name> --aws-id <aws-id>
   auth0 logs streams create eventbridge --name <name> --aws-id <aws-id> --aws-region <aws-region>
+  auth0 logs streams create eventbridge --name <name> --aws-id <aws-id> --aws-region <aws-region> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create eventbridge -n <name> -i <aws-id> -r <aws-region>
   auth0 logs streams create eventbridge -n mylogstream -i 999999999999 -r "eu-west-1" --json
 ```
@@ -35,6 +36,10 @@ auth0 logs streams create eventbridge [flags]
   -r, --aws-region string   The AWS region in which eventbridge will be created, e.g. 'us-east-2'.
       --json                Output in json format.
   -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
 ```
 
 

--- a/docs/auth0_logs_streams_create_eventgrid.md
+++ b/docs/auth0_logs_streams_create_eventgrid.md
@@ -24,6 +24,7 @@ auth0 logs streams create eventgrid [flags]
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> 
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region>
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group> --pii-config  "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create eventgrid -n <name> -i <azure-id> -r <azure-region> -g <azure-group>
   auth0 logs streams create eventgrid -n mylogstream -i "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5" -r northeurope -g "azure-logs-rg" --json
 ```
@@ -37,6 +38,10 @@ auth0 logs streams create eventgrid [flags]
   -r, --azure-region string   The region in which the Azure subscription is hosted.
       --json                  Output in json format.
   -n, --name string           The name of the log stream.
+  -c, --pii-config string     Specifies how PII fields are logged, Formatted as JSON. 
+                              including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                               Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                               (default "{}")
 ```
 
 

--- a/docs/auth0_logs_streams_create_http.md
+++ b/docs/auth0_logs_streams_create_http.md
@@ -24,6 +24,7 @@ auth0 logs streams create http [flags]
   auth0 logs streams create http --name <name> --endpoint <endpoint>
   auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type>
   auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format>
+  auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create http --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
   auth0 logs streams create http -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
   auth0 logs streams create http -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json
@@ -38,6 +39,10 @@ auth0 logs streams create http [flags]
   -f, --format string          The format of data sent over HTTP. Options are "JSONLINES", "JSONARRAY" or "JSONOBJECT"
       --json                   Output in json format.
   -n, --name string            The name of the log stream.
+  -c, --pii-config string      Specifies how PII fields are logged, Formatted as JSON. 
+                               including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                                Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                                (default "{}")
   -t, --type string            The "Content-Type" header to send over HTTP. Common value is "application/json".
 ```
 

--- a/docs/auth0_logs_streams_create_splunk.md
+++ b/docs/auth0_logs_streams_create_splunk.md
@@ -24,6 +24,7 @@ auth0 logs streams create splunk [flags]
   auth0 log streams create splunk --name <name> --domain <domain>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
   auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json
@@ -33,12 +34,16 @@ auth0 logs streams create splunk [flags]
 ## Flags
 
 ```
-  -d, --domain string   The domain name of the splunk instance.
-      --json            Output in json format.
-  -n, --name string     The name of the log stream.
-  -p, --port string     The port of the HTTP event collector.
-  -s, --secure          This should be set to 'false' when using self-signed certificates.
-  -t, --token string    Splunk event collector token.
+  -d, --domain string       The domain name of the splunk instance.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
+  -p, --port string         The port of the HTTP event collector.
+  -s, --secure              This should be set to 'false' when using self-signed certificates.
+  -t, --token string        Splunk event collector token.
 ```
 
 

--- a/docs/auth0_logs_streams_create_sumo.md
+++ b/docs/auth0_logs_streams_create_sumo.md
@@ -22,6 +22,7 @@ auth0 logs streams create sumo [flags]
   auth0 logs streams create sumo
   auth0 logs streams create sumo --name <name>
   auth0 logs streams create sumo --name <name> --source <source>
+  auth0 logs streams create sumo --name <name> --source <source> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create sumo -n <name> -s <source>
   auth0 logs streams create sumo -n "mylogstream" -s "demo.sumo.com" --json
 ```
@@ -30,9 +31,13 @@ auth0 logs streams create sumo [flags]
 ## Flags
 
 ```
-      --json            Output in json format.
-  -n, --name string     The name of the log stream.
-  -s, --source string   Generated URL for your defined HTTP source in Sumo Logic.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
+  -s, --source string       Generated URL for your defined HTTP source in Sumo Logic.
 ```
 
 

--- a/docs/auth0_logs_streams_update_datadog.md
+++ b/docs/auth0_logs_streams_update_datadog.md
@@ -23,7 +23,8 @@ auth0 logs streams update datadog [flags]
   auth0 logs streams update datadog <log-stream-id> --name <name>
   auth0 logs streams update datadog <log-stream-id> --name <name> --region <region>
   auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key>
-  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key> -c null
   auth0 logs streams update datadog <log-stream-id> -n mylogstream -r eu -k 121233123455 --json
 ```
 
@@ -31,11 +32,15 @@ auth0 logs streams update datadog [flags]
 ## Flags
 
 ```
-  -k, --api-key string   Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
-      --json             Output in json format.
-  -n, --name string      The name of the log stream.
-  -r, --region string    The region in which the datadog dashboard is created.
-                         If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
+  -k, --api-key string      Datadog API Key. To obtain a key, see the Datadog Authentication documentation (https://docs.datadoghq.com/api/latest/authentication).
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
+  -r, --region string       The region in which the datadog dashboard is created.
+                            If you are in the datadog EU site ('app.datadoghq.eu'), the Region should be EU otherwise it should be US.
 ```
 
 

--- a/docs/auth0_logs_streams_update_eventbridge.md
+++ b/docs/auth0_logs_streams_update_eventbridge.md
@@ -21,7 +21,8 @@ auth0 logs streams update eventbridge [flags]
 ```
   auth0 logs streams update eventbridge
   auth0 logs streams update eventbridge <log-stream-id> --name <name>
-  auth0 logs streams update eventbridge <log-stream-id> -n <name>
+  auth0 logs streams update eventbridge <log-stream-id> --name <name>  --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update eventbridge <log-stream-id> -n <name> -p null
   auth0 logs streams update eventbridge <log-stream-id> -n mylogstream --json
 ```
 
@@ -29,8 +30,12 @@ auth0 logs streams update eventbridge [flags]
 ## Flags
 
 ```
-      --json          Output in json format.
-  -n, --name string   The name of the log stream.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
 ```
 
 

--- a/docs/auth0_logs_streams_update_eventgrid.md
+++ b/docs/auth0_logs_streams_update_eventgrid.md
@@ -22,15 +22,20 @@ auth0 logs streams update eventgrid [flags]
   auth0 logs streams update eventgrid
   auth0 logs streams update eventgrid <log-stream-id> --name <name>
   auth0 logs streams update eventgrid <log-stream-id> -n <name>
-  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream --json
+  auth0 logs streams update eventgrid <log-stream-id> -n <name> --pii-config  "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream -c null --json
 ```
 
 
 ## Flags
 
 ```
-      --json          Output in json format.
-  -n, --name string   The name of the log stream.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
 ```
 
 

--- a/docs/auth0_logs_streams_update_http.md
+++ b/docs/auth0_logs_streams_update_http.md
@@ -23,9 +23,10 @@ auth0 logs streams update http [flags]
   auth0 logs streams update http <log-stream-id> --name <name>
   auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint>
   auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type>
+  auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type>  --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format>
   auth0 logs streams update http <log-stream-id> --name <name> --endpoint <endpoint> --type <type> --format <format> --authorization <authorization>
-  auth0 logs streams update http <log-stream-id> -n <name> -e <endpoint> -t <type> -f <format> -a <authorization>
+  auth0 logs streams update http <log-stream-id> -n <name> -e <endpoint> -t <type> -f <format> -a <authorization> -c null
   auth0 logs streams update http <log-stream-id> -n mylogstream -e "https://example.com/webhook/logs" -t "application/json" -f "JSONLINES" -a "AKIAXXXXXXXXXXXXXXXX" --json
 ```
 
@@ -38,6 +39,10 @@ auth0 logs streams update http [flags]
   -f, --format string          The format of data sent over HTTP. Options are "JSONLINES", "JSONARRAY" or "JSONOBJECT"
       --json                   Output in json format.
   -n, --name string            The name of the log stream.
+  -c, --pii-config string      Specifies how PII fields are logged, Formatted as JSON. 
+                               including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                                Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                                (default "{}")
   -t, --type string            The "Content-Type" header to send over HTTP. Common value is "application/json".
 ```
 

--- a/docs/auth0_logs_streams_update_splunk.md
+++ b/docs/auth0_logs_streams_update_splunk.md
@@ -24,8 +24,9 @@ auth0 logs streams update splunk [flags]
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure=false
-  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s -c null
   auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s=false --json
 ```
 
@@ -33,12 +34,16 @@ auth0 logs streams update splunk [flags]
 ## Flags
 
 ```
-  -d, --domain string   The domain name of the splunk instance.
-      --json            Output in json format.
-  -n, --name string     The name of the log stream.
-  -p, --port string     The port of the HTTP event collector.
-  -s, --secure          This should be set to 'false' when using self-signed certificates.
-  -t, --token string    Splunk event collector token.
+  -d, --domain string       The domain name of the splunk instance.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                            
+  -p, --port string         The port of the HTTP event collector.
+  -s, --secure              This should be set to 'false' when using self-signed certificates.
+  -t, --token string        Splunk event collector token.
 ```
 
 

--- a/docs/auth0_logs_streams_update_sumo.md
+++ b/docs/auth0_logs_streams_update_sumo.md
@@ -22,7 +22,8 @@ auth0 logs streams update sumo [flags]
   auth0 logs streams update sumo
   auth0 logs streams update sumo <log-stream-id> --name <name>
   auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>
-  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source>
+  auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>  --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source> -c null
   auth0 logs streams update sumo <log-stream-id> -n "mylogstream" -s "demo.sumo.com" --json
 ```
 
@@ -30,9 +31,13 @@ auth0 logs streams update sumo [flags]
 ## Flags
 
 ```
-      --json            Output in json format.
-  -n, --name string     The name of the log stream.
-  -s, --source string   Generated URL for your defined HTTP source in Sumo Logic.
+      --json                Output in json format.
+  -n, --name string         The name of the log stream.
+  -c, --pii-config string   Specifies how PII fields are logged, Formatted as JSON. 
+                            including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 
+                             Example : {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}. 
+                             (default "{}")
+  -s, --source string       Generated URL for your defined HTTP source in Sumo Logic.
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/PuerkitoBio/rehttp v1.4.0
 	github.com/atotto/clipboard v0.1.4
-	github.com/auth0/go-auth0 v1.24.0
+	github.com/auth0/go-auth0 v1.25.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/auth0/go-auth0 v1.24.0 h1:9H3Qv+mAbvv90OLab2pd2ktn7SFdQN86xY9d6niOtd0=
-github.com/auth0/go-auth0 v1.24.0/go.mod h1:g9S/4ImupKFx1gSLqeQO0v1yV91Oo5J5bYobLCAL+J4=
+github.com/auth0/go-auth0 v1.25.0 h1:fNlbDL8CPA+w3mfuuGD12cHjtEK/EDLJAc20xrL1+Eg=
+github.com/auth0/go-auth0 v1.25.0/go.mod h1:g9S/4ImupKFx1gSLqeQO0v1yV91Oo5J5bYobLCAL+J4=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/cli/log_streams.go
+++ b/internal/cli/log_streams.go
@@ -35,6 +35,17 @@ var (
 		Help:         "The name of the log stream.",
 		AlwaysPrompt: true,
 	}
+
+	logStreamPIIConfig = Flag{
+		Name:      "PII Configuration",
+		LongForm:  "pii-config",
+		ShortForm: "c",
+		Help: "Specifies how PII fields are logged, Formatted as JSON. \n" +
+			"including which fields to log (first_name, last_name, username, email, phone, address)," +
+			"the protection method (mask or hash), and the hashing algorithm (xxhash). \n" +
+			" Example : {\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}. \n",
+		AlwaysPrompt: true,
+	}
 )
 
 func logStreamsCmd(cli *cli) *cobra.Command {

--- a/internal/cli/log_streams_datadog.go
+++ b/internal/cli/log_streams_datadog.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/auth0/go-auth0/management"
@@ -33,9 +34,10 @@ var (
 
 func createLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Name          string
-		DatadogAPIKey string
-		DatadogRegion string
+		name          string
+		datadogAPIKey string
+		datadogRegion string
+		piiConfig     string
 	}
 
 	cmd := &cobra.Command{
@@ -49,28 +51,42 @@ func createLogStreamsDatadogCmd(cli *cli) *cobra.Command {
   auth0 logs streams create datadog --name <name>
   auth0 logs streams create datadog --name <name> --region <region>
   auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key>
+  auth0 logs streams create datadog --name <name> --region <region> --api-key <api-key> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create datadog -n <name> -r <region> -k <api-key>
   auth0 logs streams create datadog -n mylogstream -r eu -k 121233123455 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+			if err := logStreamName.Ask(cmd, &inputs.name, nil); err != nil {
 				return err
 			}
 
-			if err := datadogRegion.Select(cmd, &inputs.DatadogRegion, datadogRegionOptions, nil); err != nil {
+			if err := datadogRegion.Select(cmd, &inputs.datadogRegion, datadogRegionOptions, nil); err != nil {
 				return err
 			}
 
-			if err := datadogAPIKey.AskPassword(cmd, &inputs.DatadogAPIKey); err != nil {
+			if err := datadogAPIKey.AskPassword(cmd, &inputs.datadogAPIKey); err != nil {
 				return err
+			}
+
+			var piiConfig *management.LogStreamPiiConfig
+
+			if err := logStreamPIIConfig.Ask(cmd, &inputs.piiConfig, auth0.String("{}")); err != nil {
+				return err
+			}
+
+			if inputs.piiConfig != "{}" {
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
 			}
 
 			newLogStream := &management.LogStream{
-				Name: &inputs.Name,
+				Name: &inputs.name,
 				Type: auth0.String(string(logStreamTypeDatadog)),
 				Sink: &management.LogStreamSinkDatadog{
-					Region: &inputs.DatadogRegion,
-					APIKey: &inputs.DatadogAPIKey,
+					Region: &inputs.datadogRegion,
+					APIKey: &inputs.datadogAPIKey,
 				},
+				PIIConfig: piiConfig,
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -79,26 +95,26 @@ func createLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to create log stream: %w", err)
 			}
 
-			cli.renderer.LogStreamCreate(newLogStream)
-
-			return nil
+			return cli.renderer.LogStreamCreate(newLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterString(cmd, &inputs.Name, "")
-	datadogAPIKey.RegisterString(cmd, &inputs.DatadogAPIKey, "")
-	datadogRegion.RegisterString(cmd, &inputs.DatadogRegion, "")
+	logStreamName.RegisterString(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterString(cmd, &inputs.piiConfig, "{}")
+	datadogAPIKey.RegisterString(cmd, &inputs.datadogAPIKey, "")
+	datadogRegion.RegisterString(cmd, &inputs.datadogRegion, "")
 
 	return cmd
 }
 
 func updateLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID            string
-		Name          string
-		DatadogAPIKey string
-		DatadogRegion string
+		id            string
+		name          string
+		piiConfig     string
+		datadogAPIKey string
+		datadogRegion string
 	}
 
 	cmd := &cobra.Command{
@@ -112,57 +128,73 @@ func updateLogStreamsDatadogCmd(cli *cli) *cobra.Command {
   auth0 logs streams update datadog <log-stream-id> --name <name>
   auth0 logs streams update datadog <log-stream-id> --name <name> --region <region>
   auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key>
-  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key>
+  auth0 logs streams update datadog <log-stream-id> --name <name> --region <region> --api-key <api-key> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update datadog <log-stream-id> -n <name> -r <region> -k <api-key> -c null
   auth0 logs streams update datadog <log-stream-id> -n mylogstream -r eu -k 121233123455 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeDatadog))
+				err := logStreamID.Pick(cmd, &inputs.id, cli.logStreamPickerOptionsByType(logStreamTypeDatadog))
 				if err != nil {
 					return err
 				}
 			} else {
-				inputs.ID = args[0]
+				inputs.id = args[0]
 			}
 
 			var oldLogStream *management.LogStream
 			if err := ansi.Waiting(func() (err error) {
-				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.ID)
+				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.id)
 				return err
 			}); err != nil {
-				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.ID, err)
+				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.id, err)
 			}
 
 			if oldLogStream.GetType() != string(logStreamTypeDatadog) {
-				return errInvalidLogStreamType(inputs.ID, oldLogStream.GetType(), string(logStreamTypeDatadog))
+				return errInvalidLogStreamType(inputs.id, oldLogStream.GetType(), string(logStreamTypeDatadog))
 			}
 
-			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+			if err := logStreamName.AskU(cmd, &inputs.name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			existing, _ := json.Marshal(oldLogStream.GetPIIConfig())
+			if err := logStreamPIIConfig.AskU(cmd, &inputs.piiConfig, auth0.String(string(existing))); err != nil {
 				return err
 			}
 
 			datadogSink := oldLogStream.Sink.(*management.LogStreamSinkDatadog)
 
-			if err := datadogRegion.SelectU(cmd, &inputs.DatadogRegion, datadogRegionOptions, datadogSink.Region); err != nil {
+			if err := datadogRegion.SelectU(cmd, &inputs.datadogRegion, datadogRegionOptions, datadogSink.Region); err != nil {
 				return err
 			}
 
-			if err := datadogAPIKey.AskPasswordU(cmd, &inputs.DatadogAPIKey); err != nil {
+			if err := datadogAPIKey.AskPasswordU(cmd, &inputs.datadogAPIKey); err != nil {
 				return err
 			}
 
-			updatedLogStream := &management.LogStream{}
+			updatedLogStream := &management.LogStream{
+				PIIConfig: oldLogStream.GetPIIConfig(),
+			}
 
-			if inputs.Name != "" {
-				updatedLogStream.Name = &inputs.Name
+			if inputs.name != "" {
+				updatedLogStream.Name = &inputs.name
 			}
-			if inputs.DatadogRegion != "" {
-				datadogSink.Region = &inputs.DatadogRegion
+			if inputs.datadogRegion != "" {
+				datadogSink.Region = &inputs.datadogRegion
 			}
-			if inputs.DatadogAPIKey != "" {
-				datadogSink.APIKey = &inputs.DatadogAPIKey
+			if inputs.datadogAPIKey != "" {
+				datadogSink.APIKey = &inputs.datadogAPIKey
 			}
 
 			updatedLogStream.Sink = datadogSink
+
+			if inputs.piiConfig != "{}" {
+				var piiConfig *management.LogStreamPiiConfig
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
+				updatedLogStream.PIIConfig = piiConfig
+			}
 
 			if err := ansi.Waiting(func() error {
 				return cli.api.LogStream.Update(cmd.Context(), oldLogStream.GetID(), updatedLogStream)
@@ -170,16 +202,15 @@ func updateLogStreamsDatadogCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to update log stream with ID %q: %w", oldLogStream.GetID(), err)
 			}
 
-			cli.renderer.LogStreamUpdate(updatedLogStream)
-
-			return nil
+			return cli.renderer.LogStreamUpdate(updatedLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
-	datadogAPIKey.RegisterStringU(cmd, &inputs.DatadogAPIKey, "")
-	datadogRegion.RegisterStringU(cmd, &inputs.DatadogRegion, "")
+	logStreamName.RegisterStringU(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterStringU(cmd, &inputs.piiConfig, "{}")
+	datadogAPIKey.RegisterStringU(cmd, &inputs.datadogAPIKey, "")
+	datadogRegion.RegisterStringU(cmd, &inputs.datadogRegion, "")
 
 	return cmd
 }

--- a/internal/cli/log_streams_event_grid.go
+++ b/internal/cli/log_streams_event_grid.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/auth0/go-auth0/management"
@@ -36,10 +37,11 @@ var (
 
 func createLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Name                string
-		AzureSubscriptionID string
-		AzureRegion         string
-		AzureResourceGroup  string
+		name                string
+		azureSubscriptionID string
+		azureRegion         string
+		azureResourceGroup  string
+		piiConfig           string
 	}
 
 	cmd := &cobra.Command{
@@ -54,33 +56,47 @@ func createLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> 
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region>
   auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group>
+  auth0 logs streams create eventgrid --name <name> --azure-id <azure-id> --azure-region <azure-region> --azure-group <azure-group> --pii-config  "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create eventgrid -n <name> -i <azure-id> -r <azure-region> -g <azure-group>
   auth0 logs streams create eventgrid -n mylogstream -i "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5" -r northeurope -g "azure-logs-rg" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+			if err := logStreamName.Ask(cmd, &inputs.name, nil); err != nil {
 				return err
 			}
 
-			if err := azureSubscriptionID.Ask(cmd, &inputs.AzureSubscriptionID, nil); err != nil {
+			if err := azureSubscriptionID.Ask(cmd, &inputs.azureSubscriptionID, nil); err != nil {
 				return err
 			}
 
-			if err := azureRegion.Ask(cmd, &inputs.AzureRegion, nil); err != nil {
+			if err := azureRegion.Ask(cmd, &inputs.azureRegion, nil); err != nil {
 				return err
 			}
 
-			if err := azureResourceGroup.Ask(cmd, &inputs.AzureResourceGroup, nil); err != nil {
+			if err := azureResourceGroup.Ask(cmd, &inputs.azureResourceGroup, nil); err != nil {
 				return err
+			}
+
+			var piiConfig *management.LogStreamPiiConfig
+
+			if err := logStreamPIIConfig.Ask(cmd, &inputs.piiConfig, auth0.String("{}")); err != nil {
+				return err
+			}
+
+			if inputs.piiConfig != "{}" {
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
 			}
 
 			newLogStream := &management.LogStream{
-				Name: &inputs.Name,
+				Name: &inputs.name,
 				Type: auth0.String(string(logStreamTypeAzureEventGrid)),
 				Sink: &management.LogStreamSinkAzureEventGrid{
-					SubscriptionID: &inputs.AzureSubscriptionID,
-					ResourceGroup:  &inputs.AzureResourceGroup,
-					Region:         &inputs.AzureRegion,
+					SubscriptionID: &inputs.azureSubscriptionID,
+					ResourceGroup:  &inputs.azureResourceGroup,
+					Region:         &inputs.azureRegion,
 				},
+				PIIConfig: piiConfig,
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -89,25 +105,25 @@ func createLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to create log stream: %w", err)
 			}
 
-			cli.renderer.LogStreamCreate(newLogStream)
-
-			return nil
+			return cli.renderer.LogStreamCreate(newLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterString(cmd, &inputs.Name, "")
-	azureSubscriptionID.RegisterString(cmd, &inputs.AzureSubscriptionID, "")
-	azureRegion.RegisterString(cmd, &inputs.AzureRegion, "")
-	azureResourceGroup.RegisterString(cmd, &inputs.AzureResourceGroup, "")
+	logStreamName.RegisterString(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterString(cmd, &inputs.piiConfig, "{}")
+	azureSubscriptionID.RegisterString(cmd, &inputs.azureSubscriptionID, "")
+	azureRegion.RegisterString(cmd, &inputs.azureRegion, "")
+	azureResourceGroup.RegisterString(cmd, &inputs.azureResourceGroup, "")
 
 	return cmd
 }
 
 func updateLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID   string
-		Name string
+		id        string
+		name      string
+		piiConfig string
 	}
 
 	cmd := &cobra.Command{
@@ -120,36 +136,50 @@ func updateLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 logs streams update eventgrid
   auth0 logs streams update eventgrid <log-stream-id> --name <name>
   auth0 logs streams update eventgrid <log-stream-id> -n <name>
-  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream --json`,
+  auth0 logs streams update eventgrid <log-stream-id> -n <name> --pii-config  "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update eventgrid <log-stream-id> -n mylogstream -c null --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeAzureEventGrid))
+				err := logStreamID.Pick(cmd, &inputs.id, cli.logStreamPickerOptionsByType(logStreamTypeAzureEventGrid))
 				if err != nil {
 					return err
 				}
 			} else {
-				inputs.ID = args[0]
+				inputs.id = args[0]
 			}
 
 			var oldLogStream *management.LogStream
 			if err := ansi.Waiting(func() (err error) {
-				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.ID)
+				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.id)
 				return err
 			}); err != nil {
-				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.ID, err)
+				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.id, err)
 			}
 
 			if oldLogStream.GetType() != string(logStreamTypeAzureEventGrid) {
-				return errInvalidLogStreamType(inputs.ID, oldLogStream.GetType(), string(logStreamTypeAzureEventGrid))
+				return errInvalidLogStreamType(inputs.id, oldLogStream.GetType(), string(logStreamTypeAzureEventGrid))
 			}
 
-			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+			if err := logStreamName.AskU(cmd, &inputs.name, oldLogStream.Name); err != nil {
 				return err
 			}
 
 			updatedLogStream := &management.LogStream{}
-			if inputs.Name != "" {
-				updatedLogStream.Name = &inputs.Name
+			if inputs.name != "" {
+				updatedLogStream.Name = &inputs.name
+			}
+
+			if inputs.piiConfig != "{}" {
+				var piiConfig *management.LogStreamPiiConfig
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
+				updatedLogStream.PIIConfig = piiConfig
+			}
+
+			existing, _ := json.Marshal(oldLogStream.GetPIIConfig())
+			if err := logStreamPIIConfig.AskU(cmd, &inputs.piiConfig, auth0.String(string(existing))); err != nil {
+				return err
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -158,14 +188,13 @@ func updateLogStreamsAzureEventGridCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to update log stream with ID %q: %w", oldLogStream.GetID(), err)
 			}
 
-			cli.renderer.LogStreamUpdate(updatedLogStream)
-
-			return nil
+			return cli.renderer.LogStreamUpdate(updatedLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
+	logStreamName.RegisterStringU(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterStringU(cmd, &inputs.piiConfig, "{}")
 
 	return cmd
 }

--- a/internal/cli/log_streams_splunk.go
+++ b/internal/cli/log_streams_splunk.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/auth0/go-auth0/management"
@@ -41,11 +42,12 @@ var (
 
 func createLogStreamsSplunkCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Name            string
-		SplunkDomain    string
-		SplunkToken     string
-		SplunkPort      string
-		SplunkVerifyTLS bool
+		name            string
+		splunkDomain    string
+		splunkToken     string
+		splunkPort      string
+		splunkVerifyTLS bool
+		piiConfig       string
 	}
 
 	cmd := &cobra.Command{
@@ -60,41 +62,55 @@ func createLogStreamsSplunkCmd(cli *cli) *cobra.Command {
   auth0 log streams create splunk --name <name> --domain <domain>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token>
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 log streams create splunk --name <name> --domain <domain> --token <token> --port <port> --secure=false
   auth0 log streams create splunk -n <name> -d <domain> -t <token> -p <port> -s
   auth0 log streams create splunk -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s false --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+			if err := logStreamName.Ask(cmd, &inputs.name, nil); err != nil {
 				return err
 			}
 
-			if err := splunkDomain.Ask(cmd, &inputs.SplunkDomain, nil); err != nil {
+			if err := splunkDomain.Ask(cmd, &inputs.splunkDomain, nil); err != nil {
 				return err
 			}
 
-			if err := splunkToken.Ask(cmd, &inputs.SplunkToken, nil); err != nil {
+			if err := splunkToken.Ask(cmd, &inputs.splunkToken, nil); err != nil {
 				return err
 			}
 
-			if err := splunkPort.Ask(cmd, &inputs.SplunkPort, nil); err != nil {
+			if err := splunkPort.Ask(cmd, &inputs.splunkPort, nil); err != nil {
 				return err
 			}
 
-			if err := splunkVerifyTLS.AskBool(cmd, &inputs.SplunkVerifyTLS, nil); err != nil {
+			if err := splunkVerifyTLS.AskBool(cmd, &inputs.splunkVerifyTLS, nil); err != nil {
 				return err
+			}
+
+			var piiConfig *management.LogStreamPiiConfig
+
+			if err := logStreamPIIConfig.Ask(cmd, &inputs.piiConfig, auth0.String("{}")); err != nil {
+				return err
+			}
+
+			if inputs.piiConfig != "{}" {
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
 			}
 
 			newLogStream := &management.LogStream{
-				Name: &inputs.Name,
-				Type: auth0.String(string(logStreamTypeSplunk)),
+				Name:      &inputs.name,
+				Type:      auth0.String(string(logStreamTypeSplunk)),
+				PIIConfig: piiConfig,
 			}
 			sink := &management.LogStreamSinkSplunk{
-				Domain: &inputs.SplunkDomain,
-				Token:  &inputs.SplunkToken,
-				Secure: &inputs.SplunkVerifyTLS,
+				Domain: &inputs.splunkDomain,
+				Token:  &inputs.splunkToken,
+				Secure: &inputs.splunkVerifyTLS,
 			}
-			if inputs.SplunkPort != "" {
-				sink.Port = &inputs.SplunkPort
+			if inputs.splunkPort != "" {
+				sink.Port = &inputs.splunkPort
 			}
 			newLogStream.Sink = sink
 
@@ -104,30 +120,30 @@ func createLogStreamsSplunkCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to create log stream: %w", err)
 			}
 
-			cli.renderer.LogStreamCreate(newLogStream)
-
-			return nil
+			return cli.renderer.LogStreamCreate(newLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterString(cmd, &inputs.Name, "")
-	splunkDomain.RegisterString(cmd, &inputs.SplunkDomain, "")
-	splunkToken.RegisterString(cmd, &inputs.SplunkToken, "")
-	splunkPort.RegisterString(cmd, &inputs.SplunkPort, "")
-	splunkVerifyTLS.RegisterBool(cmd, &inputs.SplunkVerifyTLS, false)
+	logStreamName.RegisterString(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterString(cmd, &inputs.piiConfig, "{}")
+	splunkDomain.RegisterString(cmd, &inputs.splunkDomain, "")
+	splunkToken.RegisterString(cmd, &inputs.splunkToken, "")
+	splunkPort.RegisterString(cmd, &inputs.splunkPort, "")
+	splunkVerifyTLS.RegisterBool(cmd, &inputs.splunkVerifyTLS, false)
 
 	return cmd
 }
 
 func updateLogStreamsSplunkCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID              string
-		Name            string
-		SplunkDomain    string
-		SplunkToken     string
-		SplunkPort      string
-		SplunkVerifyTLS bool
+		id              string
+		name            string
+		splunkDomain    string
+		splunkToken     string
+		splunkPort      string
+		splunkVerifyTLS bool
+		piiConfig       string
 	}
 
 	cmd := &cobra.Command{
@@ -142,65 +158,81 @@ func updateLogStreamsSplunkCmd(cli *cli) *cobra.Command {
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token>
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port>
+  auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
   auth0 log streams update splunk <log-stream-id> --name <name> --domain <domain> --token <token> --port <port> --secure=false
-  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s
+  auth0 log streams update splunk <log-stream-id> -n <name> -d <domain> -t <token> -p <port> -s -c null
   auth0 log streams update splunk <log-stream-id> -n mylogstream -d "demo.splunk.com" -t "12a34ab5-c6d7-8901-23ef-456b7c89d0c1" -p "8088" -s=false --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeSplunk))
+				err := logStreamID.Pick(cmd, &inputs.id, cli.logStreamPickerOptionsByType(logStreamTypeSplunk))
 				if err != nil {
 					return err
 				}
 			} else {
-				inputs.ID = args[0]
+				inputs.id = args[0]
 			}
 
 			var oldLogStream *management.LogStream
 			if err := ansi.Waiting(func() (err error) {
-				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.ID)
+				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.id)
 				return err
 			}); err != nil {
-				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.ID, err)
+				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.id, err)
 			}
 
 			if oldLogStream.GetType() != string(logStreamTypeSplunk) {
-				return errInvalidLogStreamType(inputs.ID, oldLogStream.GetType(), string(logStreamTypeSplunk))
+				return errInvalidLogStreamType(inputs.id, oldLogStream.GetType(), string(logStreamTypeSplunk))
 			}
 
-			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+			if err := logStreamName.AskU(cmd, &inputs.name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			existing, _ := json.Marshal(oldLogStream.GetPIIConfig())
+			if err := logStreamPIIConfig.AskU(cmd, &inputs.piiConfig, auth0.String(string(existing))); err != nil {
 				return err
 			}
 
 			splunkSink := oldLogStream.Sink.(*management.LogStreamSinkSplunk)
 
-			if err := splunkDomain.AskU(cmd, &inputs.SplunkDomain, splunkSink.Domain); err != nil {
+			if err := splunkDomain.AskU(cmd, &inputs.splunkDomain, splunkSink.Domain); err != nil {
 				return err
 			}
-			if err := splunkToken.AskU(cmd, &inputs.SplunkToken, splunkSink.Token); err != nil {
+			if err := splunkToken.AskU(cmd, &inputs.splunkToken, splunkSink.Token); err != nil {
 				return err
 			}
-			if err := splunkPort.AskU(cmd, &inputs.SplunkPort, splunkSink.Port); err != nil {
+			if err := splunkPort.AskU(cmd, &inputs.splunkPort, splunkSink.Port); err != nil {
 				return err
 			}
-			if err := splunkVerifyTLS.AskBoolU(cmd, &inputs.SplunkVerifyTLS, splunkSink.Secure); err != nil {
+			if err := splunkVerifyTLS.AskBoolU(cmd, &inputs.splunkVerifyTLS, splunkSink.Secure); err != nil {
 				return err
 			}
 
-			updatedLogStream := &management.LogStream{}
-			if inputs.Name != "" {
-				updatedLogStream.Name = &inputs.Name
+			updatedLogStream := &management.LogStream{
+				PIIConfig: oldLogStream.GetPIIConfig(),
 			}
-			if inputs.SplunkDomain != "" {
-				splunkSink.Domain = &inputs.SplunkDomain
+			if inputs.name != "" {
+				updatedLogStream.Name = &inputs.name
 			}
-			if inputs.SplunkToken != "" {
-				splunkSink.Token = &inputs.SplunkToken
+			if inputs.splunkDomain != "" {
+				splunkSink.Domain = &inputs.splunkDomain
 			}
-			if inputs.SplunkPort != "" {
-				splunkSink.Port = &inputs.SplunkPort
+			if inputs.splunkToken != "" {
+				splunkSink.Token = &inputs.splunkToken
 			}
-			splunkSink.Secure = &inputs.SplunkVerifyTLS
+			if inputs.splunkPort != "" {
+				splunkSink.Port = &inputs.splunkPort
+			}
+			splunkSink.Secure = &inputs.splunkVerifyTLS
 			updatedLogStream.Sink = splunkSink
+
+			if inputs.piiConfig != "{}" {
+				var piiConfig *management.LogStreamPiiConfig
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
+				updatedLogStream.PIIConfig = piiConfig
+			}
 
 			if err := ansi.Waiting(func() error {
 				return cli.api.LogStream.Update(cmd.Context(), oldLogStream.GetID(), updatedLogStream)
@@ -208,18 +240,17 @@ func updateLogStreamsSplunkCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to update log stream with ID %q: %w", oldLogStream.GetID(), err)
 			}
 
-			cli.renderer.LogStreamUpdate(updatedLogStream)
-
-			return nil
+			return cli.renderer.LogStreamUpdate(updatedLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
-	splunkDomain.RegisterStringU(cmd, &inputs.SplunkDomain, "")
-	splunkToken.RegisterStringU(cmd, &inputs.SplunkToken, "")
-	splunkPort.RegisterStringU(cmd, &inputs.SplunkPort, "")
-	splunkVerifyTLS.RegisterBoolU(cmd, &inputs.SplunkVerifyTLS, false)
+	logStreamName.RegisterStringU(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterStringU(cmd, &inputs.piiConfig, "")
+	splunkDomain.RegisterStringU(cmd, &inputs.splunkDomain, "")
+	splunkToken.RegisterStringU(cmd, &inputs.splunkToken, "")
+	splunkPort.RegisterStringU(cmd, &inputs.splunkPort, "")
+	splunkVerifyTLS.RegisterBoolU(cmd, &inputs.splunkVerifyTLS, false)
 
 	return cmd
 }

--- a/internal/cli/log_streams_sumo.go
+++ b/internal/cli/log_streams_sumo.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/auth0/go-auth0/management"
@@ -22,8 +23,9 @@ var (
 
 func createLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		Name            string
-		SumoLogicSource string
+		mame            string
+		sumoLogicSource string
+		piiConfig       string
 	}
 
 	cmd := &cobra.Command{
@@ -36,23 +38,37 @@ func createLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 logs streams create sumo
   auth0 logs streams create sumo --name <name>
   auth0 logs streams create sumo --name <name> --source <source>
+  auth0 logs streams create sumo --name <name> --source <source> --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"hash\", \"algorithm\": \"xxhash\"}"
   auth0 logs streams create sumo -n <name> -s <source>
   auth0 logs streams create sumo -n "mylogstream" -s "demo.sumo.com" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := logStreamName.Ask(cmd, &inputs.Name, nil); err != nil {
+			if err := logStreamName.Ask(cmd, &inputs.mame, nil); err != nil {
 				return err
 			}
 
-			if err := sumoLogicSource.Ask(cmd, &inputs.SumoLogicSource, nil); err != nil {
+			if err := sumoLogicSource.Ask(cmd, &inputs.sumoLogicSource, nil); err != nil {
 				return err
+			}
+
+			var piiConfig *management.LogStreamPiiConfig
+
+			if err := logStreamPIIConfig.Ask(cmd, &inputs.piiConfig, auth0.String("{}")); err != nil {
+				return err
+			}
+
+			if inputs.piiConfig != "{}" {
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
 			}
 
 			newLogStream := &management.LogStream{
-				Name: &inputs.Name,
+				Name: &inputs.mame,
 				Type: auth0.String(string(logStreamTypeSumo)),
 				Sink: &management.LogStreamSinkSumo{
-					SourceAddress: &inputs.SumoLogicSource,
+					SourceAddress: &inputs.sumoLogicSource,
 				},
+				PIIConfig: piiConfig,
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -61,24 +77,24 @@ func createLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to create log stream: %w", err)
 			}
 
-			cli.renderer.LogStreamCreate(newLogStream)
-
-			return nil
+			return cli.renderer.LogStreamCreate(newLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterString(cmd, &inputs.Name, "")
-	sumoLogicSource.RegisterString(cmd, &inputs.SumoLogicSource, "")
+	logStreamName.RegisterString(cmd, &inputs.mame, "")
+	logStreamPIIConfig.RegisterString(cmd, &inputs.piiConfig, "{}")
+	sumoLogicSource.RegisterString(cmd, &inputs.sumoLogicSource, "")
 
 	return cmd
 }
 
 func updateLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID              string
-		Name            string
-		SumoLogicSource string
+		id              string
+		name            string
+		sumoLogicSource string
+		piiConfig       string
 	}
 
 	cmd := &cobra.Command{
@@ -91,47 +107,63 @@ func updateLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 		Example: `  auth0 logs streams update sumo
   auth0 logs streams update sumo <log-stream-id> --name <name>
   auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>
-  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source>
+  auth0 logs streams update sumo <log-stream-id> --name <name> --source <source>  --pii-config "{\"log_fields\": [\"first_name\", \"last_name\"], \"method\": \"mask\", \"algorithm\": \"xxhash\"}"
+  auth0 logs streams update sumo <log-stream-id> -n <name> -s <source> -c null
   auth0 logs streams update sumo <log-stream-id> -n "mylogstream" -s "demo.sumo.com" --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				err := logStreamID.Pick(cmd, &inputs.ID, cli.logStreamPickerOptionsByType(logStreamTypeSumo))
+				err := logStreamID.Pick(cmd, &inputs.id, cli.logStreamPickerOptionsByType(logStreamTypeSumo))
 				if err != nil {
 					return err
 				}
 			} else {
-				inputs.ID = args[0]
+				inputs.id = args[0]
 			}
 
 			var oldLogStream *management.LogStream
 			if err := ansi.Waiting(func() (err error) {
-				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.ID)
+				oldLogStream, err = cli.api.LogStream.Read(cmd.Context(), inputs.id)
 				return err
 			}); err != nil {
-				return fmt.Errorf("failed to read log stream with ID %q: %w", inputs.ID, err)
+				return fmt.Errorf("failed to read log stream with id %q: %w", inputs.id, err)
 			}
 
 			if oldLogStream.GetType() != string(logStreamTypeSumo) {
-				return errInvalidLogStreamType(inputs.ID, oldLogStream.GetType(), string(logStreamTypeSumo))
+				return errInvalidLogStreamType(inputs.id, oldLogStream.GetType(), string(logStreamTypeSumo))
 			}
 
-			if err := logStreamName.AskU(cmd, &inputs.Name, oldLogStream.Name); err != nil {
+			if err := logStreamName.AskU(cmd, &inputs.name, oldLogStream.Name); err != nil {
+				return err
+			}
+
+			existing, _ := json.Marshal(oldLogStream.GetPIIConfig())
+			if err := logStreamPIIConfig.AskU(cmd, &inputs.piiConfig, auth0.String(string(existing))); err != nil {
 				return err
 			}
 
 			sumoSink := oldLogStream.Sink.(*management.LogStreamSinkSumo)
-			if err := sumoLogicSource.AskU(cmd, &inputs.SumoLogicSource, sumoSink.SourceAddress); err != nil {
+			if err := sumoLogicSource.AskU(cmd, &inputs.sumoLogicSource, sumoSink.SourceAddress); err != nil {
 				return err
 			}
 
-			updatedLogStream := &management.LogStream{}
-			if inputs.Name != "" {
-				updatedLogStream.Name = &inputs.Name
+			updatedLogStream := &management.LogStream{
+				PIIConfig: oldLogStream.GetPIIConfig(),
 			}
-			if inputs.SumoLogicSource != "" {
-				sumoSink.SourceAddress = &inputs.SumoLogicSource
+			if inputs.name != "" {
+				updatedLogStream.Name = &inputs.name
+			}
+			if inputs.sumoLogicSource != "" {
+				sumoSink.SourceAddress = &inputs.sumoLogicSource
 			}
 			updatedLogStream.Sink = sumoSink
+
+			if inputs.piiConfig != "{}" {
+				var piiConfig *management.LogStreamPiiConfig
+				if err := json.Unmarshal([]byte(inputs.piiConfig), &piiConfig); err != nil {
+					return fmt.Errorf("provider: %s credentials invalid JSON: %w", inputs.piiConfig, err)
+				}
+				updatedLogStream.PIIConfig = piiConfig
+			}
 
 			if err := ansi.Waiting(func() error {
 				return cli.api.LogStream.Update(cmd.Context(), oldLogStream.GetID(), updatedLogStream)
@@ -139,15 +171,14 @@ func updateLogStreamsSumoLogicCmd(cli *cli) *cobra.Command {
 				return fmt.Errorf("failed to update log stream with ID %q: %w", oldLogStream.GetID(), err)
 			}
 
-			cli.renderer.LogStreamUpdate(updatedLogStream)
-
-			return nil
+			return cli.renderer.LogStreamUpdate(updatedLogStream)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
-	logStreamName.RegisterStringU(cmd, &inputs.Name, "")
-	sumoLogicSource.RegisterStringU(cmd, &inputs.SumoLogicSource, "")
+	logStreamName.RegisterStringU(cmd, &inputs.name, "")
+	logStreamPIIConfig.RegisterStringU(cmd, &inputs.piiConfig, "{}")
+	sumoLogicSource.RegisterStringU(cmd, &inputs.sumoLogicSource, "")
 
 	return cmd
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- `auth0 log streams` supports new flag --pii-config for all types of log_streams 
- PII Config : Formatted as JSON. Including which fields to log (first_name, last_name, username, email, phone, address),the protection method (mask or hash), and the hashing algorithm (xxhash). 

Example : --pii-config {"log_fields": ["first_name", "last_name"], "method": "mask", "algorithm": "xxhash"}

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
