### PR TITLE
feat: Support third party app security params

### DIFF
--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -50,11 +50,11 @@ auth0 apps create [flags]
       --metadata stringToString             Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
   -n, --name string                         Name of the application.
   -o, --origins strings                     Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
-  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.
+  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'. Require --is-first-party=false
   -z, --refresh-token string                Refresh Token Config for the application, formatted as JSON.
       --resource-server-identifier string   The identifier of the resource server that this client is associated with. This property can only be sent when app_type=resource_server and cannot be changed once the client is created.
   -r, --reveal-secrets                      Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
-  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'.
+  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'. Require --is-first-party=false
   -t, --type string                         Type of application:
                                             - native: mobile, desktop, CLI and smart device apps running natively.
                                             - spa (single page application): a JavaScript front-end app that uses an API.

--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -31,7 +31,7 @@ auth0 apps create [flags]
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
   auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
-  auth0 apps create --name "My 3P App" --type regular --third-party-security-mode strict --redirection-policy open_redirect_protection
+  auth0 apps create --name "My 3P App" --type regular --is-first-party=false --third-party-security-mode strict --redirection-policy open_redirect_protection
 ```
 
 
@@ -43,6 +43,7 @@ auth0 apps create [flags]
   -c, --callbacks strings                   After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
   -d, --description string                  Description of the application. Max character count is 140.
   -g, --grants strings                      List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
+  -f, --is-first-party                      Whether the application is a first-party client (true) or third-party client (false). (default true)
       --json                                Output in json format.
       --json-compact                        Output in compact json format.
   -l, --logout-urls strings                 Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.

--- a/docs/auth0_apps_create.md
+++ b/docs/auth0_apps_create.md
@@ -31,6 +31,7 @@ auth0 apps create [flags]
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
   auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
+  auth0 apps create --name "My 3P App" --type regular --third-party-security-mode strict --redirection-policy open_redirect_protection
 ```
 
 
@@ -48,9 +49,11 @@ auth0 apps create [flags]
       --metadata stringToString             Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
   -n, --name string                         Name of the application.
   -o, --origins strings                     Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
+  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.
   -z, --refresh-token string                Refresh Token Config for the application, formatted as JSON.
       --resource-server-identifier string   The identifier of the resource server that this client is associated with. This property can only be sent when app_type=resource_server and cannot be changed once the client is created.
   -r, --reveal-secrets                      Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
+  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'.
   -t, --type string                         Type of application:
                                             - native: mobile, desktop, CLI and smart device apps running natively.
                                             - spa (single page application): a JavaScript front-end app that uses an API.

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -31,7 +31,6 @@ auth0 apps update [flags]
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
   auth0 apps update <app-id> --redirection-policy allow_always
-  auth0 apps update <app-id> --third-party-security-mode strict --redirection-policy open_redirect_protection
 ```
 
 
@@ -43,6 +42,7 @@ auth0 apps update [flags]
   -c, --callbacks strings                   After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native apps, all callbacks should use protocol https://.
   -d, --description string                  Description of the application. Max character count is 140.
   -g, --grants strings                      List of grant types supported for this application. Can include code, implicit, refresh-token, credentials, password, password-realm, mfa-oob, mfa-otp, mfa-recovery-code, and device-code.
+  -f, --is-first-party                      Whether the application is a first-party client (true) or third-party client (false). (default true)
       --json                                Output in json format.
       --json-compact                        Output in compact json format.
   -l, --logout-urls strings                 Comma-separated list of URLs that are valid to redirect to after logout from Auth0. Wildcards are allowed for subdomains.

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -30,6 +30,8 @@ auth0 apps update [flags]
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
+  auth0 apps update <app-id> --redirection-policy allow_always
+  auth0 apps update <app-id> --third-party-security-mode strict --redirection-policy open_redirect_protection
 ```
 
 
@@ -47,8 +49,10 @@ auth0 apps update [flags]
       --metadata stringToString             Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
   -n, --name string                         Name of the application.
   -o, --origins strings                     Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
+  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.
   -z, --refresh-token string                Refresh Token Config for the application, formatted as JSON.
   -r, --reveal-secrets                      Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
+  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'.
   -t, --type string                         Type of application:
                                             - native: mobile, desktop, CLI and smart device apps running natively.
                                             - spa (single page application): a JavaScript front-end app that uses an API.

--- a/docs/auth0_apps_update.md
+++ b/docs/auth0_apps_update.md
@@ -49,10 +49,10 @@ auth0 apps update [flags]
       --metadata stringToString             Arbitrary keys-value pairs (max 255 characters each), that  can be assigned to each application. More about application metadata: https://auth0.com/docs/get-started/applications/configure-application-metadata (default [])
   -n, --name string                         Name of the application.
   -o, --origins strings                     Comma-separated list of URLs allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if necessary. You can also use wildcards at the subdomain level (e.g., https://*.contoso.com). Query strings and hash information are not taken into account when validating these URLs.
-  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.
+  -y, --redirection-policy string           Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'. Require --is-first-party=false
   -z, --refresh-token string                Refresh Token Config for the application, formatted as JSON.
   -r, --reveal-secrets                      Display the application secrets ('signing_keys', 'client_secret') as part of the command output.
-  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'.
+  -s, --third-party-security-mode string    Security mode for third-party clients: 'strict' or 'permissive'. Require --is-first-party=false
   -t, --type string                         Type of application:
                                             - native: mobile, desktop, CLI and smart device apps running natively.
                                             - spa (single page application): a JavaScript front-end app that uses an API.

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -186,13 +186,13 @@ var (
 		Name:      "Third Party Security Mode",
 		LongForm:  "third-party-security-mode",
 		ShortForm: "s",
-		Help:      "Security mode for third-party clients: 'strict' or 'permissive'.",
+		Help:      "Security mode for third-party clients: 'strict' or 'permissive'. Require --is-first-party=false",
 	}
 	appRedirectionPolicy = Flag{
 		Name:      "Redirection Policy",
 		LongForm:  "redirection-policy",
 		ShortForm: "y",
-		Help:      "Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.",
+		Help:      "Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'. Require --is-first-party=false",
 	}
 )
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -176,6 +176,12 @@ var (
 		ShortForm: "p",
 		Help:      "Comma-separated list of enabled token exchange types for this client. Possible values: custom_authentication, on_behalf_of_token_exchange.",
 	}
+	appIsFirstParty = Flag{
+		Name:      "Is First Party",
+		LongForm:  "is-first-party",
+		ShortForm: "f",
+		Help:      "Whether the application is a first-party client (true) or third-party client (false).",
+	}
 	appThirdPartySecurityMode = Flag{
 		Name:      "Third Party Security Mode",
 		LongForm:  "third-party-security-mode",
@@ -446,6 +452,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 		RefreshToken             string
 		ResourceServerIdentifier string
 		AllowAnyProfileOfType    []string
+		IsFirstParty             bool
 		ThirdPartySecurityMode   string
 		RedirectionPolicy        string
 	}
@@ -471,7 +478,7 @@ func createAppCmd(cli *cli) *cobra.Command {
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
   auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
-  auth0 apps create --name "My 3P App" --type regular --third-party-security-mode strict --redirection-policy open_redirect_protection`,
+  auth0 apps create --name "My 3P App" --type regular --is-first-party=false --third-party-security-mode strict --redirection-policy open_redirect_protection`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := appName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -489,7 +496,9 @@ func createAppCmd(cli *cli) *cobra.Command {
 			appIsNative := apiTypeFor(inputs.Type) == appTypeNative
 			appIsSPA := apiTypeFor(inputs.Type) == appTypeSPA
 			appIsResourceServer := apiTypeFor(inputs.Type) == appTypeResourceServer
-			isThirdPartyApp := inputs.ThirdPartySecurityMode != "" || inputs.RedirectionPolicy != ""
+
+			// IsFirstParty flag is explisitly set to false
+			isThirdPartyApp := appIsFirstParty.IsSet(cmd) && !inputs.IsFirstParty
 
 			// Prompt for callback URLs if app is not m2m and not resource_server.
 			if !appIsM2M && !appIsResourceServer {
@@ -609,14 +618,15 @@ func createAppCmd(cli *cli) *cobra.Command {
 				a.TokenEndpointAuthMethod = apiAuthMethodFor(inputs.AuthMethod)
 			}
 
+			// Set first and third party fields.
+			if appIsFirstParty.IsSet(cmd) {
+				a.IsFirstParty = auth0.Bool(inputs.IsFirstParty)
+			}
 			if inputs.ThirdPartySecurityMode != "" {
 				a.ThirdPartySecurityMode = &inputs.ThirdPartySecurityMode
 			}
 			if inputs.RedirectionPolicy != "" {
 				a.RedirectionPolicy = &inputs.RedirectionPolicy
-			}
-			if isThirdPartyApp {
-				a.IsFirstParty = auth0.Bool(false)
 			}
 
 			// Set grants.
@@ -659,6 +669,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 	appTEAllowAnyProfileOfType.RegisterStringSlice(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
+	appIsFirstParty.RegisterBool(cmd, &inputs.IsFirstParty, true)
 	appThirdPartySecurityMode.RegisterString(cmd, &inputs.ThirdPartySecurityMode, "")
 	appRedirectionPolicy.RegisterString(cmd, &inputs.RedirectionPolicy, "")
 
@@ -681,6 +692,7 @@ func updateAppCmd(cli *cli) *cobra.Command {
 		Metadata               map[string]string
 		RefreshToken           string
 		AllowAnyProfileOfType  []string
+		IsFirstParty           bool
 		ThirdPartySecurityMode string
 		RedirectionPolicy      string
 	}
@@ -704,8 +716,7 @@ func updateAppCmd(cli *cli) *cobra.Command {
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
-  auth0 apps update <app-id> --redirection-policy allow_always
-  auth0 apps update <app-id> --third-party-security-mode strict --redirection-policy open_redirect_protection`,
+  auth0 apps update <app-id> --redirection-policy allow_always`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.Client
 
@@ -879,6 +890,10 @@ func updateAppCmd(cli *cli) *cobra.Command {
 				}
 			}
 
+			if appIsFirstParty.IsSet(cmd) {
+				a.IsFirstParty = auth0.Bool(inputs.IsFirstParty)
+			}
+
 			if appThirdPartySecurityMode.IsSet(cmd) {
 				a.ThirdPartySecurityMode = &inputs.ThirdPartySecurityMode
 			}
@@ -914,6 +929,7 @@ func updateAppCmd(cli *cli) *cobra.Command {
 	appTEAllowAnyProfileOfType.RegisterStringSliceU(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
+	appIsFirstParty.RegisterBoolU(cmd, &inputs.IsFirstParty, true)
 	appThirdPartySecurityMode.RegisterStringU(cmd, &inputs.ThirdPartySecurityMode, "")
 	appRedirectionPolicy.RegisterStringU(cmd, &inputs.RedirectionPolicy, "")
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -497,7 +497,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 			appIsSPA := apiTypeFor(inputs.Type) == appTypeSPA
 			appIsResourceServer := apiTypeFor(inputs.Type) == appTypeResourceServer
 
-			// IsFirstParty flag is explisitly set to false
+			// IsFirstParty flag is explisitly set to false.
 			isThirdPartyApp := appIsFirstParty.IsSet(cmd) && !inputs.IsFirstParty
 
 			// Prompt for callback URLs if app is not m2m and not resource_server.

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -176,6 +176,18 @@ var (
 		ShortForm: "p",
 		Help:      "Comma-separated list of enabled token exchange types for this client. Possible values: custom_authentication, on_behalf_of_token_exchange.",
 	}
+	appThirdPartySecurityMode = Flag{
+		Name:      "Third Party Security Mode",
+		LongForm:  "third-party-security-mode",
+		ShortForm: "s",
+		Help:      "Security mode for third-party clients: 'strict' or 'permissive'.",
+	}
+	appRedirectionPolicy = Flag{
+		Name:      "Redirection Policy",
+		LongForm:  "redirection-policy",
+		ShortForm: "y",
+		Help:      "Controls whether Auth0 redirects users to the application's callback URL on authentication errors or in email verification flows: 'allow_always' or 'open_redirect_protection'.",
+	}
 )
 
 func appsCmd(cli *cli) *cobra.Command {
@@ -434,6 +446,8 @@ func createAppCmd(cli *cli) *cobra.Command {
 		RefreshToken             string
 		ResourceServerIdentifier string
 		AllowAnyProfileOfType    []string
+		ThirdPartySecurityMode   string
+		RedirectionPolicy        string
 	}
 	var oidcConformant = true
 	var algorithm = "RS256"
@@ -456,7 +470,8 @@ func createAppCmd(cli *cli) *cobra.Command {
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps create -n myapp -d <description> -t [native|spa|regular|m2m|resource_server] -r --json --metadata "foo=bar,bazz=buzz"
   auth0 apps create --name "My API Client" --type resource_server --resource-server-identifier "https://api.example.com"
-  auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange`,
+  auth0 apps create --name myapp --type resource_server --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
+  auth0 apps create --name "My 3P App" --type regular --third-party-security-mode strict --redirection-policy open_redirect_protection`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := appName.Ask(cmd, &inputs.Name, nil); err != nil {
 				return err
@@ -474,6 +489,7 @@ func createAppCmd(cli *cli) *cobra.Command {
 			appIsNative := apiTypeFor(inputs.Type) == appTypeNative
 			appIsSPA := apiTypeFor(inputs.Type) == appTypeSPA
 			appIsResourceServer := apiTypeFor(inputs.Type) == appTypeResourceServer
+			isThirdPartyApp := inputs.ThirdPartySecurityMode != "" || inputs.RedirectionPolicy != ""
 
 			// Prompt for callback URLs if app is not m2m and not resource_server.
 			if !appIsM2M && !appIsResourceServer {
@@ -488,8 +504,8 @@ func createAppCmd(cli *cli) *cobra.Command {
 				}
 			}
 
-			// Prompt for logout URLs if app is not m2m and not resource_server.
-			if !appIsM2M && !appIsResourceServer {
+			// Prompt for logout URLs if app is not m2m and not resource_server and not a third-party app.
+			if !appIsM2M && !appIsResourceServer && !isThirdPartyApp {
 				var defaultValue string
 
 				if !appIsNative {
@@ -593,11 +609,21 @@ func createAppCmd(cli *cli) *cobra.Command {
 				a.TokenEndpointAuthMethod = apiAuthMethodFor(inputs.AuthMethod)
 			}
 
+			if inputs.ThirdPartySecurityMode != "" {
+				a.ThirdPartySecurityMode = &inputs.ThirdPartySecurityMode
+			}
+			if inputs.RedirectionPolicy != "" {
+				a.RedirectionPolicy = &inputs.RedirectionPolicy
+			}
+			if isThirdPartyApp {
+				a.IsFirstParty = auth0.Bool(false)
+			}
+
 			// Set grants.
-			if len(inputs.Grants) == 0 {
-				a.GrantTypes = apiDefaultGrantsFor(inputs.Type)
-			} else {
+			if len(inputs.Grants) > 0 {
 				a.GrantTypes = apiGrantsFor(inputs.Grants)
+			} else if !isThirdPartyApp {
+				a.GrantTypes = apiDefaultGrantsFor(inputs.Type)
 			}
 
 			// Create app.
@@ -633,26 +659,30 @@ func createAppCmd(cli *cli) *cobra.Command {
 	appTEAllowAnyProfileOfType.RegisterStringSlice(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
+	appThirdPartySecurityMode.RegisterString(cmd, &inputs.ThirdPartySecurityMode, "")
+	appRedirectionPolicy.RegisterString(cmd, &inputs.RedirectionPolicy, "")
 
 	return cmd
 }
 
 func updateAppCmd(cli *cli) *cobra.Command {
 	var inputs struct {
-		ID                    string
-		Name                  string
-		Type                  string
-		Description           string
-		Callbacks             []string
-		AllowedOrigins        []string
-		AllowedWebOrigins     []string
-		AllowedLogoutURLs     []string
-		AuthMethod            string
-		Grants                []string
-		RevealSecrets         bool
-		Metadata              map[string]string
-		RefreshToken          string
-		AllowAnyProfileOfType []string
+		ID                     string
+		Name                   string
+		Type                   string
+		Description            string
+		Callbacks              []string
+		AllowedOrigins         []string
+		AllowedWebOrigins      []string
+		AllowedLogoutURLs      []string
+		AuthMethod             string
+		Grants                 []string
+		RevealSecrets          bool
+		Metadata               map[string]string
+		RefreshToken           string
+		AllowAnyProfileOfType  []string
+		ThirdPartySecurityMode string
+		RedirectionPolicy      string
 	}
 
 	cmd := &cobra.Command{
@@ -673,7 +703,9 @@ func updateAppCmd(cli *cli) *cobra.Command {
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar" --metadata "bazz=buzz"
   auth0 apps update <app-id> -n myapp -d <description> -t [native|spa|regular|m2m] -r --json --metadata "foo=bar,bazz=buzz"
-  auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange`,
+  auth0 apps update <app-id> --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange
+  auth0 apps update <app-id> --redirection-policy allow_always
+  auth0 apps update <app-id> --third-party-security-mode strict --redirection-policy open_redirect_protection`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var current *management.Client
 
@@ -847,6 +879,14 @@ func updateAppCmd(cli *cli) *cobra.Command {
 				}
 			}
 
+			if appThirdPartySecurityMode.IsSet(cmd) {
+				a.ThirdPartySecurityMode = &inputs.ThirdPartySecurityMode
+			}
+
+			if appRedirectionPolicy.IsSet(cmd) {
+				a.RedirectionPolicy = &inputs.RedirectionPolicy
+			}
+
 			if err := ansi.Waiting(func() error {
 				return cli.api.Client.Update(cmd.Context(), inputs.ID, a)
 			}); err != nil {
@@ -874,6 +914,8 @@ func updateAppCmd(cli *cli) *cobra.Command {
 	appTEAllowAnyProfileOfType.RegisterStringSliceU(cmd, &inputs.AllowAnyProfileOfType, nil)
 	revealSecrets.RegisterBool(cmd, &inputs.RevealSecrets, false)
 	refreshToken.RegisterString(cmd, &inputs.RefreshToken, "")
+	appThirdPartySecurityMode.RegisterStringU(cmd, &inputs.ThirdPartySecurityMode, "")
+	appRedirectionPolicy.RegisterStringU(cmd, &inputs.RedirectionPolicy, "")
 
 	return cmd
 }

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -274,8 +274,14 @@ func (f *clientGrantResourceFetcher) FetchData(ctx context.Context) (importDataL
 		}
 
 		for _, grant := range grants.ClientGrants {
+			var resourceName string
+			if grant.GetDefaultFor() != "" {
+				resourceName = "auth0_client_grant." + sanitizeResourceName("default_for_"+grant.GetDefaultFor()+"_"+grant.GetAudience())
+			} else {
+				resourceName = "auth0_client_grant." + sanitizeResourceName(grant.GetClientID()+"_"+grant.GetAudience())
+			}
 			data = append(data, importDataItem{
-				ResourceName: "auth0_client_grant." + sanitizeResourceName(grant.GetClientID()+"_"+grant.GetAudience()),
+				ResourceName: resourceName,
 				ImportID:     grant.GetID(),
 			})
 		}

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -274,15 +274,12 @@ func (f *clientGrantResourceFetcher) FetchData(ctx context.Context) (importDataL
 		}
 
 		for _, grant := range grants.ClientGrants {
-			var resourceName string
-			// Grants with default_for have no client_id; use the default_for value as prefix instead.
-			if grant.GetDefaultFor() != "" {
-				resourceName = "auth0_client_grant." + sanitizeResourceName("default_for_"+grant.GetDefaultFor()+"_"+grant.GetAudience())
-			} else {
-				resourceName = "auth0_client_grant." + sanitizeResourceName(grant.GetClientID()+"_"+grant.GetAudience())
+			identifier := grant.GetClientID()
+			if identifier == "" {
+				identifier = grant.GetDefaultFor()
 			}
 			data = append(data, importDataItem{
-				ResourceName: resourceName,
+				ResourceName: "auth0_client_grant." + sanitizeResourceName(identifier+"_"+grant.GetAudience()),
 				ImportID:     grant.GetID(),
 			})
 		}

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -275,6 +275,7 @@ func (f *clientGrantResourceFetcher) FetchData(ctx context.Context) (importDataL
 
 		for _, grant := range grants.ClientGrants {
 			var resourceName string
+			// Grants with default_for have no client_id; use the default_for value as prefix instead.
 			if grant.GetDefaultFor() != "" {
 				resourceName = "auth0_client_grant." + sanitizeResourceName("default_for_"+grant.GetDefaultFor()+"_"+grant.GetAudience())
 			} else {

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -771,11 +771,11 @@ func TestClientGrantResourceFetcher_FetchData(t *testing.T) {
 				ImportID:     "cgr_1",
 			},
 			{
-				ResourceName: "auth0_client_grant.default_for_third_party_clients_https_travel0_com_api",
+				ResourceName: "auth0_client_grant.third_party_clients_https_travel0_com_api",
 				ImportID:     "cgr_2",
 			},
 			{
-				ResourceName: "auth0_client_grant.default_for_third_party_clients_https_partner_api_example_com",
+				ResourceName: "auth0_client_grant.third_party_clients_https_partner_api_example_com",
 				ImportID:     "cgr_3",
 			},
 		}

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -723,6 +723,67 @@ func TestClientGrantResourceFetcher_FetchData(t *testing.T) {
 		_, err := fetcher.FetchData(context.Background())
 		assert.EqualError(t, err, "failed to list clients")
 	})
+
+	t.Run("it handles default_for grants correctly", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clientGrantAPI := mock.NewMockClientGrantAPI(ctrl)
+		clientGrantAPI.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(
+				&management.ClientGrantList{
+					List: management.List{
+						Start: 0,
+						Limit: 3,
+						Total: 3,
+					},
+					ClientGrants: []*management.ClientGrant{
+						{
+							ID:       auth0.String("cgr_1"),
+							ClientID: auth0.String("client-id-1"),
+							Audience: auth0.String("https://travel0.com/api"),
+						},
+						{
+							ID:        auth0.String("cgr_2"),
+							DefaultFor: auth0.String("third_party_clients"),
+							Audience:  auth0.String("https://travel0.com/api"),
+						},
+						{
+							ID:        auth0.String("cgr_3"),
+							DefaultFor: auth0.String("third_party_clients"),
+							Audience:  auth0.String("https://partner-api.example.com"),
+						},
+					},
+				},
+				nil,
+			)
+
+		fetcher := clientGrantResourceFetcher{
+			api: &auth0.API{
+				ClientGrant: clientGrantAPI,
+			},
+		}
+
+		expectedData := importDataList{
+			{
+				ResourceName: "auth0_client_grant.client_id_1_https_travel0_com_api",
+				ImportID:     "cgr_1",
+			},
+			{
+				ResourceName: "auth0_client_grant.default_for_third_party_clients_https_travel0_com_api",
+				ImportID:     "cgr_2",
+			},
+			{
+				ResourceName: "auth0_client_grant.default_for_third_party_clients_https_partner_api_example_com",
+				ImportID:     "cgr_3",
+			},
+		}
+
+		data, err := fetcher.FetchData(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, data)
+	})
 }
 
 func TestConnectionResourceFetcher_FetchData(t *testing.T) {

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -745,14 +745,14 @@ func TestClientGrantResourceFetcher_FetchData(t *testing.T) {
 							Audience: auth0.String("https://travel0.com/api"),
 						},
 						{
-							ID:        auth0.String("cgr_2"),
+							ID:         auth0.String("cgr_2"),
 							DefaultFor: auth0.String("third_party_clients"),
-							Audience:  auth0.String("https://travel0.com/api"),
+							Audience:   auth0.String("https://travel0.com/api"),
 						},
 						{
-							ID:        auth0.String("cgr_3"),
+							ID:         auth0.String("cgr_3"),
 							DefaultFor: auth0.String("third_party_clients"),
-							Audience:  auth0.String("https://partner-api.example.com"),
+							Audience:   auth0.String("https://partner-api.example.com"),
 						},
 					},
 				},

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -40,6 +40,8 @@ type applicationView struct {
 	RefreshToken             string
 	ResourceServerIdentifier string
 	AllowAnyProfileOfType    []string
+	ThirdPartySecurityMode   string
+	RedirectionPolicy        string
 	revealSecret             bool
 
 	raw interface{}
@@ -128,6 +130,14 @@ func (v *applicationView) KeyValues() [][]string {
 		keyValues = append(keyValues, []string{"TOKEN EXCHANGE TYPES", strings.Join(v.AllowAnyProfileOfType, ", ")})
 	}
 
+	if v.ThirdPartySecurityMode != "" {
+		keyValues = append(keyValues, []string{"THIRD PARTY SECURITY MODE", v.ThirdPartySecurityMode})
+	}
+
+	if v.RedirectionPolicy != "" {
+		keyValues = append(keyValues, []string{"REDIRECTION POLICY", v.RedirectionPolicy})
+	}
+
 	return keyValues
 }
 
@@ -213,6 +223,8 @@ func makeApplicationView(client *management.Client, revealSecrets bool) *applica
 		Metadata:                 mapPointerToArray(client.ClientMetadata),
 		ResourceServerIdentifier: client.GetResourceServerIdentifier(),
 		AllowAnyProfileOfType:    client.GetTokenExchange().GetAllowAnyProfileOfType(),
+		ThirdPartySecurityMode:   client.GetThirdPartySecurityMode(),
+		RedirectionPolicy:        client.GetRedirectionPolicy(),
 		raw:                      client,
 		RefreshToken:             string(jsonRefreshToken),
 	}

--- a/internal/display/apps.go
+++ b/internal/display/apps.go
@@ -40,6 +40,7 @@ type applicationView struct {
 	RefreshToken             string
 	ResourceServerIdentifier string
 	AllowAnyProfileOfType    []string
+	IsFirstParty             *bool
 	ThirdPartySecurityMode   string
 	RedirectionPolicy        string
 	revealSecret             bool
@@ -128,6 +129,10 @@ func (v *applicationView) KeyValues() [][]string {
 
 	if len(v.AllowAnyProfileOfType) > 0 {
 		keyValues = append(keyValues, []string{"TOKEN EXCHANGE TYPES", strings.Join(v.AllowAnyProfileOfType, ", ")})
+	}
+
+	if v.IsFirstParty != nil {
+		keyValues = append(keyValues, []string{"IS FIRST PARTY", boolean(*v.IsFirstParty)})
 	}
 
 	if v.ThirdPartySecurityMode != "" {
@@ -223,6 +228,7 @@ func makeApplicationView(client *management.Client, revealSecrets bool) *applica
 		Metadata:                 mapPointerToArray(client.ClientMetadata),
 		ResourceServerIdentifier: client.GetResourceServerIdentifier(),
 		AllowAnyProfileOfType:    client.GetTokenExchange().GetAllowAnyProfileOfType(),
+		IsFirstParty:             client.IsFirstParty,
 		ThirdPartySecurityMode:   client.GetThirdPartySecurityMode(),
 		RedirectionPolicy:        client.GetRedirectionPolicy(),
 		raw:                      client,

--- a/test/integration/apps-test-cases.yaml
+++ b/test/integration/apps-test-cases.yaml
@@ -376,3 +376,13 @@ tests:
   050 - given a resource server app, it successfully deletes the app:
     command: auth0 apps delete $(./test/integration/scripts/get-resource-server-app-id.sh) --force
     exit-code: 0
+
+  051 - it successfully creates a regular app with third-party-security-mode and redirection-policy and outputs in json:
+    command: auth0 apps create --name integration-test-app-3p-strict --type regular --description 3PApp1 --third-party-security-mode strict --redirection-policy open_redirect_protection --json
+    exit-code: 0
+    stdout:
+      json:
+        name: integration-test-app-3p-strict
+        app_type: regular_web
+        third_party_security_mode: strict
+        redirection_policy: open_redirect_protection

--- a/test/integration/apps-test-cases.yaml
+++ b/test/integration/apps-test-cases.yaml
@@ -377,12 +377,28 @@ tests:
     command: auth0 apps delete $(./test/integration/scripts/get-resource-server-app-id.sh) --force
     exit-code: 0
 
-  051 - it successfully creates a regular app with third-party-security-mode and redirection-policy and outputs in json:
-    command: auth0 apps create --name integration-test-app-3p-strict --type regular --description 3PApp1 --third-party-security-mode strict --redirection-policy open_redirect_protection --json
+  051 - it successfully creates a third-party app with strict security mode:
+    command: ./test/integration/scripts/get-3p-app-id.sh
+    exit-code: 0
+
+  052 - it successfully shows a third-party app with security mode and redirection policy in json:
+    command: auth0 apps show $(./test/integration/scripts/get-3p-app-id.sh) --json
     exit-code: 0
     stdout:
       json:
         name: integration-test-app-3p-strict
         app_type: regular_web
+        is_first_party: "false"
         third_party_security_mode: strict
         redirection_policy: open_redirect_protection
+
+  053 - it successfully updates the redirection-policy of a third-party app and outputs in json:
+    command: auth0 apps update $(./test/integration/scripts/get-3p-app-id.sh) --redirection-policy allow_always --json
+    exit-code: 0
+    stdout:
+      json:
+        redirection_policy: allow_always
+
+  054 - given a third-party app, it successfully deletes the app:
+    command: auth0 apps delete $(./test/integration/scripts/get-3p-app-id.sh) --force
+    exit-code: 0

--- a/test/integration/scripts/get-3p-app-id.sh
+++ b/test/integration/scripts/get-3p-app-id.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+FILE=./test/integration/identifiers/3p-app-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
+app=$( auth0 apps create -n integration-test-app-3p-strict -t regular --description 3PApp1 --is-first-party=false --third-party-security-mode strict --redirection-policy open_redirect_protection --json --no-input )
+
+mkdir -p ./test/integration/identifiers
+echo "$app" | jq -r '.["client_id"]' > $FILE
+cat $FILE


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds CLI support for Auth0's Third-Party Client security improvements.

**New flags on `apps create`:**
- `--is-first-party` (`-f`): Whether the application is a first-party client (true) or third-party client (false). Default: `true`
- `--third-party-security-mode` (`-s`): Set security mode to `strict` or `permissive`
- `--redirection-policy` (`-y`): Set to `allow_always` or `open_redirect_protection`

**New flags on `apps update`:**
- `--is-first-party` (`-f`): Update whether the application is first-party or third-party
- `--third-party-security-mode` (`-s`): Update the security mode
- `--redirection-policy` (`-y`): Update the redirection policy

**Display updates:**
- `apps show` and `apps list` now display `IS FIRST PARTY`, `THIRD PARTY SECURITY MODE` and `REDIRECTION POLICY` fields when set

**Terraform fetcher fix:**
- Handles `default_for` client grants correctly during `auth0 tf generate`. Grants with `default_for` (which lack a `client_id`) now produce a meaningful resource name (`default_for_third_party_clients_<audience>`) instead of a broken `_<audience>` name.

**Behavioral notes:**
- Default grant types are not applied for third-party apps (the API manages defaults)
- Logout URL prompts are suppressed for third-party apps (not applicable)
- Update uses `IsSet()` guards so these fields are only sent when explicitly provided

### 📚 References

- API Docs: https://auth0.com/docs/api/management/v2/clients/post-clients

### 🔬 Testing

- Unit test added: `TestClientGrantResourceFetcher_FetchData` — verifies `default_for` grants produce correct resource names
- Integration test added: test case 051 creates a regular app with `--third-party-security-mode strict --redirection-policy open_redirect_protection` and validates JSON output

#### Manual testing:
 - Verified CRUD operation on 3rd party apps using new flag values
 - Verified terraform generation for client grants with default_for value
 
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
