### PR TITLE
fix(terraform): improve error message for terraform plan failure

### DIFF
--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -221,7 +221,7 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			})
 
 			if err != nil {
-				cli.renderer.Warnf("Terraform resource config generated successfully but there was an error with terraform plan.\n\n")
+				cli.renderer.Warnf("Terraform resource config generated successfully but there was an error: %s\n\n", err)
 				cli.renderer.Warnf("Run " + ansi.Cyan(cdInstructions+"./terraform plan") + " to troubleshoot\n\n")
 				cli.renderer.Warnf("Once the plan succeeds, run " + ansi.Cyan("./terraform apply") + " to complete the import.\n\n")
 				cli.renderer.Infof("The terraform binary and auth0_import.tf files can be deleted afterwards.\n")

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -61,6 +61,8 @@ type (
 	}
 )
 
+var errTerraformInstallFailed = errors.New("failed to install terraform")
+
 func (i *terraformInputs) parseResourceFetchers(api *auth0.API, apiv2 *auth0.APIV2) ([]resourceDataFetcher, error) {
 	fetchers := make([]resourceDataFetcher, 0)
 	var err error
@@ -221,7 +223,11 @@ func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.
 			})
 
 			if err != nil {
-				cli.renderer.Warnf("Terraform resource config generated successfully but there was an error: %s\n\n", err)
+				if errors.Is(err, errTerraformInstallFailed) {
+					cli.renderer.Warnf("%s\n\n", err)
+				} else {
+					cli.renderer.Warnf("Terraform resource config generated successfully but there was an error with terraform plan.\n\n")
+				}
 				cli.renderer.Warnf("Run " + ansi.Cyan(cdInstructions+"./terraform plan") + " to troubleshoot\n\n")
 				cli.renderer.Warnf("Once the plan succeeds, run " + ansi.Cyan("./terraform apply") + " to complete the import.\n\n")
 				cli.renderer.Infof("The terraform binary and auth0_import.tf files can be deleted afterwards.\n")
@@ -378,7 +384,7 @@ func generateTerraformResourceConfig(ctx context.Context, input *terraformInputs
 
 	execPath, err := installer.Install(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", errTerraformInstallFailed, err)
 	}
 
 	tf, err := tfexec.NewTerraform(absoluteOutputPath, execPath)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### Problem

When `hc-install` fails to install Terraform (e.g. due to an expired OpenPGP key: `unable to verify checksums signature: openpgp: invalid message: openpgp: key expired`), the error was silently discarded. The user saw only a generic message:

> "Terraform resource config generated successfully but there was an error with terraform plan."

This was misleading on two counts:
1. The error came from the **install step**, not from `terraform plan`.
2. The actual error message was never shown, leaving users with no actionable information.

### 🔧 Changes

Include the real error in the warning output so users can diagnose what went wrong — whether it's an OpenPGP verification failure, a network error, a version resolution issue, or anything else from `hc-install` or `tfexec`.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

https://github.com/auth0/auth0-cli/issues/1499#issuecomment-4446636507

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->


<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
