### PR TITLE
chore: Add Sentry DSN so crash reporting works in all builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
           workdir: 'auth0-cli'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       # Homebrew Tap Process
       - name: Checkout Homebrew Tap Repo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,6 @@ builds:
       - -X 'github.com/auth0/auth0-cli/internal/buildinfo.Revision={{.Commit}}'
       - -X 'github.com/auth0/auth0-cli/internal/buildinfo.BuildUser=goreleaser'
       - -X 'github.com/auth0/auth0-cli/internal/buildinfo.BuildDate={{.Date}}'
-      - -X 'github.com/auth0/auth0-cli/internal/instrumentation.SentryDSN={{.Env.SENTRY_DSN}}'
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ title .Os }}_{{ if eq .Arch "arm64" }}arm64{{ else }}x86_64{{ end }}'
     files:

--- a/internal/instrumentation/instrumentation.go
+++ b/internal/instrumentation/instrumentation.go
@@ -7,7 +7,13 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-var SentryDSN string
+// SentryDSN is the destination for crash reports. A Sentry DSN is a public,
+// write-only key that is safe to ship inside client binaries, so we hardcode a
+// default here. This ensures crash reporting works for builds that are not
+// produced by our release pipeline (for example Homebrew Core, which builds
+// from source and cannot inject build-time values). Release builds may still
+// override this via ldflags.
+var SentryDSN = "https://370df87d33df46cb90182dd80a50fdc4@o27592.ingest.sentry.io/5694458"
 
 // ReportException is designed to be called once as the CLI exits. We're
 // purposefully initializing a client all the time given this context.

--- a/internal/instrumentation/instrumentation.go
+++ b/internal/instrumentation/instrumentation.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
+	"github.com/auth0/auth0-cli/internal/buildinfo"
 )
 
 // SentryDSN is the destination for crash reports. A Sentry DSN is a public,
@@ -19,6 +21,15 @@ var SentryDSN = "https://370df87d33df46cb90182dd80a50fdc4@o27592.ingest.sentry.i
 // purposefully initializing a client all the time given this context.
 func ReportException(err error) bool {
 	if SentryDSN == "" {
+		return false
+	}
+
+	// Skip crash reporting for local/development builds so that dev-time panics
+	// and errors are not shipped to Sentry. Release pipelines (goreleaser and
+	// Homebrew Core) stamp a real semantic version via ldflags, whereas a local
+	// `make build`/`make install` stamps "dev" and a plain `go build` leaves it
+	// empty.
+	if buildinfo.Version == "" || buildinfo.Version == "dev" {
 		return false
 	}
 

--- a/internal/instrumentation/instrumentation_test.go
+++ b/internal/instrumentation/instrumentation_test.go
@@ -1,0 +1,62 @@
+package instrumentation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/auth0-cli/internal/buildinfo"
+)
+
+func TestReportException(t *testing.T) {
+	tests := []struct {
+		name      string
+		sentryDSN string
+		version   string
+		want      bool
+	}{
+		{
+			name:      "skips when Sentry DSN is empty",
+			sentryDSN: "",
+			version:   "1.32.0",
+			want:      false,
+		},
+		{
+			name:      "skips for a plain go build with no version",
+			sentryDSN: "https://public@o0.ingest.sentry.io/0",
+			version:   "",
+			want:      false,
+		},
+		{
+			name:      "skips for a local dev build",
+			sentryDSN: "https://public@o0.ingest.sentry.io/0",
+			version:   "dev",
+			want:      false,
+		},
+		{
+			name:      "reports for a real release build",
+			sentryDSN: "https://public@o0.ingest.sentry.io/0",
+			version:   "1.32.0",
+			want:      true,
+		},
+	}
+
+	originalDSN := SentryDSN
+	originalVersion := buildinfo.Version
+	t.Cleanup(func() {
+		SentryDSN = originalDSN
+		buildinfo.Version = originalVersion
+	})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			SentryDSN = test.sentryDSN
+			buildinfo.Version = test.version
+
+			got := ReportException(errors.New("boom"))
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### 🔧 Changes

Hardcodes the Sentry DSN as the default value of `instrumentation.SentryDSN`, and removes the build-time `SENTRY_DSN` injection from the release pipeline.

A Sentry DSN is a public, write-only key that is safe to ship in client binaries. Hardcoding it means crash reporting works consistently across all build paths, including from-source builds such as Homebrew Core that cannot inject build-time values.

- `internal/instrumentation/instrumentation.go`: `SentryDSN` now defaults to the project DSN.
- `.goreleaser.yml`: removed the `-X ...SentryDSN` ldflag.
- `.github/workflows/release.yml`: removed the now-unused `SENTRY_DSN` env var.

### 🔬 Testing

Built from source and confirmed the DSN is embedded in the binary, with version stamping unaffected.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A) — N/A
- [x] I have added documentation for all new/changed functionality (or N/A) — N/A
