### PR TITLE
feat: add client_id_metadata_document_supported tenant settings support

### DIFF
--- a/internal/cli/tenant_settings.go
+++ b/internal/cli/tenant_settings.go
@@ -239,6 +239,8 @@ func setSelectTenantSettings(tenant *management.Tenant, selectedFlags []string, 
 			tenant.AllowOrgNameInAuthAPI = val
 		case "pushed_authorization_requests_supported", "PushedAuthorizationRequestsSupported":
 			tenant.PushedAuthorizationRequestsSupported = val
+		case "client_id_metadata_document_supported", "ClientIDMetadataDocumentSupported":
+			tenant.ClientIDMetadataDocumentSupported = val
 		case "oidc_logout.rp_logout_end_session_endpoint_discovery", "OIDCLogout.RPLogoutEndSessionEndpointDiscovery":
 			if tenant.OIDCLogout == nil {
 				tenant.OIDCLogout = &management.TenantOIDCLogout{}

--- a/internal/display/tenant-settings.go
+++ b/internal/display/tenant-settings.go
@@ -35,6 +35,7 @@ var SupportedTenantSettings = map[string]string{
 	"CustomizeMFAInPostLoginAction":                  "customize_mfa_in_postlogin_action",
 	"AllowOrgNameInAuthAPI":                          "allow_organization_name_in_authentication_api",
 	"PushedAuthorizationRequestsSupported":           "pushed_authorization_requests_supported",
+	"ClientIDMetadataDocumentSupported":              "client_id_metadata_document_supported",
 	"OIDCLogout.RPLogoutEndSessionEndpointDiscovery": "oidc_logout.rp_logout_end_session_endpoint_discovery",
 	"MTLS.EnableEndpointAliases":                     "mtls.enable_endpoint_aliases",
 }
@@ -155,6 +156,8 @@ func makeTenantSettings(tenant *management.Tenant) []View {
 			addSetting(settingName, friendlyFlagName, tenant.AllowOrgNameInAuthAPI)
 		case "PushedAuthorizationRequestsSupported":
 			addSetting(settingName, friendlyFlagName, tenant.PushedAuthorizationRequestsSupported)
+		case "ClientIDMetadataDocumentSupported":
+			addSetting(settingName, friendlyFlagName, tenant.ClientIDMetadataDocumentSupported)
 		case "OIDCLogout.RPLogoutEndSessionEndpointDiscovery":
 			if tenant.OIDCLogout != nil {
 				addSetting(settingName, friendlyFlagName, tenant.OIDCLogout.OIDCResourceProviderLogoutEndSessionEndpointDiscovery)

--- a/test/integration/tenant-settings-test-cases.yaml
+++ b/test/integration/tenant-settings-test-cases.yaml
@@ -24,6 +24,7 @@ tests:
         - DisableManagementAPISMSObfuscation    flags.disable_management_api_sms_obfuscation   ✗
         - AllowOrgNameInAuthAPI                 allow_organization_name_in_authentication_api  ✗
         - PushedAuthorizationRequestsSupported  pushed_authorization_requests_supported        ✗
+        - ClientIDMetadataDocumentSupported     client_id_metadata_document_supported           ✗
         - EnableLegacyLogsSearchV2              flags.enable_legacy_logs_search_v2             ✗
         - EnableLegacyProfile                   flags.enable_legacy_profile                    ✗
         - EnableCustomDomainInEmails            flags.enable_custom_domain_in_emails           ✗
@@ -68,6 +69,7 @@ tests:
         - EnableADFSWAADEmailVerification       flags.enable_adfs_waad_email_verification      ✗
         - CustomizeMFAInPostLoginAction         customize_mfa_in_postlogin_action              ✗
         - PushedAuthorizationRequestsSupported  pushed_authorization_requests_supported        ✗
+        - ClientIDMetadataDocumentSupported     client_id_metadata_document_supported           ✗
         - EnableAPIsSection                     flags.enable_apis_section                      ✗
         - DisableClickjackProtectionHeaders     flags.disable_clickjack_protection_headers     ✗
         - UseScopeDescriptionsForConsent        flags.use_scope_descriptions_for_consent       ✗
@@ -103,6 +105,7 @@ tests:
         - EnableADFSWAADEmailVerification       flags.enable_adfs_waad_email_verification      ✗
         - CustomizeMFAInPostLoginAction         customize_mfa_in_postlogin_action              ✗
         - PushedAuthorizationRequestsSupported  pushed_authorization_requests_supported        ✗
+        - ClientIDMetadataDocumentSupported     client_id_metadata_document_supported           ✗
         - EnableAPIsSection                     flags.enable_apis_section                      ✗
         - DisableClickjackProtectionHeaders     flags.disable_clickjack_protection_headers     ✗
         - UseScopeDescriptionsForConsent        flags.use_scope_descriptions_for_consent       ✗


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Added support for the `client_id_metadata_document_supported` tenant setting to the `auth0 tenant-settings` command.

**Changes made:**

- **internal/display/tenant-settings.go**
  - Added `"ClientIDMetadataDocumentSupported": "client_id_metadata_document_supported"` to the `SupportedTenantSettings` map
  - Added case handler in `makeTenantSettings()` to display the new setting

- **internal/cli/tenant_settings.go**
  - Added case handler in `setSelectTenantSettings()` function to support both friendly name (`client_id_metadata_document_supported`) and struct name (`ClientIDMetadataDocumentSupported`)
  - Enables users to enable/disable this setting via `auth0 tenant-settings update set` and `auth0 tenant-settings update unset` commands

- **test/integration/tenant-settings-test-cases.yaml**
  - Added test assertions for the new setting in all three test scenarios (show, set, unset)

The new setting is now fully integrated and works consistently with existing tenant settings, supporting both interactive and non-interactive command modes.

### 📚 References

This feature is being added to better support the upcoming Manual CIMD rollout, and will be referenced in the MCP Tenant Settings quickstarts.
https://github.com/auth0-samples/auth0-ai-samples/tree/main/auth-for-mcp/fastmcp-mcp-js#auth0-tenant-setup 

### 🔬 Testing

Tested this to work locally against a DEV tenant today. Some screenshots:

`auth0 tenant-settings show` :
<img width="850" height="647" alt="Screenshot 2026-04-14 at 4 37 26 PM" src="https://github.com/user-attachments/assets/fa1853e5-04dc-4b5f-b191-324a79e70fa7" />

`auth0 tenant-settings update unset` (or `auth0 tenant-settings update unset client_id_metadata_document_supported`):
<img width="882" height="541" alt="Screenshot 2026-04-14 at 4 38 16 PM" src="https://github.com/user-attachments/assets/20cf7c92-5aed-4aba-b7b8-b778efb8e737" />


(validated setting disabled in tenant):
<img width="1529" height="1165" alt="Screenshot 2026-04-14 at 4 38 04 PM" src="https://github.com/user-attachments/assets/5461973d-447c-441d-b514-b66a01463f62" />

`auth0 tenant-settings update set client_id_metadata_document_supported`:
<img width="859" height="514" alt="Screenshot 2026-04-14 at 4 38 57 PM" src="https://github.com/user-attachments/assets/481a4920-7938-4b94-8a92-c59976acb339" />

(validated setting enabled in tenant):
<img width="1529" height="1165" alt="Screenshot 2026-04-14 at 4 38 47 PM" src="https://github.com/user-attachments/assets/622819db-b27c-45b2-a6e8-a76c325a1885" />


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

