### PR TITLE
docs: use official Homebrew core and Scoop main bucket for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,15 @@ Build, manage and test your [Auth0](https://auth0.com/) integrations from the co
 Install via [Homebrew](https://brew.sh/):
 
 ```bash
-brew tap auth0/auth0-cli && brew install auth0
+brew install auth0
 ```
+
+> [!NOTE]
+> The CLI is now available in the official Homebrew core, so a custom tap is no longer needed. If you previously installed via the `auth0/auth0-cli` tap, migrate with:
+> ```bash
+> brew uninstall auth0 && brew untap auth0/auth0-cli
+> brew install auth0
+> ```
 
 Install via [cURL](https://curl.se/):
 
@@ -60,10 +67,15 @@ Install via [cURL](https://curl.se/):
 Install via [Scoop](https://scoop.sh/):
 
 ```bash
-scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
 scoop install auth0
 ```
 
+> [!NOTE]
+> The CLI is now available in the official Scoop `main` bucket (enabled by default), so a custom bucket is no longer needed. If you previously installed from the `auth0/scoop-auth0-cli` bucket, migrate with:
+> ```bash
+> scoop uninstall auth0 && scoop bucket rm auth0
+> scoop install auth0
+> ```
 
 Install via [Powershell](https://learn.microsoft.com/en-us/powershell/):
 


### PR DESCRIPTION
### 🔧 Changes

The Auth0 CLI is now published to the official Homebrew core and the Scoop `main` bucket, so the custom tap and bucket are no longer required to install the stable release. This updates the README installation section accordingly:

- **Homebrew (Linux/macOS):** simplified to `brew install auth0` (dropped the `brew tap auth0/auth0-cli` step).
- **Scoop (Windows):** simplified to `scoop install auth0` (dropped the `scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git` step, since `main` is enabled by default).
- Added migration notes for users who previously installed from the old tap/bucket, showing how to uninstall, remove the tap/bucket, and reinstall from the official source.

The beta installation section is intentionally left unchanged, as beta builds (`auth0-beta`) are still published through the custom `auth0/auth0-cli` tap and `auth0/scoop-auth0-cli` bucket.

### 📚 References

N/A

### 🔬 Testing

Documentation-only change. Verified that `auth0` is present in Homebrew core (`brew install auth0`) and the Scoop `main` bucket before updating the instructions.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
