### PR TITLE
Support cimd clients in terrafrom generate

### DIFF
--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -202,7 +202,6 @@ func (f *clientResourceFetcher) FetchData(ctx context.Context) (importDataList, 
 		}
 
 		for _, client := range clients.Clients {
-
 			if client.GetExternalMetadataType() == "cimd" {
 				data = append(data, importDataItem{
 					ResourceName: "auth0_client_cimd." + sanitizeResourceName(client.GetName()),

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -195,17 +195,25 @@ func (f *clientResourceFetcher) FetchData(ctx context.Context) (importDataList, 
 			ctx,
 			management.Page(page),
 			management.Parameter("is_global", "false"),
-			management.IncludeFields("client_id", "name"),
+			management.IncludeFields("client_id", "name", "external_metadata_type"),
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, client := range clients.Clients {
-			data = append(data, importDataItem{
-				ResourceName: "auth0_client." + sanitizeResourceName(client.GetName()),
-				ImportID:     client.GetClientID(),
-			})
+
+			if client.GetExternalMetadataType() == "cimd" {
+				data = append(data, importDataItem{
+					ResourceName: "auth0_client_cimd." + sanitizeResourceName(client.GetName()),
+					ImportID:     client.GetClientID(),
+				})
+			} else {
+				data = append(data, importDataItem{
+					ResourceName: "auth0_client." + sanitizeResourceName(client.GetName()),
+					ImportID:     client.GetClientID(),
+				})
+			}
 
 			data = append(data, importDataItem{
 				ResourceName: "auth0_client_credentials." + sanitizeResourceName(client.GetName()),

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -402,6 +402,112 @@ func TestClientResourceFetcher_FetchData(t *testing.T) {
 		assert.Equal(t, expectedData, data)
 	})
 
+	t.Run("it successfully retrieves cimd client data with auth0_client_cimd resource name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clientAPI := mock.NewMockClientAPI(ctrl)
+		clientAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.ClientList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 2,
+					},
+					Clients: []*management.Client{
+						{
+							ClientID:             auth0.String("clientID_cimd_1"),
+							Name:                 auth0.String("My CIMD Client"),
+							ExternalMetadataType: auth0.String("cimd"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := clientResourceFetcher{
+			api: &auth0.API{
+				Client: clientAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_client_cimd.my_cimd_client",
+				ImportID:     "clientID_cimd_1",
+			},
+			{
+				ResourceName: "auth0_client_credentials.my_cimd_client",
+				ImportID:     "clientID_cimd_1",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
+	t.Run("it successfully retrieves mixed regular and cimd client data", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clientAPI := mock.NewMockClientAPI(ctrl)
+		clientAPI.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(
+				&management.ClientList{
+					List: management.List{
+						Start: 0,
+						Limit: 2,
+						Total: 2,
+					},
+					Clients: []*management.Client{
+						{
+							ClientID: auth0.String("clientID_1"),
+							Name:     auth0.String("Regular Client"),
+						},
+						{
+							ClientID:             auth0.String("clientID_2"),
+							Name:                 auth0.String("CIMD Client"),
+							ExternalMetadataType: auth0.String("cimd"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := clientResourceFetcher{
+			api: &auth0.API{
+				Client: clientAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_client.regular_client",
+				ImportID:     "clientID_1",
+			},
+			{
+				ResourceName: "auth0_client_credentials.regular_client",
+				ImportID:     "clientID_1",
+			},
+			{
+				ResourceName: "auth0_client_cimd.cimd_client",
+				ImportID:     "clientID_2",
+			},
+			{
+				ResourceName: "auth0_client_credentials.cimd_client",
+				ImportID:     "clientID_2",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
+
 	t.Run("it returns an error if api call fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds CIMD (Customer Identity Management for Developers) client support to the Terraform resource fetcher.

- Updates `clientResourceFetcher.FetchData` to distinguish CIMD clients from regular clients based on `ExternalMetadataType`
- CIMD clients are now exported as `auth0_client_cimd.` resources instead of `auth0_client.`
- Includes `external_metadata_type` in the API field list to support the branching logic
- Regular clients and `auth0_client_credentials` resources remain unchanged
- When using `--resources auth0_client`, both `auth0_client` and `auth0_client_cimd` resources are generated. CIMD clients are automatically detected and mapped to the `auth0_client_cimd` Terraform resource type.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

DXCDT-1604

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Added unit tests for CIMD-only client fetching and mixed (regular + CIMD) client fetching
- All 4 subtests in `TestClientResourceFetcher_FetchData` pass
- Manually tested the `terraform generate` import functionality with mixed client types

```bash
go test -run TestClientResourceFetcher_FetchData ./internal/cli/...
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
