### PR TITLE
fix(keyring): clear stale access-token chunks instead of deleting the client secret

### DIFF
--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -73,9 +73,9 @@ func DeleteSecretsForTenant(tenant string) error {
 func StoreAccessToken(tenant, value string) error {
 	// First, clear any existing chunks to prevent concatenation issues.
 	for i := 0; i < secretAccessTokenMaxChunks; i++ {
-		if err := keyring.Delete(secretClientSecret, tenant); err != nil {
+		if err := keyring.Delete(fmt.Sprintf("%s %d", secretAccessToken, i), tenant); err != nil {
 			if !errors.Is(err, keyring.ErrNotFound) {
-				return fmt.Errorf("failed to delete client secret from keyring: %s", err)
+				return fmt.Errorf("failed to delete access token chunk from keyring: %s", err)
 			}
 		}
 	}

--- a/internal/keyring/keyring_test.go
+++ b/internal/keyring/keyring_test.go
@@ -87,6 +87,42 @@ func TestSecrets(t *testing.T) {
 		assert.Equal(t, expectedAccessToken, actualAccessToken)
 	})
 
+	t.Run("it overwrites a previously stored token without leaving stale chunks", func(t *testing.T) {
+		keyring.MockInit()
+
+		// Store a long token spanning several chunks.
+		longToken := randomStringOfLength((2048 * 5) + 1)
+		err := StoreAccessToken(testTenantName, longToken)
+		assert.NoError(t, err)
+
+		// Overwrite with a token that fits in a single chunk.
+		shortToken := "short-token"
+		err = StoreAccessToken(testTenantName, shortToken)
+		assert.NoError(t, err)
+
+		// Must return exactly the short token, with no trailing chunks
+		// left over from the longer one (which would corrupt the JWT).
+		actualAccessToken, err := GetAccessToken(testTenantName)
+		assert.NoError(t, err)
+		assert.Equal(t, shortToken, actualAccessToken)
+	})
+
+	t.Run("it does not delete the client secret when storing an access token", func(t *testing.T) {
+		keyring.MockInit()
+
+		err := StoreClientSecret(testTenantName, "the-client-secret")
+		assert.NoError(t, err)
+
+		err = StoreAccessToken(testTenantName, "an-access-token")
+		assert.NoError(t, err)
+
+		// Storing the access token must not clobber the client secret,
+		// otherwise machine logins cannot refresh their token.
+		actualClientSecret, err := GetClientSecret(testTenantName)
+		assert.NoError(t, err)
+		assert.Equal(t, "the-client-secret", actualClientSecret)
+	})
+
 	t.Run("it successfully retrieves an access token split up into multiple chunks", func(t *testing.T) {
 		keyring.MockInit()
 


### PR DESCRIPTION
## Description

`StoreAccessToken`'s "clear existing chunks" loop deleted the `secretClientSecret` key on every iteration instead of the indexed `secretAccessToken` chunks (introduced in #1358). This caused two failures:

1. **Stale chunks → corrupted token.** Old access-token chunks were never cleared, so re-storing a shorter token left trailing chunks that concatenate into a malformed JWT → `authentication token is corrupted`.
2. **Machine logins couldn't refresh.** The client secret was deleted immediately after a machine login stored it, so `RegenerateAccessToken → GetClientSecret` failed and client-credentials sessions broke at the first token expiry (and never auto-renewed).

The loop now deletes the indexed access-token chunks (matching `DeleteSecretsForTenant` and the store/get loops) and leaves the client secret untouched.

Fixes #1526

## Testing

Added two regression tests in `internal/keyring/keyring_test.go`:
- overwriting a multi-chunk token with a single-chunk token returns exactly the new token (no stale chunks left over)
- `StoreAccessToken` does not delete the client secret

Both **fail on `main`** and pass with this change. Also verified end-to-end against a live tenant: a machine login followed by a forced token expiry now auto-renews silently instead of erroring with `please re-authenticate`.

## Checklist

- [x] Regression tests added
- [x] `go test ./internal/keyring/...` passes
- [x] Change is minimal and matches existing patterns in the file