### PR TITLE
fix: update integration test script to reflect new events naming convention

### DIFF
--- a/test/integration/scripts/test-cleanup.sh
+++ b/test/integration/scripts/test-cleanup.sh
@@ -29,7 +29,7 @@ delete_resources "roles" "integration-test-role" "id"
 delete_resources "rules" "integration-test-rule" "id"
 delete_resources "orgs" "integration-test-org" "id"
 delete_resources "actions" "integration-test-" "id"
-delete_resources "events" "integration-test-" "id"
+delete_resources "event-streams" "integration-test-" "id"
 delete_resources "logs streams" "integration-test-" "id"
 
 auth0 domains delete $(./test/integration/scripts/get-custom-domain-id.sh) --no-input


### PR DESCRIPTION
`auth0 events` have been modified to `auth0 event-streams` 
Updated the integration test script to reflect the same.