### PR TITLE
Add changelog for v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+# [v.1.17.1](https://github.com/auth0/auth0-cli/tree/v1.17.1) (August 12, 2025)
+
+[Full Changelog](https://github.com/auth0/auth0-cli/compare/v1.17.0...v1.17.1)
+
+### Fixed
+- Updated custom domain retrieval to use the `LIST` endpoint instead of `ListWithPagination`. [#1306]
+
+
 # [v.1.17.0](https://github.com/auth0/auth0-cli/tree/v1.17.0) (August 07, 2025)
 
 [Full Changelog](https://github.com/auth0/auth0-cli/compare/v1.16.0...v1.17.0)
@@ -538,6 +546,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [unreleased]: https://github.com/auth0/auth0-cli/compare/v1.17.0...HEAD
+[1306]: https://github.com/auth0/auth0-cli/issues/1306
 [1283]: https://github.com/auth0/auth0-cli/issues/1283
 [1280]: https://github.com/auth0/auth0-cli/issues/1280
 [#1268]: https://github.com/auth0/auth0-cli/issues/1268


### PR DESCRIPTION
### Fixed

- Updated custom domain retrieval to use the `LIST` endpoint instead of `ListWithPagination`. [#1306]
