### PR TITLE
Revert checkpoint pagination and use LIST endpoint for custom domains

### DIFF
--- a/internal/cli/custom_domains.go
+++ b/internal/cli/custom_domains.go
@@ -119,7 +119,7 @@ func listCustomDomainsCmd(cli *cli) *cobra.Command {
 			var list []*management.CustomDomain
 
 			if err := ansi.Waiting(func() (err error) {
-				list, err = cli.ListAllCustomDomains(cmd.Context())
+				list, err = cli.api.CustomDomain.List(cmd.Context())
 				return err
 			}); err != nil {
 				return fmt.Errorf("failed to list custom domains: %w", err)
@@ -504,7 +504,7 @@ func apiTLSPolicyFor(v string) *string {
 func (c *cli) customDomainsPickerOptions(ctx context.Context) (pickerOptions, error) {
 	var opts pickerOptions
 
-	domains, err := c.ListAllCustomDomains(ctx)
+	domains, err := c.api.CustomDomain.List(ctx)
 	if err != nil {
 		var errStatus management.Error
 		errors.As(err, &errStatus)
@@ -528,35 +528,4 @@ func (c *cli) customDomainsPickerOptions(ctx context.Context) (pickerOptions, er
 	}
 
 	return opts, nil
-}
-
-func (c *cli) ListAllCustomDomains(ctx context.Context) ([]*management.CustomDomain, error) {
-	var (
-		from       string
-		allDomains []*management.CustomDomain
-		options    = []management.RequestOption{
-			management.Take(100),
-		}
-	)
-
-	for {
-		if from != "" {
-			options = append(options, management.From(from))
-		}
-
-		list, err := c.api.CustomDomain.ListWithPagination(ctx, options...)
-		if err != nil {
-			return nil, err
-		}
-
-		allDomains = append(allDomains, list.CustomDomains...)
-
-		if !list.HasNext() {
-			break
-		}
-
-		from = list.Next
-	}
-
-	return allDomains, nil
 }

--- a/internal/cli/custom_domains_test.go
+++ b/internal/cli/custom_domains_test.go
@@ -87,26 +87,24 @@ func TestAPITLSPolicyFor(t *testing.T) {
 
 func TestCustomDomainsPickerOptions(t *testing.T) {
 	tests := []struct {
-		name              string
-		customDomainsList *management.CustomDomainList
-		apiError          error
-		assertOutput      func(t testing.TB, options pickerOptions)
-		assertError       func(t testing.TB, err error)
+		name          string
+		customDomains []*management.CustomDomain
+		apiError      error
+		assertOutput  func(t testing.TB, options pickerOptions)
+		assertError   func(t testing.TB, err error)
 	}{
 		{
 			name: "happy path",
-			customDomainsList: &management.CustomDomainList{
-				CustomDomains: []*management.CustomDomain{
-					{
-						ID:     auth0.String("some-id-1"),
-						Domain: auth0.String("some-domain-1"),
-						Status: auth0.String("ready"),
-					},
-					{
-						ID:     auth0.String("some-id-2"),
-						Domain: auth0.String("some-domain-2"),
-						Status: auth0.String("ready"),
-					},
+			customDomains: []*management.CustomDomain{
+				{
+					ID:     auth0.String("some-id-1"),
+					Domain: auth0.String("some-domain-1"),
+					Status: auth0.String("ready"),
+				},
+				{
+					ID:     auth0.String("some-id-2"),
+					Domain: auth0.String("some-domain-2"),
+					Status: auth0.String("ready"),
 				},
 			},
 			assertOutput: func(t testing.TB, options pickerOptions) {
@@ -122,18 +120,16 @@ func TestCustomDomainsPickerOptions(t *testing.T) {
 		},
 		{
 			name: "custom domains with a non-ready status",
-			customDomainsList: &management.CustomDomainList{
-				CustomDomains: []*management.CustomDomain{
-					{
-						ID:     auth0.String("some-id-1"),
-						Domain: auth0.String("some-domain-1"),
-						Status: auth0.String("pending_verification"),
-					},
-					{
-						ID:     auth0.String("some-id-2"),
-						Domain: auth0.String("some-domain-2"),
-						Status: auth0.String("ready"),
-					},
+			customDomains: []*management.CustomDomain{
+				{
+					ID:     auth0.String("some-id-1"),
+					Domain: auth0.String("some-domain-1"),
+					Status: auth0.String("pending_verification"),
+				},
+				{
+					ID:     auth0.String("some-id-2"),
+					Domain: auth0.String("some-domain-2"),
+					Status: auth0.String("ready"),
 				},
 			},
 			assertOutput: func(t testing.TB, options pickerOptions) {
@@ -148,10 +144,8 @@ func TestCustomDomainsPickerOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "no custom domains",
-			customDomainsList: &management.CustomDomainList{
-				CustomDomains: []*management.CustomDomain{},
-			},
+			name:          "no custom domains",
+			customDomains: []*management.CustomDomain{},
 			assertOutput: func(t testing.TB, options pickerOptions) {
 				t.Fail()
 			},
@@ -188,8 +182,8 @@ func TestCustomDomainsPickerOptions(t *testing.T) {
 
 			customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 			customDomainAPI.EXPECT().
-				ListWithPagination(gomock.Any(), gomock.Any()).
-				Return(test.customDomainsList, test.apiError)
+				List(gomock.Any()).
+				Return(test.customDomains, test.apiError)
 
 			cli := &cli{
 				api: &auth0.API{CustomDomain: customDomainAPI},

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -259,42 +259,24 @@ func (f *connectionResourceFetcher) FetchData(ctx context.Context) (importDataLi
 }
 
 func (f *customDomainResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
-	var (
-		data       importDataList
-		from       string
-		options    = []management.RequestOption{management.Take(100)}
-		allDomains []*management.CustomDomain
-	)
+	var data importDataList
 
-	for {
-		if from != "" {
-			options = append([]management.RequestOption{management.From(from)}, options...)
+	customDomains, err := f.api.CustomDomain.List(ctx)
+	if err != nil {
+		errNotEnabled := []string{
+			"The account is not allowed to perform this operation, please contact our support team",
+			"There must be a verified credit card on file to perform this operation",
 		}
 
-		list, err := f.api.CustomDomain.ListWithPagination(ctx, options...)
-		if err != nil {
-			errNotEnabled := []string{
-				"The account is not allowed to perform this operation, please contact our support team",
-				"There must be a verified credit card on file to perform this operation",
+		for _, e := range errNotEnabled {
+			if strings.Contains(err.Error(), e) {
+				return data, nil
 			}
-
-			for _, e := range errNotEnabled {
-				if strings.Contains(err.Error(), e) {
-					return data, nil
-				}
-			}
-			return nil, err
 		}
-
-		allDomains = append(allDomains, list.CustomDomains...)
-
-		if !list.HasNext() {
-			break
-		}
-		from = list.Next
+		return nil, err
 	}
 
-	for _, domain := range allDomains {
+	for _, domain := range customDomains {
 		data = append(data, importDataItem{
 			ResourceName: "auth0_custom_domain." + sanitizeResourceName(domain.GetDomain()),
 			ImportID:     domain.GetID(),

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -581,20 +581,19 @@ func TestCustomDomainResourceFetcher_FetchData(t *testing.T) {
 
 		customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 		customDomainAPI.EXPECT().
-			ListWithPagination(gomock.Any(), gomock.Any()).
+			List(gomock.Any()).
 			Return(
-				&management.CustomDomainList{
-					CustomDomains: []*management.CustomDomain{
-						{
-							ID:     auth0.String("cd_XDVfBNsfL2vj7Wm1"),
-							Domain: auth0.String("travel0.com"),
-						},
-						{
-							ID:     auth0.String("cd_XDVfBNsfL2vj7Wm1"),
-							Domain: auth0.String("enterprise.travel0.com"),
-						},
+				[]*management.CustomDomain{
+					{
+						ID:     auth0.String("cd_XDVfBNsfL2vj7Wm1"),
+						Domain: auth0.String("travel0.com"),
 					},
-				}, nil,
+					{
+						ID:     auth0.String("cd_XDVfBNsfL2vj7Wm1"),
+						Domain: auth0.String("enterprise.travel0.com"),
+					},
+				},
+				nil,
 			)
 
 		fetcher := customDomainResourceFetcher{
@@ -625,7 +624,7 @@ func TestCustomDomainResourceFetcher_FetchData(t *testing.T) {
 
 		customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 		customDomainAPI.EXPECT().
-			ListWithPagination(gomock.Any(), gomock.Any()).
+			List(gomock.Any()).
 			Return(nil, fmt.Errorf("failed to list custom domains"))
 
 		fetcher := customDomainResourceFetcher{
@@ -644,7 +643,7 @@ func TestCustomDomainResourceFetcher_FetchData(t *testing.T) {
 
 		customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 		customDomainAPI.EXPECT().
-			ListWithPagination(gomock.Any(), gomock.Any()).
+			List(gomock.Any()).
 			Return(nil, fmt.Errorf("403 Forbidden: The account is not allowed to perform this operation, please contact our support team"))
 
 		fetcher := customDomainResourceFetcher{
@@ -664,7 +663,7 @@ func TestCustomDomainResourceFetcher_FetchData(t *testing.T) {
 
 		customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 		customDomainAPI.EXPECT().
-			ListWithPagination(gomock.Any(), gomock.Any()).
+			List(gomock.Any()).
 			Return(nil, fmt.Errorf("403 Forbidden: There must be a verified credit card on file to perform this operation"))
 
 		fetcher := customDomainResourceFetcher{

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -370,7 +370,7 @@ func selectClientToUseForTestsAndValidateExistence(cli *cli, cmd *cobra.Command,
 func (c *cli) customDomainPickerOptions(ctx context.Context) (pickerOptions, error) {
 	var opts pickerOptions
 
-	domains, err := c.ListAllCustomDomains(ctx)
+	domains, err := c.api.CustomDomain.List(ctx)
 	if err != nil {
 		errStatus := err.(management.Error)
 		// 403 is a valid response for free tenants that don't have

--- a/internal/cli/universal_login_templates.go
+++ b/internal/cli/universal_login_templates.go
@@ -264,44 +264,17 @@ func (cli *cli) fetchTemplateData(ctx context.Context) (*TemplateData, error) {
 }
 
 func ensureCustomDomainIsEnabled(ctx context.Context, api *auth0.API) error {
-	var (
-		from         string
-		allDomains   []*management.CustomDomain
-		options      = []management.RequestOption{management.Take(100)}
-		customDomain *management.CustomDomainList
-		err          error
-	)
-
-	for {
-		reqOptions := append([]management.RequestOption{}, options...)
-		if from != "" {
-			reqOptions = append(reqOptions, management.From(from))
-		}
-
-		customDomain, err = api.CustomDomain.ListWithPagination(ctx, reqOptions...)
-		if err != nil {
-			break
-		}
-
-		allDomains = append(allDomains, customDomain.CustomDomains...)
-
-		if !customDomain.HasNext() {
-			break
-		}
-
-		from = customDomain.Next
-	}
-
+	domains, err := api.CustomDomain.List(ctx)
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusForbidden {
-			return errNotAllowed // 403 is expected for tenants without custom domain support.
+			return errNotAllowed // 403 is a valid response for free tenants that don't have custom domains enabled.
 		}
 
 		return err
 	}
 
 	const domainIsVerified = "ready"
-	for _, domain := range allDomains {
+	for _, domain := range domains {
 		if domain.GetStatus() == domainIsVerified {
 			return nil
 		}

--- a/internal/cli/universal_login_templates_test.go
+++ b/internal/cli/universal_login_templates_test.go
@@ -79,8 +79,8 @@ func TestEnsureCustomDomainIsEnabled(t *testing.T) {
 
 			customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 			customDomainAPI.EXPECT().
-				ListWithPagination(gomock.Any(), gomock.Any()).
-				Return(&management.CustomDomainList{CustomDomains: test.customDomain}, test.apiError)
+				List(gomock.Any()).
+				Return(test.customDomain, test.apiError)
 
 			ctx := context.Background()
 			api := &auth0.API{CustomDomain: customDomainAPI}
@@ -216,7 +216,7 @@ func TestFetchTemplateData(t *testing.T) {
 		name           string
 		brandingUL     *management.BrandingUniversalLogin
 		clients        []*management.Client
-		customDomain   []*management.CustomDomain
+		customDomain   *management.CustomDomain
 		prompt         *management.Prompt
 		tenant         *management.Tenant
 		clientAPIError management.Error
@@ -242,10 +242,8 @@ func TestFetchTemplateData(t *testing.T) {
 					LogoURI:  auth0.String("https://example.com/logo-2.png"),
 				},
 			},
-			customDomain: []*management.CustomDomain{
-				{
-					Status: auth0.String("ready"),
-				},
+			customDomain: &management.CustomDomain{
+				Status: auth0.String("ready"),
 			},
 			prompt: &management.Prompt{
 				UniversalLoginExperience: "classic",
@@ -274,10 +272,8 @@ func TestFetchTemplateData(t *testing.T) {
 		},
 		{
 			name: "client api error",
-			customDomain: []*management.CustomDomain{
-				{
-					Status: auth0.String("ready"),
-				},
+			customDomain: &management.CustomDomain{
+				Status: auth0.String("ready"),
 			},
 			prompt: &management.Prompt{
 				UniversalLoginExperience: "",
@@ -302,10 +298,8 @@ func TestFetchTemplateData(t *testing.T) {
 					LogoURI:  auth0.String(""),
 				},
 			},
-			customDomain: []*management.CustomDomain{
-				{
-					Status: auth0.String("ready"),
-				},
+			customDomain: &management.CustomDomain{
+				Status: auth0.String("ready"),
 			},
 			tenant: &management.Tenant{
 				FriendlyName: auth0.String(""),
@@ -327,10 +321,8 @@ func TestFetchTemplateData(t *testing.T) {
 					LogoURI:  auth0.String(""),
 				},
 			},
-			customDomain: []*management.CustomDomain{
-				{
-					Status: auth0.String("ready"),
-				},
+			customDomain: &management.CustomDomain{
+				Status: auth0.String("ready"),
 			},
 			prompt: &management.Prompt{
 				UniversalLoginExperience: "",
@@ -374,8 +366,8 @@ func TestFetchTemplateData(t *testing.T) {
 
 			customDomainAPI := mock.NewMockCustomDomainAPI(ctrl)
 			customDomainAPI.EXPECT().
-				ListWithPagination(gomock.Any(), gomock.Any()).
-				Return(&management.CustomDomainList{CustomDomains: test.customDomain}, nil).
+				List(gomock.Any()).
+				Return([]*management.CustomDomain{test.customDomain}, nil).
 				Do(func(ctx context.Context, opts ...management.RequestOption) {
 					defer wg.Done()
 				})


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

retrieve custom domains in the Auth0 CLI to use the LIST endpoint instead of ListWithPagination.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Closes - https://github.com/auth0/auth0-cli/issues/1304

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
