### PR TITLE
Fix tenant scope validation causing unnecessary re-authentication

### DIFF
--- a/internal/config/tenant.go
+++ b/internal/config/tenant.go
@@ -44,8 +44,8 @@ type (
 	}
 )
 
-// GetMissingRequiredScopes returns a slice of missing required scopes.
-// Returns empty slice if all required scopes are present
+// GetMissingRequiredScopes returns a slice of required scopes
+// that are missing from the tenant's current scopes.
 func (t *Tenant) GetMissingRequiredScopes() []string {
 	var missingScopes []string
 	for _, requiredScope := range auth.RequiredScopes {

--- a/internal/config/tenant.go
+++ b/internal/config/tenant.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/auth0/auth0-cli/internal/auth"
@@ -42,6 +43,19 @@ type (
 		ClientID     string    `json:"client_id"`
 	}
 )
+
+// GetMissingRequiredScopes returns a slice of missing required scopes.
+// Returns empty slice if all required scopes are present
+func (t *Tenant) GetMissingRequiredScopes() []string {
+	var missingScopes []string
+	for _, requiredScope := range auth.RequiredScopes {
+		if !slices.Contains(t.Scopes, requiredScope) {
+			missingScopes = append(missingScopes, requiredScope)
+		}
+	}
+
+	return missingScopes
+}
 
 // GetExtraRequestedScopes retrieves any extra scopes requested
 // for the tenant when logging in through the device code flow.
@@ -96,8 +110,8 @@ func (t *Tenant) GetAccessToken() string {
 // CheckAuthenticationStatus checks to see if the tenant in the config
 // has all the required scopes and that the access token is not expired.
 func (t *Tenant) CheckAuthenticationStatus() error {
-	if extraScopes := t.GetExtraRequestedScopes(); len(extraScopes) > 0 && t.IsAuthenticatedWithDeviceCodeFlow() {
-		return ErrTokenMissingRequiredScopes{MissingScopes: extraScopes}
+	if missingScopes := t.GetMissingRequiredScopes(); len(missingScopes) > 0 && t.IsAuthenticatedWithDeviceCodeFlow() {
+		return ErrTokenMissingRequiredScopes{MissingScopes: missingScopes}
 	}
 
 	accessToken := t.GetAccessToken()


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fixed unnecessary re-authentication bug in CLI v1.20.0 caused by scope validation logic

- **Root Cause**: The authentication flow was correctly identifying missing scopes but inappropriately triggering re-authentication for device code flow users even when they had valid tokens with proper scopes
- **Fix**: Corrected the scope validation logic to properly handle cases where users have legitimate access tokens.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

**User Report**:  CLI v1.20.0 requires re-authentication on every command with message: "Required scopes have changed (missing: create:client_grants, delete:client_grants). Please log in to re-authorize the CLI"
Regression: This behavior was not present in v1.15.0

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
