### PR TITLE
refactor: migrate management SDK usage from go-auth0 v2 to v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,17 @@ Apply these on every task in this repo — they keep changes correct, small, and
 
 ## Project Overview
 
-**auth0-cli** is the official command-line interface for Auth0 — build, manage, and test Auth0 integrations from the terminal.
+**auth0-cli** is the official command-line interface for Auth0, used to build, manage, and test Auth0 integrations from the terminal.
 
 - **Language:** Go 1.25.8
-- **Tech Stack:** Cobra (commands) + pflag, go-auth0 Management SDK (v1 `management` and v2), Sentry crash reporting, zalando/go-keyring for secret storage, terraform-exec (Terraform export), charmbracelet/glamour (markdown rendering)
-- **Package Manager:** Go modules — **vendored** (`vendor/` is committed; run `go mod tidy && go mod vendor` after dependency changes)
-- **Minimum Platform Version:** Go 1.25.8 (from `go.mod`)
-- **Dependencies:** go-auth0 v1.44.0 + v2.14.0, spf13/cobra 1.10.2, getsentry/sentry-go 0.47.0, zalando/go-keyring 0.2.8 · test: stretchr/testify 1.11.1, golang/mock (gomock) 1.6.0
-
+- **Package Manager:** Go modules (vendored). Run `go mod tidy && go mod vendor` after dependency changes.
+- **Command Framework:** Cobra (`spf13/cobra`) with `pflag`
+- **Auth0 APIs:** `go-auth0` Management SDK (v1 and v3)
+- **Secret Storage:** `zalando/go-keyring`
+- **Crash Reporting:** Sentry (`sentry-go`)
+- **Terraform:** `terraform-exec` for Terraform export functionality
+- **Markdown Rendering:** `charmbracelet/glamour`
+- **Testing:** Go `testing`, `stretchr/testify`, and `gomock`
 ---
 
 ## Project Structure
@@ -136,7 +139,7 @@ See [references/git-workflow.md](references/git-workflow.md) for branch, commit,
 
 ## Common Pitfalls
 
-The top one: forgetting `make docs` after a command/flag change fails CI (`make check-docs`). Others involve vendoring, mock regeneration, and the v1/v2 go-auth0 split.
+The top one: forgetting `make docs` after a command/flag change fails CI (`make check-docs`). Others involve vendoring, mock regeneration, and the v1/3 go-auth0 split.
 
 See [references/pitfalls.md](references/pitfalls.md) for the full list. Read it when a build/CI step fails unexpectedly.
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.4.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/auth0/go-auth0 v1.45.0
-	github.com/auth0/go-auth0/v2 v2.14.0
+	github.com/auth0/go-auth0/v3 v3.2.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/PuerkitoBio/rehttp v1.4.0
 	github.com/atotto/clipboard v0.1.4
-	github.com/auth0/go-auth0 v1.45.0
+	github.com/auth0/go-auth0 v1.46.0
 	github.com/auth0/go-auth0/v3 v3.2.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/auth0/go-auth0 v1.45.0 h1:fQaNSWpoMneYsutOr+3fTOXIsFAQThSf2A0ShL3oaZg=
 github.com/auth0/go-auth0 v1.45.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
-github.com/auth0/go-auth0/v2 v2.14.0 h1:zDxwRHGAt6gLK/OG6wAkB5ScQEJ8WW/ex1EnJig8fFc=
-github.com/auth0/go-auth0/v2 v2.14.0/go.mod h1:Q/Y3VZVoI3sw87VyTPhx2TQL6Sq4Q/iCP67rW2gcn+M=
+github.com/auth0/go-auth0/v3 v3.2.0 h1:/6kg5IXrsJcrWxOtfk8H2FHESeBbYvlFsHFwfLV65/E=
+github.com/auth0/go-auth0/v3 v3.2.0/go.mod h1:0a8Yg46Et2wJICZZt5ihpnN/Q53GGiV8fSWkIhEK5x4=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/auth0/attack_protection.go
+++ b/internal/auth0/attack_protection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/auth0/go-auth0/management"
-	managementv2 "github.com/auth0/go-auth0/v2/management"
-	"github.com/auth0/go-auth0/v2/management/option"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	"github.com/auth0/go-auth0/v3/management/option"
 )
 
 type AttackProtectionAPI interface {
@@ -67,18 +67,18 @@ type AttackProtectionAPI interface {
 	) (err error)
 }
 
-type AttackProtectionBotDetectionAPIV2 interface {
+type AttackProtectionBotDetectionAPIV3 interface {
 	// Get the Bot Detection configuration of tenant.
 	//
 	// Required scope: `read:attack_protection`
 	//
 	// See: https://auth0.com/docs/api/management/v2#!/attack-protection/get-bot-detection
-	Get(ctx context.Context, opts ...option.RequestOption) (*managementv2.GetBotDetectionSettingsResponseContent, error)
+	Get(ctx context.Context, opts ...option.RequestOption) (*managementv3.GetBotDetectionSettingsResponseContent, error)
 
 	// Update the Bot Detection configuration of tenant.
 	//
 	// Required scope: `update:attack_protection`
 	//
 	// See: https://auth0.com/docs/api/management/v2#!/attack-protection/patch-bot-detection
-	Update(ctx context.Context, request *managementv2.UpdateBotDetectionSettingsRequestContent, opts ...option.RequestOption) (*managementv2.UpdateBotDetectionSettingsResponseContent, error)
+	Update(ctx context.Context, request *managementv3.UpdateBotDetectionSettingsRequestContent, opts ...option.RequestOption) (*managementv3.UpdateBotDetectionSettingsResponseContent, error)
 }

--- a/internal/auth0/auth0.go
+++ b/internal/auth0/auth0.go
@@ -3,7 +3,7 @@ package auth0
 import (
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
-	managementv2 "github.com/auth0/go-auth0/v2/management/client"
+	managementv3 "github.com/auth0/go-auth0/v3/management/client"
 )
 
 // API mimics `management.Management`s general interface, except it refers to
@@ -77,14 +77,14 @@ func NewAPI(m *management.Management) *API {
 	}
 }
 
-type APIV2 struct {
-	AttackProtectionBotDetection AttackProtectionBotDetectionAPIV2
-	Events                       EventsAPIV2
+type APIV3 struct {
+	AttackProtectionBotDetection AttackProtectionBotDetectionAPIV3
+	Events                       EventsAPIV3
 	PhoneNotificationTemplate    PhoneNotificationTemplateAPI
 }
 
-func NewAPIV2(m *managementv2.Management) *APIV2 {
-	return &APIV2{
+func NewAPIV3(m *managementv3.Management) *APIV3 {
+	return &APIV3{
 		AttackProtectionBotDetection: m.AttackProtection.BotDetection,
 		Events:                       m.Events,
 		PhoneNotificationTemplate:    m.Branding.Phone.Templates,

--- a/internal/auth0/events.go
+++ b/internal/auth0/events.go
@@ -3,14 +3,14 @@ package auth0
 import (
 	"context"
 
-	managementv2 "github.com/auth0/go-auth0/v2/management"
-	"github.com/auth0/go-auth0/v2/management/core"
-	"github.com/auth0/go-auth0/v2/management/option"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	"github.com/auth0/go-auth0/v3/management/core"
+	"github.com/auth0/go-auth0/v3/management/option"
 )
 
-// EventsAPIV2 is the V2 SDK interface for the /events endpoint
+// EventsAPIV3 is the V3 SDK interface for the /events endpoint
 // (Server-Sent Event subscription stream).
-type EventsAPIV2 interface {
+type EventsAPIV3 interface {
 	// Subscribe to events via Server-Sent Events (SSE).
 	//
 	// Required scope: `read:events`
@@ -18,7 +18,7 @@ type EventsAPIV2 interface {
 	// See: https://auth0.com/docs/api/management/v2/events/get-events
 	Subscribe(
 		ctx context.Context,
-		request *managementv2.SubscribeEventsRequestParameters,
+		request *managementv3.SubscribeEventsRequestParameters,
 		opts ...option.RequestOption,
-	) (*core.Stream[managementv2.EventStreamSubscribeEventsResponseContent], error)
+	) (*core.Stream[managementv3.EventStreamSubscribeEventsResponseContent], error)
 }

--- a/internal/auth0/mock/phone_notification_template_mock.go
+++ b/internal/auth0/mock/phone_notification_template_mock.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	management "github.com/auth0/go-auth0/v2/management"
-	option "github.com/auth0/go-auth0/v2/management/option"
+	management "github.com/auth0/go-auth0/v3/management"
+	option "github.com/auth0/go-auth0/v3/management/option"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/internal/auth0/phone_notification_template.go
+++ b/internal/auth0/phone_notification_template.go
@@ -5,10 +5,10 @@ package auth0
 import (
 	"context"
 
-	managementv2 "github.com/auth0/go-auth0/v2/management"
-	"github.com/auth0/go-auth0/v2/management/option"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	"github.com/auth0/go-auth0/v3/management/option"
 )
 
 type PhoneNotificationTemplateAPI interface {
-	List(ctx context.Context, request *managementv2.ListPhoneTemplatesRequestParameters, opts ...option.RequestOption) (*managementv2.ListPhoneTemplatesResponseContent, error)
+	List(ctx context.Context, request *managementv3.ListPhoneTemplatesRequestParameters, opts ...option.RequestOption) (*managementv3.ListPhoneTemplatesResponseContent, error)
 }

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/auth0/go-auth0/v2/management/core"
+	"github.com/auth0/go-auth0/v3/management/core"
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/ansi"

--- a/internal/cli/attack_protection_bot_detection.go
+++ b/internal/cli/attack_protection_bot_detection.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"strings"
 
-	managementv2 "github.com/auth0/go-auth0/v2/management"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
@@ -150,9 +150,9 @@ func updateBotDetectionCmd(cli *cli) *cobra.Command {
 
 func showBotDetectionCmdRun(cli *cli) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		var bd *managementv2.GetBotDetectionSettingsResponseContent
+		var bd *managementv3.GetBotDetectionSettingsResponseContent
 		err := ansi.Waiting(func() (err error) {
-			bd, err = cli.apiv2.AttackProtectionBotDetection.Get(cmd.Context())
+			bd, err = cli.apiv3.AttackProtectionBotDetection.Get(cmd.Context())
 			return err
 		})
 		if err != nil {
@@ -167,15 +167,15 @@ func showBotDetectionCmdRun(cli *cli) func(cmd *cobra.Command, args []string) er
 
 func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		var current *managementv2.GetBotDetectionSettingsResponseContent
+		var current *managementv3.GetBotDetectionSettingsResponseContent
 		if err := ansi.Waiting(func() (err error) {
-			current, err = cli.apiv2.AttackProtectionBotDetection.Get(cmd.Context())
+			current, err = cli.apiv3.AttackProtectionBotDetection.Get(cmd.Context())
 			return err
 		}); err != nil {
 			return err
 		}
 
-		bdUpdate := &managementv2.UpdateBotDetectionSettingsRequestContent{}
+		bdUpdate := &managementv3.UpdateBotDetectionSettingsRequestContent{}
 		noLocalFlagSet := noLocalFlagSet(cmd)
 
 		// Set bot detection level.
@@ -186,7 +186,7 @@ func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *co
 			if inputs.BotDetectionLevel == "" {
 				inputs.BotDetectionLevel = string(current.GetBotDetectionLevel())
 			}
-			botDetectionLevel, err := managementv2.NewBotDetectionLevelEnumFromString(inputs.BotDetectionLevel)
+			botDetectionLevel, err := managementv3.NewBotDetectionLevelEnumFromString(inputs.BotDetectionLevel)
 			if err != nil {
 				return err
 			}
@@ -201,7 +201,7 @@ func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *co
 			if inputs.ChallengePasswordPolicy == "" {
 				inputs.ChallengePasswordPolicy = string(current.GetChallengePasswordPolicy())
 			}
-			challengePasswordPolicy, err := managementv2.NewBotDetectionChallengePolicyPasswordFlowEnumFromString(inputs.ChallengePasswordPolicy)
+			challengePasswordPolicy, err := managementv3.NewBotDetectionChallengePolicyPasswordFlowEnumFromString(inputs.ChallengePasswordPolicy)
 			if err != nil {
 				return err
 			}
@@ -216,7 +216,7 @@ func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *co
 			if inputs.ChallengePasswordlessPolicy == "" {
 				inputs.ChallengePasswordlessPolicy = string(current.GetChallengePasswordlessPolicy())
 			}
-			challengePasswordlessPolicy, err := managementv2.NewBotDetectionChallengePolicyPasswordlessFlowEnumFromString(inputs.ChallengePasswordlessPolicy)
+			challengePasswordlessPolicy, err := managementv3.NewBotDetectionChallengePolicyPasswordlessFlowEnumFromString(inputs.ChallengePasswordlessPolicy)
 			if err != nil {
 				return err
 			}
@@ -231,7 +231,7 @@ func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *co
 			if inputs.ChallengePasswordResetPolicy == "" {
 				inputs.ChallengePasswordResetPolicy = string(current.GetChallengePasswordResetPolicy())
 			}
-			challengePasswordResetPolicy, err := managementv2.NewBotDetectionChallengePolicyPasswordResetFlowEnumFromString(inputs.ChallengePasswordResetPolicy)
+			challengePasswordResetPolicy, err := managementv3.NewBotDetectionChallengePolicyPasswordResetFlowEnumFromString(inputs.ChallengePasswordResetPolicy)
 			if err != nil {
 				return err
 			}
@@ -258,10 +258,10 @@ func updateBotDetectionCmdRun(cli *cli, inputs *botDetectionInputs) func(cmd *co
 			bdUpdate.SetMonitoringModeEnabled(&inputs.MonitoringModeEnabled)
 		}
 
-		var updatedBD *managementv2.UpdateBotDetectionSettingsResponseContent
+		var updatedBD *managementv3.UpdateBotDetectionSettingsResponseContent
 		if err := ansi.Waiting(func() error {
 			var err error
-			updatedBD, err = cli.apiv2.AttackProtectionBotDetection.Update(cmd.Context(), bdUpdate)
+			updatedBD, err = cli.apiv3.AttackProtectionBotDetection.Update(cmd.Context(), bdUpdate)
 			return err
 		}); err != nil {
 			return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,7 @@ const userAgent = "Auth0 CLI"
 type cli struct {
 	// Core primitives exposed to command builders.
 	api      *auth0.API
-	apiv2    *auth0.APIV2
+	apiv3    *auth0.APIV3
 	renderer *display.Renderer
 	tracker  *analytics.Tracker
 
@@ -139,13 +139,13 @@ func (c *cli) setupWithAuthentication(ctx context.Context) error {
 		return err
 	}
 
-	apiv2, err := initializeManagementClientV2(tenant.Domain, tenant.GetAccessToken())
+	apiv3, err := initializeManagementClientV3(tenant.Domain, tenant.GetAccessToken())
 	if err != nil {
 		return err
 	}
 
 	c.api = auth0.NewAPI(api)
-	c.apiv2 = auth0.NewAPIV2(apiv2)
+	c.apiv3 = auth0.NewAPIV3(apiv3)
 	return nil
 }
 

--- a/internal/cli/event_streams_subscribe.go
+++ b/internal/cli/event_streams_subscribe.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	managementv2 "github.com/auth0/go-auth0/v2/management"
-	managementoption "github.com/auth0/go-auth0/v2/management/option"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	managementoption "github.com/auth0/go-auth0/v3/management/option"
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
@@ -100,28 +100,28 @@ var (
 // SDK enum constants so a rename or removal in go-auth0 is a compile-time
 // failure here. New types added to the SDK still need a manual append.
 var supportedEventTypes = []string{
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupCreated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupMemberAdded),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupMemberDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupRoleAssigned),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupRoleDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumGroupUpdated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionAdded),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionRemoved),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionUpdated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationCreated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationGroupRoleAssigned),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationGroupRoleDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberAdded),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberRoleAssigned),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberRoleDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumOrganizationUpdated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumUserCreated),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumUserDeleted),
-	string(managementv2.EventStreamSubscribeEventsEventTypeEnumUserUpdated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupCreated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupMemberAdded),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupMemberDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupRoleAssigned),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupRoleDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumGroupUpdated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionAdded),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionRemoved),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationConnectionUpdated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationCreated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationGroupRoleAssigned),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationGroupRoleDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberAdded),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberRoleAssigned),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationMemberRoleDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumOrganizationUpdated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumUserCreated),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumUserDeleted),
+	string(managementv3.EventStreamSubscribeEventsEventTypeEnumUserUpdated),
 }
 
 type subscribeInputs struct {
@@ -176,7 +176,7 @@ func subscribeEventStreamCmd(cli *cli) *cobra.Command {
 				return nil
 			}
 
-			req := &managementv2.SubscribeEventsRequestParameters{}
+			req := &managementv3.SubscribeEventsRequestParameters{}
 
 			if inputs.From != "" {
 				req.From = &inputs.From
@@ -185,14 +185,14 @@ func subscribeEventStreamCmd(cli *cli) *cobra.Command {
 				req.FromTimestamp = &inputs.FromTimestamp
 			}
 			if len(inputs.EventTypes) > 0 {
-				eventTypes := make([]*managementv2.EventStreamSubscribeEventsEventTypeEnum, 0, len(inputs.EventTypes))
+				eventTypes := make([]*managementv3.EventStreamSubscribeEventsEventTypeEnum, 0, len(inputs.EventTypes))
 				var invalid []string
 				for _, t := range inputs.EventTypes {
 					t = strings.TrimSpace(t)
 					if t == "" {
 						continue
 					}
-					enum, err := managementv2.NewEventStreamSubscribeEventsEventTypeEnumFromString(t)
+					enum, err := managementv3.NewEventStreamSubscribeEventsEventTypeEnumFromString(t)
 					if err != nil {
 						invalid = append(invalid, t)
 						continue
@@ -304,7 +304,7 @@ func subscribeEventStreamCmd(cli *cli) *cobra.Command {
 			// Per-event handler shared across reconnects. Returns true when an
 			// event counts as forward progress (a real event or heartbeat),
 			// which resets the reconnect backoff.
-			handleEvent := func(event managementv2.EventStreamSubscribeEventsResponseContent) bool {
+			handleEvent := func(event managementv3.EventStreamSubscribeEventsResponseContent) bool {
 				summary := summarizeEvent(&event)
 
 				if summary.offset != "" {
@@ -389,7 +389,7 @@ func subscribeEventStreamCmd(cli *cli) *cobra.Command {
 				}
 
 				attemptStart := time.Now()
-				progressed, serverRetry, err := runStreamSession(ctx, cli.apiv2, req, lastOffset, handleEvent)
+				progressed, serverRetry, err := runStreamSession(ctx, cli.apiv3, req, lastOffset, handleEvent)
 				sessionDuration := time.Since(attemptStart)
 
 				// Ctrl+C or parent cancellation: always a graceful exit.
@@ -481,10 +481,10 @@ func subscribeEventStreamCmd(cli *cli) *cobra.Command {
 // clean server close).
 func runStreamSession(
 	ctx context.Context,
-	api *auth0.APIV2,
-	req *managementv2.SubscribeEventsRequestParameters,
+	api *auth0.APIV3,
+	req *managementv3.SubscribeEventsRequestParameters,
 	resumeFrom string,
-	handleEvent func(managementv2.EventStreamSubscribeEventsResponseContent) bool,
+	handleEvent func(managementv3.EventStreamSubscribeEventsResponseContent) bool,
 ) (progressed bool, serverRetry time.Duration, err error) {
 	if resumeFrom != "" {
 		req.From = &resumeFrom
@@ -564,7 +564,7 @@ type eventSummary struct {
 	errorMessage string
 }
 
-func summarizeEvent(ev *managementv2.EventStreamSubscribeEventsResponseContent) eventSummary {
+func summarizeEvent(ev *managementv3.EventStreamSubscribeEventsResponseContent) eventSummary {
 	s := eventSummary{eventType: ev.GetType()}
 	if s.eventType == "offset-only" {
 		s.isHeartbeat = true

--- a/internal/cli/event_streams_subscribe_test.go
+++ b/internal/cli/event_streams_subscribe_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	managementv2 "github.com/auth0/go-auth0/v2/management"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
 	"github.com/stretchr/testify/assert"
 )
 
-func unmarshalSubscribeEvent(t *testing.T, raw string) *managementv2.EventStreamSubscribeEventsResponseContent {
+func unmarshalSubscribeEvent(t *testing.T, raw string) *managementv3.EventStreamSubscribeEventsResponseContent {
 	t.Helper()
-	var ev managementv2.EventStreamSubscribeEventsResponseContent
+	var ev managementv3.EventStreamSubscribeEventsResponseContent
 	if err := json.Unmarshal([]byte(raw), &ev); err != nil {
 		t.Fatalf("unmarshal subscribe event: %v", err)
 	}

--- a/internal/cli/management.go
+++ b/internal/cli/management.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/auth0/go-auth0/management"
-	managementv2 "github.com/auth0/go-auth0/v2/management/client"
-	"github.com/auth0/go-auth0/v2/management/option"
+	managementv3 "github.com/auth0/go-auth0/v3/management/client"
+	"github.com/auth0/go-auth0/v3/management/option"
 
 	"github.com/auth0/auth0-cli/internal/buildinfo"
 )
@@ -32,8 +32,8 @@ func initializeManagementClient(tenantDomain string, accessToken string) (*manag
 	return client, err
 }
 
-func initializeManagementClientV2(tenantDomain string, accessToken string) (*managementv2.Management, error) {
-	client, err := managementv2.New(
+func initializeManagementClientV3(tenantDomain string, accessToken string) (*managementv3.Management, error) {
+	client, err := managementv3.New(
 		tenantDomain,
 		option.WithToken(accessToken),
 		option.WithUserAgent(fmt.Sprintf("%v/%v", userAgent, strings.TrimPrefix(buildinfo.Version, "v"))),

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,7 +11,7 @@ import (
 	"unicode"
 
 	"github.com/auth0/go-auth0/management"
-	"github.com/auth0/go-auth0/v2/management/core"
+	"github.com/auth0/go-auth0/v3/management/core"
 	"github.com/spf13/cobra"
 
 	"github.com/auth0/auth0-cli/internal/analytics"
@@ -372,16 +372,16 @@ func classifyCommandFailure(err error) map[string]string {
 
 // managementHTTPStatus extracts the HTTP status from a go-auth0 management API
 // error anywhere in the error chain, supporting both the v1 (management.Error)
-// and v2 (*core.APIError) SDK error types.
+// and v3 (*core.APIError) SDK error types.
 func managementHTTPStatus(err error) (int, bool) {
 	var v1 management.Error
 	if errors.As(err, &v1) {
 		return v1.Status(), true
 	}
 
-	var v2 *core.APIError
-	if errors.As(err, &v2) {
-		return v2.StatusCode, true
+	var v3 *core.APIError
+	if errors.As(err, &v3) {
+		return v3.StatusCode, true
 	}
 
 	return 0, false

--- a/internal/cli/terraform.go
+++ b/internal/cli/terraform.go
@@ -63,7 +63,7 @@ type (
 
 var errTerraformInstallFailed = errors.New("failed to install terraform")
 
-func (i *terraformInputs) parseResourceFetchers(api *auth0.API, apiv2 *auth0.APIV2) ([]resourceDataFetcher, error) {
+func (i *terraformInputs) parseResourceFetchers(api *auth0.API, apiv3 *auth0.APIV3) ([]resourceDataFetcher, error) {
 	fetchers := make([]resourceDataFetcher, 0)
 	var err error
 
@@ -80,7 +80,7 @@ func (i *terraformInputs) parseResourceFetchers(api *auth0.API, apiv2 *auth0.API
 		case "auth0_phone_provider":
 			fetchers = append(fetchers, &phoneProviderResourceFetcher{api})
 		case "auth0_phone_notification_template":
-			fetchers = append(fetchers, &phoneNotificationTemplateResourceFetcher{apiv2})
+			fetchers = append(fetchers, &phoneNotificationTemplateResourceFetcher{apiv3})
 		case "auth0_client", "auth0_client_credentials":
 			fetchers = append(fetchers, &clientResourceFetcher{api})
 		case "auth0_client_grant":
@@ -181,7 +181,7 @@ func generateTerraformCmd(cli *cli) *cobra.Command {
 
 func generateTerraformCmdRun(cli *cli, inputs *terraformInputs) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		resources, err := inputs.parseResourceFetchers(cli.api, cli.apiv2)
+		resources, err := inputs.parseResourceFetchers(cli.api, cli.apiv3)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/terraform_fetcher.go
+++ b/internal/cli/terraform_fetcher.go
@@ -135,7 +135,7 @@ type (
 	}
 
 	phoneNotificationTemplateResourceFetcher struct {
-		apiv2 *auth0.APIV2
+		apiv3 *auth0.APIV3
 	}
 )
 
@@ -198,7 +198,7 @@ func (f *phoneProviderResourceFetcher) FetchData(ctx context.Context) (importDat
 }
 
 func (f *phoneNotificationTemplateResourceFetcher) FetchData(ctx context.Context) (importDataList, error) {
-	phoneNotificationTemplateList, err := f.apiv2.PhoneNotificationTemplate.List(ctx, nil)
+	phoneNotificationTemplateList, err := f.apiv3.PhoneNotificationTemplate.List(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/terraform_fetcher_test.go
+++ b/internal/cli/terraform_fetcher_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/auth0/go-auth0/management"
-	managementv2 "github.com/auth0/go-auth0/v2/management"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -315,15 +315,15 @@ func Test_phoneNotificationTemplateResourceFetcher_FetchData(t *testing.T) {
 		phoneNotificationTemplateAPI.EXPECT().
 			List(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(
-				&managementv2.ListPhoneTemplatesResponseContent{
-					Templates: []*managementv2.PhoneTemplate{
+				&managementv3.ListPhoneTemplatesResponseContent{
+					Templates: []*managementv3.PhoneTemplate{
 						{
 							ID:   auth0.String("pnt_abc123"),
-							Type: managementv2.PhoneTemplateNotificationTypeEnumOtpVerify,
+							Type: managementv3.PhoneTemplateNotificationTypeEnumOtpVerify,
 						},
 						{
 							ID:   auth0.String("pnt_def456"),
-							Type: managementv2.PhoneTemplateNotificationTypeEnumOtpEnroll,
+							Type: managementv3.PhoneTemplateNotificationTypeEnumOtpEnroll,
 						},
 					},
 				},
@@ -331,7 +331,7 @@ func Test_phoneNotificationTemplateResourceFetcher_FetchData(t *testing.T) {
 			)
 
 		fetcher := phoneNotificationTemplateResourceFetcher{
-			apiv2: &auth0.APIV2{
+			apiv3: &auth0.APIV3{
 				PhoneNotificationTemplate: phoneNotificationTemplateAPI,
 			},
 		}
@@ -360,14 +360,14 @@ func Test_phoneNotificationTemplateResourceFetcher_FetchData(t *testing.T) {
 		phoneNotificationTemplateAPI.EXPECT().
 			List(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(
-				&managementv2.ListPhoneTemplatesResponseContent{
-					Templates: []*managementv2.PhoneTemplate{},
+				&managementv3.ListPhoneTemplatesResponseContent{
+					Templates: []*managementv3.PhoneTemplate{},
 				},
 				nil,
 			)
 
 		fetcher := phoneNotificationTemplateResourceFetcher{
-			apiv2: &auth0.APIV2{
+			apiv3: &auth0.APIV3{
 				PhoneNotificationTemplate: phoneNotificationTemplateAPI,
 			},
 		}
@@ -387,7 +387,7 @@ func Test_phoneNotificationTemplateResourceFetcher_FetchData(t *testing.T) {
 			Return(nil, fmt.Errorf("failed to list phone notification templates"))
 
 		fetcher := phoneNotificationTemplateResourceFetcher{
-			apiv2: &auth0.APIV2{
+			apiv3: &auth0.APIV3{
 				PhoneNotificationTemplate: phoneNotificationTemplateAPI,
 			},
 		}

--- a/internal/cli/terraform_test.go
+++ b/internal/cli/terraform_test.go
@@ -462,7 +462,7 @@ func TestCleanOutputDirectory(t *testing.T) {
 
 func TestTerraformInputs_ParseResourceFetchers(t *testing.T) {
 	api := &auth0.API{}
-	apiv2 := &auth0.APIV2{}
+	apiv3 := &auth0.APIV3{}
 
 	var testCases = []struct {
 		name                 string
@@ -485,7 +485,7 @@ func TestTerraformInputs_ParseResourceFetchers(t *testing.T) {
 				Resources: []string{"auth0_phone_notification_template"},
 			},
 			expectedDataFetchers: []resourceDataFetcher{
-				&phoneNotificationTemplateResourceFetcher{apiv2},
+				&phoneNotificationTemplateResourceFetcher{apiv3},
 			},
 		},
 		{
@@ -523,7 +523,7 @@ func TestTerraformInputs_ParseResourceFetchers(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := testCase.input.parseResourceFetchers(api, apiv2)
+			actual, err := testCase.input.parseResourceFetchers(api, apiv3)
 
 			if testCase.expectedError != "" {
 				assert.EqualError(t, err, testCase.expectedError)

--- a/internal/display/attack_protection.go
+++ b/internal/display/attack_protection.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/auth0/go-auth0/management"
-	managementv2 "github.com/auth0/go-auth0/v2/management"
+	managementv3 "github.com/auth0/go-auth0/v3/management"
 
 	"github.com/auth0/auth0-cli/internal/ansi"
 )
@@ -222,17 +222,17 @@ func (bd *botDetectionView) Object() interface{} {
 	return bd.raw
 }
 
-func (r *Renderer) BotDetectionShow(bd *managementv2.GetBotDetectionSettingsResponseContent) {
+func (r *Renderer) BotDetectionShow(bd *managementv3.GetBotDetectionSettingsResponseContent) {
 	r.Heading("bot detection")
 	r.Result(makeBotDetectionShowView(bd))
 }
 
-func (r *Renderer) BotDetectionUpdate(bd *managementv2.UpdateBotDetectionSettingsResponseContent) {
+func (r *Renderer) BotDetectionUpdate(bd *managementv3.UpdateBotDetectionSettingsResponseContent) {
 	r.Heading("bot detection updated")
 	r.Result(makeBotDetectionUpdateView(bd))
 }
 
-func makeBotDetectionShowView(bd *managementv2.GetBotDetectionSettingsResponseContent) *botDetectionView {
+func makeBotDetectionShowView(bd *managementv3.GetBotDetectionSettingsResponseContent) *botDetectionView {
 	return &botDetectionView{
 		BotDetectionLevel:            string(bd.GetBotDetectionLevel()),
 		ChallengePasswordPolicy:      string(bd.GetChallengePasswordPolicy()),
@@ -245,7 +245,7 @@ func makeBotDetectionShowView(bd *managementv2.GetBotDetectionSettingsResponseCo
 	}
 }
 
-func makeBotDetectionUpdateView(bd *managementv2.UpdateBotDetectionSettingsResponseContent) *botDetectionView {
+func makeBotDetectionUpdateView(bd *managementv3.UpdateBotDetectionSettingsResponseContent) *botDetectionView {
 	return &botDetectionView{
 		BotDetectionLevel:            string(bd.GetBotDetectionLevel()),
 		ChallengePasswordPolicy:      string(bd.GetChallengePasswordPolicy()),


### PR DESCRIPTION
### 🔧 Changes

Migrates the CLI's Management API usage from **go-auth0 v2 to v3**. v3 keeps v2's client initialization, package layout, and option pattern, so this is effectively an import-path change plus a naming refresh. It lays the groundwork for the upcoming priority-resource commands, which will be built on v3.

- Updated every `github.com/auth0/go-auth0/v2` import to `github.com/auth0/go-auth0/v3` across the `internal/cli`, `internal/auth0`, and `internal/display` packages.
- Renamed the v2-flavored identifiers to their v3 equivalents: the `managementv2` import alias, the `APIV2` struct and its `AttackProtectionBotDetectionAPIV2` / `EventsAPIV2` interfaces, the `NewAPIV2` constructor, the `apiv2` field on the `cli` struct, and `initializeManagementClientV2`.
- Regenerated the phone-notification-template mock (`make test-mocks`) against the v3 interface.
- Dropped `go-auth0/v2` from `go.mod`; the repo now depends on v1 + v3.

No command surface, flags, or output behavior change. None of the tightened v3 types (connection attribute identifiers, role pagination, phone backoff enum, federated tokensets, session-transfer device-binding enum) are referenced in the CLI, so the migration required no type fixes.

### 📚 References

Part of the CLI Priority Resource Coverage effort. This is the first PR in a stack that will add Connections, Client Grants, Flows & Forms, and Sessions + Refresh Tokens commands on top of go-auth0 v3.

### 🔬 Testing

- `go build ./...` and `go vet ./...` pass.
- Unit tests pass for the affected packages (`internal/cli`, `internal/auth0`, `internal/display`).
- `make lint` surfaces only pre-existing issues in files untouched by this change.
- The generated command docs are unchanged, since no command surface was modified.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
