### PR TITLE
Support for On-behalf-of Token Exchange

### DIFF
--- a/docs/auth0_apis_create.md
+++ b/docs/auth0_apis_create.md
@@ -19,7 +19,7 @@ auth0 apis create [flags]
 ## Examples
 
 ```
-  auth0 apis create 
+  auth0 apis create
   auth0 apis create --name myapi
   auth0 apis create --name myapi --identifier http://my-api
   auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100
@@ -29,12 +29,14 @@ auth0 apis create [flags]
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json-compact
   auth0 apis create --name myapi --identifier http://my-api --subject-type-authorization '{"user":{"policy":"allow_all"},"client":{"policy":"deny_all"}}'
+  auth0 apis create --name myapi --identifier http://my-api --enforce-policies --token-dialect access_token_authz
 ```
 
 
 ## Flags
 
 ```
+      --enforce-policies                    If true, authorization policies will be enforced for this API.
   -i, --identifier string                   Identifier of the API. Cannot be changed once set.
       --json                                Output in json format.
       --json-compact                        Output in compact json format.
@@ -43,6 +45,7 @@ auth0 apis create [flags]
   -s, --scopes strings                      Comma-separated list of scopes (permissions).
       --signing-alg string                  Algorithm used to sign JWTs. Can be HS256 or RS256. PS256 available via addon. (default "RS256")
       --subject-type-authorization string   JSON object defining access policies for user and client flows. Example: '{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}}' (default "{}")
+      --token-dialect string                Dialect of access tokens for this API. Can be one of access_token, access_token_authz, rfc9068_profile, or rfc9068_profile_authz.
   -l, --token-lifetime int                  The amount of time in seconds that the token will be valid after being issued. Default value is 86400 seconds (1 day).
 ```
 

--- a/docs/auth0_apis_update.md
+++ b/docs/auth0_apis_update.md
@@ -19,7 +19,7 @@ auth0 apis update [flags]
 ## Examples
 
 ```
-  auth0 apis update 
+  auth0 apis update
   auth0 apis update <api-id|api-audience>
   auth0 apis update <api-id|api-audience> --name myapi
   auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100
@@ -28,12 +28,14 @@ auth0 apis update [flags]
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json-compact
   auth0 apis update <api-id|api-audience> --subject-type-authorization '{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}}'
+  auth0 apis update <api-id|api-audience> --enforce-policies=false --token-dialect rfc9068_profile_authz
 ```
 
 
 ## Flags
 
 ```
+      --enforce-policies                    If true, authorization policies will be enforced for this API.
       --json                                Output in json format.
       --json-compact                        Output in compact json format.
   -n, --name string                         Name of the API.
@@ -41,6 +43,7 @@ auth0 apis update [flags]
   -s, --scopes strings                      Comma-separated list of scopes (permissions).
       --signing-alg string                  Algorithm used to sign JWTs. Can be HS256 or RS256. PS256 available via addon. (default "RS256")
       --subject-type-authorization string   JSON object defining access policies for user and client flows. Example: '{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}}' (default "{}")
+      --token-dialect string                Dialect of access tokens for this API. Can be one of access_token, access_token_authz, rfc9068_profile, or rfc9068_profile_authz.
   -l, --token-lifetime int                  The amount of time in seconds that the token will be valid after being issued. Default value is 86400 seconds (1 day).
 ```
 

--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -20,7 +20,7 @@ auth0 apps create [flags]
 
 ```
   auth0 apps create
-  auth0 apps create --name myapp 
+  auth0 apps create --name myapp
   auth0 apps create --name myapp --description <description>
   auth0 apps create --name myapp --description <description> --type [native|spa|regular|m2m|resource_server]
   auth0 apps create --name myapp --description <description> --type [native|spa|regular|m2m|resource_server] --reveal-secrets
@@ -30,12 +30,14 @@ auth0 apps create [flags]
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
+  auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
 ```
 
 
 ## Flags
 
 ```
+  -p, --allow-any-profile-of-type strings   Comma-separated list of enabled token exchange types for this client. Possible values: custom_authentication, on_behalf_of_token_exchange.
   -a, --auth-method string                  Defines the requested authentication method for the token endpoint. Possible values are 'None' (public application without a client secret), 'Post' (application uses HTTP POST parameters) or 'Basic' (application uses HTTP Basic).
   -c, --callbacks strings                   After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
   -d, --description string                  Description of the application. Max character count is 140.

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -29,30 +29,32 @@ auth0 apps update [flags]
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
+  auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
 ```
 
 
 ## Flags
 
 ```
-  -a, --auth-method string        Defines the requested authentication method for the token endpoint. Possible values are 'None' (public application without a client secret), 'Post' (application uses HTTP POST parameters) or 'Basic' (application uses HTTP Basic).
-  -c, --callbacks strings         After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
-  -d, --description string        Description of the application. Max character count is 140.
-  -g, --grants strings            List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
-      --json                      Output in json format.
-      --json-compact              Output in compact json format.
-  -l, --logout-urls strings       Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.
-      --metadata stringToString   Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
-  -n, --name string               Name of the application.
-  -o, --origins strings           Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
-  -z, --refresh-token string      Refresh Token Config for the application, formatted as JSON.
-  -r, --reveal-secrets            Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
-  -t, --type string               Type of application:
-                                  - native: mobile, desktop, CLI and smart device apps running natively.
-                                  - spa (single page application): a JavaScript front-end app that uses an API.
-                                  - regular: Traditional web app using redirects.
-                                  - m2m (machine to machine): CLIs, daemons or services running on your backend.
-  -w, --web-origins strings       Comma-separated list of allowed origins for use with Cross-Origin Authentication, Device Flow, and web message response mode.
+  -p, --allow-any-profile-of-type strings   Comma-separated list of enabled token exchange types for this client. Possible values: custom_authentication, on_behalf_of_token_exchange.
+  -a, --auth-method string                  Defines the requested authentication method for the token endpoint. Possible values are 'None' (public application without a client secret), 'Post' (application uses HTTP POST parameters) or 'Basic' (application uses HTTP Basic).
+  -c, --callbacks strings                   After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
+  -d, --description string                  Description of the application. Max character count is 140.
+  -g, --grants strings                      List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
+      --json                                Output in json format.
+      --json-compact                        Output in compact json format.
+  -l, --logout-urls strings                 Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.
+      --metadata stringToString             Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
+  -n, --name string                         Name of the application.
+  -o, --origins strings                     Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
+  -z, --refresh-token string                Refresh Token Config for the application, formatted as JSON.
+  -r, --reveal-secrets                      Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
+  -t, --type string                         Type of application:
+                                            - native: mobile, desktop, CLI and smart device apps running natively.
+                                            - spa (single page application): a JavaScript front-end app that uses an API.
+                                            - regular: Traditional web app using redirects.
+                                            - m2m (machine to machine): CLIs, daemons or services running on your backend.
+  -w, --web-origins strings                 Comma-separated list of allowed origins for use with Cross-Origin Authentication, Device Flow, and web message response mode.
 ```
 
 

--- a/internal/cli/apis.go
+++ b/internal/cli/apis.go
@@ -74,6 +74,27 @@ var (
 		LongForm: "subject-type-authorization",
 		Help:     "JSON object defining access policies for user and client flows. Example: '{\"user\":{\"policy\":\"require_client_grant\"},\"client\":{\"policy\":\"deny_all\"}}'",
 	}
+	apiEnforcePolicies = Flag{
+		Name:     "Enforce Policies",
+		LongForm: "enforce-policies",
+		Help:     "If true, authorization policies will be enforced for this API.",
+	}
+	apiTokenDialect = Flag{
+		Name:     "Token Dialect",
+		LongForm: "token-dialect",
+		Help:     "Dialect of access tokens for this API. Can be one of access_token, access_token_authz, rfc9068_profile, or rfc9068_profile_authz.",
+	}
+)
+
+var (
+	apiTokenDialectNone    = "<NONE>"
+	apiTokenDialectOptions = []string{
+		apiTokenDialectNone,
+		"access_token",
+		"access_token_authz",
+		"rfc9068_profile",
+		"rfc9068_profile_authz",
+	}
 )
 
 func apisCmd(cli *cli) *cobra.Command {
@@ -227,6 +248,8 @@ func createAPICmd(cli *cli) *cobra.Command {
 		AllowOfflineAccess       bool
 		SigningAlgorithm         string
 		SubjectTypeAuthorization string
+		EnforcePolicies          bool
+		TokenDialect             string
 	}
 
 	cmd := &cobra.Command{
@@ -237,7 +260,7 @@ func createAPICmd(cli *cli) *cobra.Command {
 			"To create interactively, use `auth0 apis create` with no flags.\n\n" +
 			"To create non-interactively, supply the name, identifier, scopes, " +
 			"token lifetime and whether to allow offline access through the flags.",
-		Example: `  auth0 apis create 
+		Example: `  auth0 apis create
   auth0 apis create --name myapi
   auth0 apis create --name myapi --identifier http://my-api
   auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100
@@ -246,7 +269,8 @@ func createAPICmd(cli *cli) *cobra.Command {
   auth0 apis create --name myapi --identifier http://my-api --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read" --signing-alg "RS256"
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json
   auth0 apis create -n myapi -i http://my-api -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json-compact
-  auth0 apis create --name myapi --identifier http://my-api --subject-type-authorization '{"user":{"policy":"allow_all"},"client":{"policy":"deny_all"}}'`,
+  auth0 apis create --name myapi --identifier http://my-api --subject-type-authorization '{"user":{"policy":"allow_all"},"client":{"policy":"deny_all"}}'
+  auth0 apis create --name myapi --identifier http://my-api --enforce-policies --token-dialect access_token_authz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := apiName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -277,12 +301,17 @@ func createAPICmd(cli *cli) *cobra.Command {
 				return err
 			}
 
+			if err := apiEnforcePolicies.AskBool(cmd, &inputs.EnforcePolicies, nil); err != nil {
+				return err
+			}
+
 			api := &management.ResourceServer{
 				Name:               &inputs.Name,
 				Identifier:         &inputs.Identifier,
 				AllowOfflineAccess: &inputs.AllowOfflineAccess,
 				TokenLifetime:      &inputs.TokenLifetime,
 				SigningAlgorithm:   &inputs.SigningAlgorithm,
+				EnforcePolicies:    &inputs.EnforcePolicies,
 			}
 
 			if len(inputs.Scopes) > 0 {
@@ -301,6 +330,14 @@ func createAPICmd(cli *cli) *cobra.Command {
 					return fmt.Errorf("invalid JSON for subject-type-authorization: %w", err)
 				}
 				api.SubjectTypeAuthorization = &subjectTypeAuth
+			}
+
+			if err := apiTokenDialect.Select(cmd, &inputs.TokenDialect, apiTokenDialectOptions, nil); err != nil {
+				return err
+			}
+
+			if inputs.TokenDialect != "" && inputs.TokenDialect != apiTokenDialectNone {
+				api.TokenDialect = &inputs.TokenDialect
 			}
 
 			if err := ansi.Waiting(func() error {
@@ -329,6 +366,8 @@ func createAPICmd(cli *cli) *cobra.Command {
 	apiTokenLifetime.RegisterInt(cmd, &inputs.TokenLifetime, 0)
 	apiSigningAlgorithm.RegisterString(cmd, &inputs.SigningAlgorithm, "RS256")
 	apiSubjectTypeAuthorization.RegisterString(cmd, &inputs.SubjectTypeAuthorization, "{}")
+	apiEnforcePolicies.RegisterBool(cmd, &inputs.EnforcePolicies, false)
+	apiTokenDialect.RegisterString(cmd, &inputs.TokenDialect, "")
 
 	return cmd
 }
@@ -342,6 +381,8 @@ func updateAPICmd(cli *cli) *cobra.Command {
 		AllowOfflineAccess       bool
 		SigningAlgorithm         string
 		SubjectTypeAuthorization string
+		EnforcePolicies          bool
+		TokenDialect             string
 	}
 
 	cmd := &cobra.Command{
@@ -352,7 +393,7 @@ func updateAPICmd(cli *cli) *cobra.Command {
 			"To update interactively, use `auth0 apis update` with no arguments.\n\n" +
 			"To update non-interactively, supply the name, identifier, scopes, " +
 			"token lifetime and whether to allow offline access through the flags.",
-		Example: `  auth0 apis update 
+		Example: `  auth0 apis update
   auth0 apis update <api-id|api-audience>
   auth0 apis update <api-id|api-audience> --name myapi
   auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100
@@ -360,7 +401,8 @@ func updateAPICmd(cli *cli) *cobra.Command {
   auth0 apis update <api-id|api-audience> --name myapi --token-lifetime 6100 --offline-access=false --scopes "letter:write,letter:read" --signing-alg "RS256"
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json
   auth0 apis update <api-id|api-audience> -n myapi -t 6100 -o false -s "letter:write,letter:read" --signing-alg "RS256" --json-compact
-  auth0 apis update <api-id|api-audience> --subject-type-authorization '{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}}'`,
+  auth0 apis update <api-id|api-audience> --subject-type-authorization '{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}}'
+  auth0 apis update <api-id|api-audience> --enforce-policies=false --token-dialect rfc9068_profile_authz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				if err := apiID.Pick(cmd, &inputs.ID, cli.apiPickerOptions); err != nil {
@@ -399,7 +441,19 @@ func updateAPICmd(cli *cli) *cobra.Command {
 				return err
 			}
 
+			if !apiEnforcePolicies.IsSet(cmd) {
+				inputs.EnforcePolicies = current.GetEnforcePolicies()
+			}
+
+			if err := apiEnforcePolicies.AskBoolU(cmd, &inputs.EnforcePolicies, current.EnforcePolicies); err != nil {
+				return err
+			}
+
 			if err := apiSigningAlgorithm.AskU(cmd, &inputs.SigningAlgorithm, current.SigningAlgorithm); err != nil {
+				return err
+			}
+
+			if err := apiTokenDialect.SelectU(cmd, &inputs.TokenDialect, apiTokenDialectOptions, current.TokenDialect); err != nil {
 				return err
 			}
 
@@ -417,6 +471,7 @@ func updateAPICmd(cli *cli) *cobra.Command {
 
 			api := &management.ResourceServer{
 				AllowOfflineAccess: &inputs.AllowOfflineAccess,
+				EnforcePolicies:    &inputs.EnforcePolicies,
 			}
 
 			api.Name = current.Name
@@ -437,6 +492,10 @@ func updateAPICmd(cli *cli) *cobra.Command {
 			api.SigningAlgorithm = current.SigningAlgorithm
 			if inputs.SigningAlgorithm != "" {
 				api.SigningAlgorithm = &inputs.SigningAlgorithm
+			}
+
+			if inputs.TokenDialect != "" && inputs.TokenDialect != apiTokenDialectNone {
+				api.TokenDialect = &inputs.TokenDialect
 			}
 
 			api.SubjectTypeAuthorization = current.SubjectTypeAuthorization
@@ -468,6 +527,8 @@ func updateAPICmd(cli *cli) *cobra.Command {
 	apiTokenLifetime.RegisterIntU(cmd, &inputs.TokenLifetime, 0)
 	apiSigningAlgorithm.RegisterStringU(cmd, &inputs.SigningAlgorithm, "RS256")
 	apiSubjectTypeAuthorization.RegisterStringU(cmd, &inputs.SubjectTypeAuthorization, "{}")
+	apiEnforcePolicies.RegisterBoolU(cmd, &inputs.EnforcePolicies, false)
+	apiTokenDialect.RegisterStringU(cmd, &inputs.TokenDialect, "")
 
 	return cmd
 }

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -170,6 +170,12 @@ var (
 		ShortForm: "z",
 		Help:      "Refresh Token Config for the application, formatted as JSON.",
 	}
+	appTEAllowAnyProfileOfType = Flag{
+		Name:      "Allow Any Profile Of Type",
+		LongForm:  "allow-any-profile-of-type",
+		ShortForm: "p",
+		Help:      "Comma-separated list of enabled token exchange types for this client. Possible values: custom_authentication, on_behalf_of_token_exchange.",
+	}
 )
 
 func appsCmd(cli *cli) *cobra.Command {
@@ -427,6 +433,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 		Metadata                 map[string]string
 		RefreshToken             string
 		ResourceServerIdentifier string
+		AllowAnyProfileOfType    []string
 	}
 	var oidcConformant = true
 	var algorithm = "RS256"
@@ -439,7 +446,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 			"To create interactively, use `auth0 apps create` with no arguments.\n\n" +
 			"To create non-interactively, supply at least the application name, and type through the flags.",
 		Example: `  auth0 apps create
-  auth0 apps create --name myapp 
+  auth0 apps create --name myapp
   auth0 apps create --name myapp --description <description>
   auth0 apps create --name myapp --description <description> --type [native|spa|regular|m2m|resource_server]
   auth0 apps create --name myapp --description <description> --type [native|spa|regular|m2m|resource_server] --reveal-secrets
@@ -448,7 +455,8 @@ func createAppCmd(cli *cli) *cobra.Command {
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar"
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
-  auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"`,
+  auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
+  auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := appName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -572,6 +580,12 @@ func createAppCmd(cli *cli) *cobra.Command {
 				}
 			}
 
+			if len(inputs.AllowAnyProfileOfType) > 0 {
+				a.TokenExchange = &management.ClientTokenExchange{
+					AllowAnyProfileOfType: &inputs.AllowAnyProfileOfType,
+				}
+			}
+
 			// Set token endpoint auth method.
 			if len(inputs.AuthMethod) == 0 {
 				a.TokenEndpointAuthMethod = apiDefaultAuthMethodFor(inputs.Type)
@@ -616,6 +630,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 	appAuthMethod.RegisterString(cmd, &inputs.AuthMethod, "")
 	appGrants.RegisterStringSlice(cmd, &inputs.Grants, nil)
 	appResourceServerIdentifier.RegisterString(cmd, &inputs.ResourceServerIdentifier, "")
+	appTEAllowAnyProfileOfType.RegisterStringSlice(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
 
@@ -624,19 +639,20 @@ func createAppCmd(cli *cli) *cobra.Command {
 
 func updateAppCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID                string
-		Name              string
-		Type              string
-		Description       string
-		Callbacks         []string
-		AllowedOrigins    []string
-		AllowedWebOrigins []string
-		AllowedLogoutURLs []string
-		AuthMethod        string
-		Grants            []string
-		RevealSecrets     bool
-		Metadata          map[string]string
-		RefreshToken      string
+		ID                    string
+		Name                  string
+		Type                  string
+		Description           string
+		Callbacks             []string
+		AllowedOrigins        []string
+		AllowedWebOrigins     []string
+		AllowedLogoutURLs     []string
+		AuthMethod            string
+		Grants                []string
+		RevealSecrets         bool
+		Metadata              map[string]string
+		RefreshToken          string
+		AllowAnyProfileOfType []string
 	}
 
 	cmd := &cobra.Command{
@@ -656,7 +672,8 @@ func updateAppCmd(cli *cli) *cobra.Command {
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json-compact
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
-  auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"`,
+  auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
+  auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.Client
 
@@ -823,6 +840,13 @@ func updateAppCmd(cli *cli) *cobra.Command {
 				}
 			}
 
+			if appTEAllowAnyProfileOfType.IsSet(cmd) {
+				nonEmptyProfileTypes := excludeEmptyEntries(inputs.AllowAnyProfileOfType)
+				a.TokenExchange = &management.ClientTokenExchange{
+					AllowAnyProfileOfType: &nonEmptyProfileTypes,
+				}
+			}
+
 			if err := ansi.Waiting(func() error {
 				return cli.api.Client.Update(cmd.Context(), inputs.ID, a)
 			}); err != nil {
@@ -847,6 +871,7 @@ func updateAppCmd(cli *cli) *cobra.Command {
 	appLogoutURLs.RegisterStringSliceU(cmd, &inputs.AllowedLogoutURLs, nil)
 	appAuthMethod.RegisterStringU(cmd, &inputs.AuthMethod, "")
 	appGrants.RegisterStringSliceU(cmd, &inputs.Grants, nil)
+	appTEAllowAnyProfileOfType.RegisterStringSliceU(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
 
@@ -1012,6 +1037,17 @@ func stringSliceToPtr(s []string) *[]string {
 		return nil
 	}
 	return &s
+}
+
+func excludeEmptyEntries(s []string) []string {
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if v != "" {
+			result = append(result, v)
+		}
+	}
+
+	return result
 }
 
 func (c *cli) appPickerOptions(requestOpts ...management.RequestOption) pickerOptionsFunc {

--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -172,3 +172,11 @@ func TestCommaSeparatedStringToSlice(t *testing.T) {
 	assert.Equal(t, []string{}, commaSeparatedStringToSlice(""))
 	assert.Equal(t, []string{"foo", "bar", "baz"}, commaSeparatedStringToSlice(" foo  , bar , baz "))
 }
+
+func TestFilterEmptyStrings(t *testing.T) {
+	assert.Equal(t, []string{}, excludeEmptyEntries([]string{}))
+	assert.Equal(t, []string{}, excludeEmptyEntries([]string{""}))
+	assert.Equal(t, []string{}, excludeEmptyEntries([]string{"", ""}))
+	assert.Equal(t, []string{"a"}, excludeEmptyEntries([]string{"a"}))
+	assert.Equal(t, []string{"a", "b"}, excludeEmptyEntries([]string{"a", "", "b"}))
+}

--- a/internal/display/apis.go
+++ b/internal/display/apis.go
@@ -20,6 +20,8 @@ type apiView struct {
 	TokenLifetime       int
 	OfflineAccess       string
 	SigningAlgorithm    string
+	EnforcePolicies     string
+	TokenDialect        string
 	SubjectTypeAuthJSON string
 	ClientID            string
 
@@ -43,6 +45,11 @@ func (v *apiView) KeyValues() [][]string {
 		{"TOKEN LIFETIME", strconv.Itoa(v.TokenLifetime)},
 		{"ALLOW OFFLINE ACCESS", v.OfflineAccess},
 		{"SIGNING ALGORITHM", v.SigningAlgorithm},
+		{"ENFORCE POLICIES", v.EnforcePolicies},
+	}
+
+	if len(v.TokenDialect) > 0 {
+		kvs = append(kvs, []string{"TOKEN DIALECT", v.TokenDialect})
 	}
 
 	if len(v.SubjectTypeAuthJSON) > 0 {
@@ -140,6 +147,8 @@ func makeAPIView(api *management.ResourceServer) (*apiView, bool) {
 		TokenLifetime:       api.GetTokenLifetime(),
 		OfflineAccess:       boolean(api.GetAllowOfflineAccess()),
 		SigningAlgorithm:    api.GetSigningAlgorithm(),
+		EnforcePolicies:     boolean(api.GetEnforcePolicies()),
+		TokenDialect:        api.GetTokenDialect(),
 		SubjectTypeAuthJSON: subjectTypeAuthJSON,
 		ClientID:            api.GetClientID(),
 		raw:                 api,

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -39,6 +39,7 @@ type applicationView struct {
 	Metadata                 []string
 	RefreshToken             string
 	ResourceServerIdentifier string
+	AllowAnyProfileOfType    []string
 	revealSecret             bool
 
 	raw interface{}
@@ -121,6 +122,10 @@ func (v *applicationView) KeyValues() [][]string {
 	// Add resource server identifier if present.
 	if v.ResourceServerIdentifier != "" {
 		keyValues = append(keyValues, []string{"RESOURCE SERVER IDENTIFIER", v.ResourceServerIdentifier})
+	}
+
+	if len(v.AllowAnyProfileOfType) > 0 {
+		keyValues = append(keyValues, []string{"TOKEN EXCHANGE TYPES", strings.Join(v.AllowAnyProfileOfType, ", ")})
 	}
 
 	return keyValues
@@ -207,6 +212,7 @@ func makeApplicationView(client *management.Client, revealSecrets bool) *applica
 		Grants:                   client.GetGrantTypes(),
 		Metadata:                 mapPointerToArray(client.ClientMetadata),
 		ResourceServerIdentifier: client.GetResourceServerIdentifier(),
+		AllowAnyProfileOfType:    client.GetTokenExchange().GetAllowAnyProfileOfType(),
 		raw:                      client,
 		RefreshToken:             string(jsonRefreshToken),
 	}

--- a/test/integration/apis-test-cases.yaml
+++ b/test/integration/apis-test-cases.yaml
@@ -203,14 +203,14 @@ tests:
 
   # Test 'apis create' --enforce-policies flag
   024 - apis create with enforce-policies true and check data:
-    command: auth0 apis create --name integration-test-api-enfpol1 --identifier http://integration-test-api-enfpol1 --scopes read:todos --enforce-policies --json
+    command: auth0 apis create --name integration-test-api-enfpol1 --identifier http://integration-test-api-enfpol1 --enforce-policies --json
     exit-code: 0
     stdout:
       json:
         enforce_policies: "true"
 
   025 - apis create with enforce-policies false and check data:
-    command: auth0 apis create --name integration-test-api-enfpol2 --identifier http://integration-test-api-enfpol2 --scopes read:todos --enforce-policies=false --json
+    command: auth0 apis create --name integration-test-api-enfpol2 --identifier http://integration-test-api-enfpol2 --enforce-policies=false --json
     exit-code: 0
     stdout:
       json:
@@ -218,7 +218,7 @@ tests:
 
   # Test 'apis create' --token-dialect flag
   026 - apis create with token-dialect access_token_authz and check data:
-    command: auth0 apis create --name integration-test-api-tokdial1 --identifier http://integration-test-api-tokdial1 --scopes read:todos --enforce-policies --token-dialect access_token_authz --json
+    command: auth0 apis create --name integration-test-api-tokdial1 --identifier http://integration-test-api-tokdial1 --enforce-policies --token-dialect access_token_authz --json
     exit-code: 0
     stdout:
       json:
@@ -226,21 +226,21 @@ tests:
         enforce_policies: "true"
 
   027 - apis create with token-dialect rfc9068_profile and check data:
-    command: auth0 apis create --name integration-test-api-tokdial2 --identifier http://integration-test-api-tokdial2 --scopes read:todos --token-dialect rfc9068_profile --json
+    command: auth0 apis create --name integration-test-api-tokdial2 --identifier http://integration-test-api-tokdial2 --token-dialect rfc9068_profile --json
     exit-code: 0
     stdout:
       json:
         token_dialect: rfc9068_profile
 
   028 - apis create with enforce-policies and token-dialect and check output:
-    command: auth0 apis create --name integration-test-api-enfpol3 --identifier http://integration-test-api-enfpol3 --scopes read:todos --enforce-policies --token-dialect access_token_authz
+    command: auth0 apis create --name integration-test-api-enfpol3 --identifier http://integration-test-api-enfpol3 --enforce-policies --token-dialect access_token_authz --json
     exit-code: 0
     stdout:
-      contains:
-        - NAME                        integration-test-api-enfpol3
-        - IDENTIFIER                  http://integration-test-api-enfpol3
-        - ENFORCE POLICIES            ✓
-        - TOKEN DIALECT               access_token_authz
+      json:
+        name: integration-test-api-enfpol3
+        identifier: http://integration-test-api-enfpol3
+        enforce_policies: "true"
+        token_dialect: access_token_authz
 
   # Test 'apis update' --enforce-policies flag
   029 - apis update enforce-policies to true:

--- a/test/integration/apis-test-cases.yaml
+++ b/test/integration/apis-test-cases.yaml
@@ -201,7 +201,79 @@ tests:
         subject_type_authorization: "map[client:map[policy:deny_all] user:map[policy:require_client_grant]]"
     exit-code: 0
 
-  024 - it successfully prints out a URL to open:
+  # Test 'apis create' --enforce-policies flag
+  024 - apis create with enforce-policies true and check data:
+    command: auth0 apis create --name integration-test-api-enfpol1 --identifier http://integration-test-api-enfpol1 --scopes read:todos --enforce-policies --json
+    exit-code: 0
+    stdout:
+      json:
+        enforce_policies: "true"
+
+  025 - apis create with enforce-policies false and check data:
+    command: auth0 apis create --name integration-test-api-enfpol2 --identifier http://integration-test-api-enfpol2 --scopes read:todos --enforce-policies=false --json
+    exit-code: 0
+    stdout:
+      json:
+        enforce_policies: "false"
+
+  # Test 'apis create' --token-dialect flag
+  026 - apis create with token-dialect access_token_authz and check data:
+    command: auth0 apis create --name integration-test-api-tokdial1 --identifier http://integration-test-api-tokdial1 --scopes read:todos --enforce-policies --token-dialect access_token_authz --json
+    exit-code: 0
+    stdout:
+      json:
+        token_dialect: access_token_authz
+        enforce_policies: "true"
+
+  027 - apis create with token-dialect rfc9068_profile and check data:
+    command: auth0 apis create --name integration-test-api-tokdial2 --identifier http://integration-test-api-tokdial2 --scopes read:todos --token-dialect rfc9068_profile --json
+    exit-code: 0
+    stdout:
+      json:
+        token_dialect: rfc9068_profile
+
+  028 - apis create with enforce-policies and token-dialect and check output:
+    command: auth0 apis create --name integration-test-api-enfpol3 --identifier http://integration-test-api-enfpol3 --scopes read:todos --enforce-policies --token-dialect access_token_authz
+    exit-code: 0
+    stdout:
+      contains:
+        - NAME                        integration-test-api-enfpol3
+        - IDENTIFIER                  http://integration-test-api-enfpol3
+        - ENFORCE POLICIES            ✓
+        - TOKEN DIALECT               access_token_authz
+
+  # Test 'apis update' --enforce-policies flag
+  029 - apis update enforce-policies to true:
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --enforce-policies --json
+    stdout:
+      json:
+        enforce_policies: "true"
+    exit-code: 0
+
+  030 - apis update enforce-policies to false:
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --enforce-policies=false --json
+    stdout:
+      json:
+        enforce_policies: "false"
+    exit-code: 0
+
+  # Test 'apis update' --token-dialect flag
+  031 - apis update token-dialect:
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --enforce-policies --token-dialect access_token_authz --json
+    stdout:
+      json:
+        token_dialect: access_token_authz
+        enforce_policies: "true"
+    exit-code: 0
+
+  032 - apis update token-dialect to rfc9068_profile_authz:
+    command: auth0 apis update $(./test/integration/scripts/get-api-id.sh) --enforce-policies --token-dialect rfc9068_profile_authz --json
+    stdout:
+      json:
+        token_dialect: rfc9068_profile_authz
+    exit-code: 0
+
+  034 - it successfully prints out a URL to open:
     command: auth0 apis open $(./test/integration/scripts/get-api-id.sh) --no-input
     exit-code: 0
     stderr:

--- a/test/integration/apps-test-cases.yaml
+++ b/test/integration/apps-test-cases.yaml
@@ -318,15 +318,38 @@ tests:
         - ALLOWED METHODS   cookie, query
         - DEVICE BINDING    ip
 
-  042 - given a test app, it successfully deletes the app:
+  042 - it successfully creates a m2m app with allow-any-profile-of-type and outputs in json:
+    command: auth0 apps create --name integration-test-app-te1 --type m2m --description TEApp1 --allow-any-profile-of-type custom_authentication --json
+    exit-code: 0
+    stdout:
+      json:
+        name: integration-test-app-te1
+        app_type: non_interactive
+        token_exchange.allow_any_profile_of_type: "[custom_authentication]"
+
+  043 - it successfully updates token exchange types on an app and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-app-id.sh) --allow-any-profile-of-type custom_authentication --json
+    exit-code: 0
+    stdout:
+      json:
+        token_exchange.allow_any_profile_of_type: "[custom_authentication]"
+
+  044 - it successfully shows token exchange types on an app:
+    command: auth0 apps show $(./test/integration/scripts/get-app-id.sh)
+    exit-code: 0
+    stdout:
+      contains:
+        - TOKEN EXCHANGE TYPES  custom_authentication
+
+  045 - given a test app, it successfully deletes the app:
     command: auth0 apps delete $(./test/integration/scripts/get-app-id.sh) --force
     exit-code: 0
 
-  043 - it successfully creates a resource server app with resource-server-identifier:
+  046 - it successfully creates a resource server app with resource-server-identifier:
     command: ./test/integration/scripts/get-resource-server-app-id.sh
     exit-code: 0
 
-  044 - it successfully creates a resource server app with resource-server-identifier and outputs in json:
+  047 - it successfully creates a resource server app with resource-server-identifier and outputs in json:
     command: auth0 apps show $(./test/integration/scripts/get-resource-server-app-id.sh) --json
     exit-code: 0
     stdout:
@@ -335,7 +358,7 @@ tests:
         app_type: resource_server
         resource_server_identifier: http://integration-test-api-newapi
 
-  045 - it shows resource server app with resource-server-identifier:
+  048 - it shows resource server app with resource-server-identifier:
     command: auth0 apps show $(./test/integration/scripts/get-resource-server-app-id.sh)
     exit-code: 0
     stdout:
@@ -343,13 +366,13 @@ tests:
         - TYPE                        Resource Server
         - RESOURCE SERVER IDENTIFIER  http://integration-test-api-newapi
 
-  046 - it fails to update resource-server-identifier (immutable property):
+  049 - it fails to update resource-server-identifier (immutable property):
     command: auth0 apps update $(./test/integration/scripts/get-resource-server-app-id.sh) --resource-server-identifier http://new-api.localhost --json
     exit-code: 1
     stderr:
       contains:
         - "Unknown flag: --resource-server-identifier"
 
-  047 - given a resource server app, it successfully deletes the app:
+  050 - given a resource server app, it successfully deletes the app:
     command: auth0 apps delete $(./test/integration/scripts/get-resource-server-app-id.sh) --force
     exit-code: 0


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds CLI support for three new Management API features across `apis` and `apps` commands:

**APIs (Resource Servers):**
- `--enforce-policies` flag on `auth0 apis create` and `auth0 apis update` — enables authorization policy enforcement for the API.
- `--token-dialect` flag on `auth0 apis create` and `auth0 apis update` — sets the access token dialect. Accepts `access_token`, `access_token_authz`, `rfc9068_profile`, or `rfc9068_profile_authz`.

**Apps (Clients):**
- `--allow-any-profile-of-type` (`-p`) flag on `auth0 apps create` and `auth0 apps update` — sets enabled token exchange types on a client. Accepts a comma-separated list (e.g., `custom_authentication`, `on_behalf_of_token_exchange`). Passing an empty value on update clears the configuration.

Display output updated to show `ENFORCE POLICIES`, `TOKEN DIALECT`, and `TOKEN EXCHANGE TYPES` fields.

#### Examples

```bash
auth0 apis create --name "MCP Tools API" --identifier "http://localhost:3001/" \
  --signing-alg RS256 --token-dialect rfc9068_profile_authz --enforce-policies \
  --scopes "tool:whoami,tool:greet" --no-input
  
auth0 apis create --name "Protected First Party API" --identifier "http://localhost:8787/" \                             10s
  --signing-alg RS256 --enforce-policies --scopes "read:private" --no-input
  
auth0 apps create --name "MCP Server Client" --type resource_server \
  --resource-server-identifier "http://localhost:3001/" \
  --allow-any-profile-of-type custom_authentication --no-input
```

### 📚 References
- [create-an-api-to-represent-your-mcp-server](https://auth0.com/ai/docs/mcp/get-started/call-your-apis-on-users-behalf#create-an-api-to-represent-your-mcp-server)
- [create-a-first-party-api-to-call-from-the-mcp-server](https://auth0.com/ai/docs/mcp/get-started/call-your-apis-on-users-behalf#create-a-first-party-api-to-call-from-the-mcp-server)

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Unit tests added for `excludeEmptyEntries` helper (`apps_test.go`).
- Integration tests added for all new flags:
  - `apis create/update` with `--enforce-policies` and `--token-dialect` (test cases 024–032).
  - `apps create/update/show` with `--allow-any-profile-of-type` (test cases 042–044).
- Manual verification:
  - Verified creation/updation of new api parameters.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
