### PR TITLE
feat(analytics): add `is_api` telemetry property for raw api command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -282,7 +282,14 @@ func commandTrackingProperties(cli *cli) map[string]string {
 		"output_format": outputFormatForTracking(cli.renderer),
 		"forced":        boolString(cli.force),
 		"agent_client":  detectAgent(interactive),
+		"is_api":        boolString(isAPICommand(cli.executedCommandPath)),
 	}
+}
+
+// isAPICommand reports whether the executed command is the raw
+// `auth0 api` Management API passthrough command.
+func isAPICommand(commandPath string) bool {
+	return commandPath == "auth0 api"
 }
 
 func outputFormatForTracking(renderer *display.Renderer) string {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -159,6 +159,25 @@ func TestIsCIEnvironment(t *testing.T) {
 	})
 }
 
+func TestIsAPICommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandPath string
+		expected    bool
+	}{
+		{"api command", "auth0 api", true},
+		{"root command", "auth0", false},
+		{"apis command is not the api command", "auth0 apis list", false},
+		{"empty command path", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isAPICommand(test.commandPath))
+		})
+	}
+}
+
 func TestMergeProperties(t *testing.T) {
 	base := map[string]string{"interactive": "true", "success": "true"}
 	override := map[string]string{"success": "false", "error_class": "auth"}


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This pull request enhances the tracking of command execution in the CLI by introducing a new property that identifies when the raw `auth0 api` Management API passthrough command is used. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

* Added an `is_api` property to the command tracking data, which indicates whether the executed command is the raw `auth0 api` passthrough command. 

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Added `TestIsAPICommand` 

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
