### PR TITLE
fix: `auth apis create` subject type authorization validation

### DIFF
--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -295,7 +295,7 @@ func createAPICmd(cli *cli) *cobra.Command {
 				api.TokenLifetime = auth0.Int(inputs.TokenLifetime)
 			}
 
-			if inputs.SubjectTypeAuthorization != "{}" {
+			if inputs.SubjectTypeAuthorization != "{}" && inputs.SubjectTypeAuthorization != "" {
 				var subjectTypeAuth management.ResourceServerSubjectTypeAuthorization
 				if err := json.Unmarshal([]byte(inputs.SubjectTypeAuthorization), &subjectTypeAuth); err != nil {
 					return fmt.Errorf("invalid JSON for subject-type-authorization: %w", err)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fix `auth apis create` subject type authorization default value validation

```sh
auth0 apis create
=== <tenant-domain> error

 ▸    Invalid JSON for subject-type-authorization: unexpected end of JSON input.
```

### 📚 References
- https://github.com/auth0/auth0-cli/pull/1315
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing
Test pass - ✅ 
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
