### PR TITLE
feat(actions): add --module flag to associate action modules

### DIFF
--- a/docs/auth0_actions_create.md
+++ b/docs/auth0_actions_create.md
@@ -26,6 +26,7 @@ auth0 actions create [flags]
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0"
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --secret "SECRET=value"
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --dependency "uuid=9.0.0" --secret "API_KEY=value" --secret "SECRET=value"
+  auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --module "module_id=mod_123,module_version_id=ver_456"
   auth0 actions create -n myaction -t post-login -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json
   auth0 actions create -n myaction -t post-login -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json-compact
 ```
@@ -38,6 +39,7 @@ auth0 actions create [flags]
   -d, --dependency stringToString   Third party npm module, and its version, that the action depends on. (default [])
       --json                        Output in json format.
       --json-compact                Output in compact json format.
+  -m, --module stringArray          Action module to associate with the action, as comma-separated key=value pairs matching the API fields: module_id and module_version_id (both required, UUIDs). Can be passed multiple times to associate several modules.
   -n, --name string                 Name of the action.
   -r, --runtime string              Runtime to be used in the action.  Possible values are: node22(recommended), node18, node16, node12
   -s, --secret stringToString       Secrets to be used in the action. (default [])

--- a/docs/auth0_actions_update.md
+++ b/docs/auth0_actions_update.md
@@ -26,6 +26,7 @@ auth0 actions update [flags]
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0"
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --secret "SECRET=value"
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --dependency "uuid=9.0.0" --secret "API_KEY=value" --secret "SECRET=value"
+  auth0 actions update <action-id> --module "module_id=mod_123,module_version_id=ver_456"
   auth0 actions update <action-id> -n myaction -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json
   auth0 actions update <action-id> -n myaction -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json-compact
 ```
@@ -39,6 +40,7 @@ auth0 actions update [flags]
       --force                       Skip confirmation.
       --json                        Output in json format.
       --json-compact                Output in compact json format.
+  -m, --module stringArray          Action module to associate with the action, as comma-separated key=value pairs matching the API fields: module_id and module_version_id (both required, UUIDs). Can be passed multiple times to associate several modules.
   -n, --name string                 Name of the action.
   -r, --runtime string              Runtime to be used in the action.  Possible values are: node22(recommended), node18, node16, node12
   -s, --secret stringToString       Secrets to be used in the action. (default [])

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/auth0/go-auth0"
@@ -65,6 +66,13 @@ var (
 		LongForm:  "runtime",
 		ShortForm: "r",
 		Help:      "Runtime to be used in the action.  Possible values are: node22(recommended), node18, node16, node12",
+	}
+
+	actionModule = Flag{
+		Name:      "Module",
+		LongForm:  "module",
+		ShortForm: "m",
+		Help:      "Action module to associate with the action, as comma-separated key=value pairs matching the API fields: module_id and module_version_id (both required, UUIDs). Can be passed multiple times to associate several modules.",
 	}
 
 	actionTemplates = map[string]string{
@@ -190,6 +198,7 @@ func createActionCmd(cli *cli) *cobra.Command {
 		Dependencies map[string]string
 		Secrets      map[string]string
 		Runtime      string
+		Modules      []string
 	}
 
 	cmd := &cobra.Command{
@@ -206,6 +215,7 @@ func createActionCmd(cli *cli) *cobra.Command {
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0"
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --secret "SECRET=value"
   auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --dependency "uuid=9.0.0" --secret "API_KEY=value" --secret "SECRET=value"
+  auth0 actions create --name myaction --trigger post-login --code "$(cat path/to/code.js)" --module "module_id=mod_123,module_version_id=ver_456"
   auth0 actions create -n myaction -t post-login -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json
   auth0 actions create -n myaction -t post-login -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json-compact`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -259,6 +269,14 @@ func createActionCmd(cli *cli) *cobra.Command {
 				Secrets:      inputSecretsToActionSecrets(inputs.Secrets),
 			}
 
+			if len(inputs.Modules) != 0 {
+				modules, err := inputModulesToActionModules(inputs.Modules)
+				if err != nil {
+					return err
+				}
+				action.Modules = modules
+			}
+
 			if err := ansi.Waiting(func() error {
 				return cli.api.Action.Create(cmd.Context(), action)
 			}); err != nil {
@@ -279,6 +297,7 @@ func createActionCmd(cli *cli) *cobra.Command {
 	actionDependency.RegisterStringMap(cmd, &inputs.Dependencies, nil)
 	actionSecret.RegisterStringMap(cmd, &inputs.Secrets, nil)
 	actionRuntime.RegisterString(cmd, &inputs.Runtime, "")
+	actionModule.RegisterStringArray(cmd, &inputs.Modules, nil)
 
 	return cmd
 }
@@ -291,6 +310,7 @@ func updateActionCmd(cli *cli) *cobra.Command {
 		Dependencies map[string]string
 		Secrets      map[string]string
 		Runtime      string
+		Modules      []string
 	}
 
 	cmd := &cobra.Command{
@@ -308,6 +328,7 @@ func updateActionCmd(cli *cli) *cobra.Command {
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0"
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --secret "SECRET=value"
   auth0 actions update <action-id> --name myaction --code "$(cat path/to/code.js)" --dependency "lodash=4.0.0" --dependency "uuid=9.0.0" --secret "API_KEY=value" --secret "SECRET=value"
+  auth0 actions update <action-id> --module "module_id=mod_123,module_version_id=ver_456"
   auth0 actions update <action-id> -n myaction -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json
   auth0 actions update <action-id> -n myaction -c "$(cat path/to/code.js)" -r node18 -d "lodash=4.0.0" -d "uuid=9.0.0" -s "API_KEY=value" -s "SECRET=value" --json-compact`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -332,26 +353,33 @@ func updateActionCmd(cli *cli) *cobra.Command {
 				return err
 			}
 
-			if err := actionCode.OpenEditorU(
-				cmd,
-				&inputs.Code,
-				oldAction.GetCode(),
-				inputs.Name+".*.js",
-			); err != nil {
-				return fmt.Errorf("failed to capture input from the editor: %w", err)
-			}
-
-			if !cli.force && canPrompt(cmd) {
-				var confirmed bool
-				if err := prompt.AskBool("Do you want to save the action code?", &confirmed, true); err != nil {
-					return fmt.Errorf("failed to capture prompt input: %w", err)
+			// When the update is driven purely by non-code flags (e.g. --module),
+			// skip the interactive code editor and its save confirmation so those
+			// changes aren't discarded by answering "No".
+			editingCode := actionCode.IsSet(cmd) || !hasNonCodeFlagSet(cmd)
+			if editingCode {
+				if err := actionCode.OpenEditorU(
+					cmd,
+					&inputs.Code,
+					oldAction.GetCode(),
+					inputs.Name+".*.js",
+				); err != nil {
+					return fmt.Errorf("failed to capture input from the editor: %w", err)
 				}
-				if !confirmed {
-					return nil
+
+				if !cli.force && canPrompt(cmd) {
+					var confirmed bool
+					if err := prompt.AskBool("Do you want to save the action code?", &confirmed, true); err != nil {
+						return fmt.Errorf("failed to capture prompt input: %w", err)
+					}
+					if !confirmed {
+						return nil
+					}
 				}
 			}
 
 			updatedAction := &management.Action{
+				Name:              oldAction.Name,
 				SupportedTriggers: oldAction.SupportedTriggers,
 			}
 			if inputs.Name != "" {
@@ -365,6 +393,14 @@ func updateActionCmd(cli *cli) *cobra.Command {
 			}
 			if len(inputs.Secrets) != 0 {
 				updatedAction.Secrets = inputSecretsToActionSecrets(inputs.Secrets)
+			}
+
+			if len(inputs.Modules) != 0 {
+				modules, err := inputModulesToActionModules(inputs.Modules)
+				if err != nil {
+					return err
+				}
+				updatedAction.Modules = modules
 			}
 
 			if inputs.Runtime != "" {
@@ -391,8 +427,19 @@ func updateActionCmd(cli *cli) *cobra.Command {
 	actionDependency.RegisterStringMapU(cmd, &inputs.Dependencies, nil)
 	actionSecret.RegisterStringMapU(cmd, &inputs.Secrets, nil)
 	actionRuntime.RegisterStringU(cmd, &inputs.Runtime, "")
+	actionModule.RegisterStringArrayU(cmd, &inputs.Modules, nil)
 
 	return cmd
+}
+
+// hasNonCodeFlagSet reports whether the user set any update flag other than the
+// action code, so a non-code update (e.g. --module) can skip the code editor.
+func hasNonCodeFlagSet(cmd *cobra.Command) bool {
+	return actionName.IsSet(cmd) ||
+		actionDependency.IsSet(cmd) ||
+		actionSecret.IsSet(cmd) ||
+		actionRuntime.IsSet(cmd) ||
+		actionModule.IsSet(cmd)
 }
 
 func deleteActionCmd(cli *cli) *cobra.Command {
@@ -720,6 +767,49 @@ func inputSecretsToActionSecrets(secrets map[string]string) *[]management.Action
 	}
 
 	return &actionSecrets
+}
+
+// inputModulesToActionModules parses repeatable --module flag values into the
+// action's Modules payload. Each value is a comma-separated set of key=value
+// pairs whose keys mirror the Management API field names: module_id and
+// module_version_id, both required. The API identifies the version to attach by
+// its UUID (module_version_id); the version number is derived server-side and
+// returned on read, so it is not accepted as input here.
+func inputModulesToActionModules(modules []string) (*[]management.ActionModules, error) {
+	actionModules := make([]management.ActionModules, 0, len(modules))
+
+	for _, raw := range modules {
+		var module management.ActionModules
+
+		for _, pair := range strings.Split(raw, ",") {
+			key, value, found := strings.Cut(pair, "=")
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if !found || key == "" || value == "" {
+				return nil, fmt.Errorf("invalid --module value %q: expected comma-separated key=value pairs (e.g. \"module_id=<uuid>,module_version_id=<uuid>\")", raw)
+			}
+
+			switch key {
+			case "module_id":
+				module.ModuleID = auth0.String(value)
+			case "module_version_id":
+				module.ModuleVersionID = auth0.String(value)
+			default:
+				return nil, fmt.Errorf("invalid --module value %q: unknown key %q (supported keys: module_id, module_version_id)", raw, key)
+			}
+		}
+
+		if module.ModuleID == nil {
+			return nil, fmt.Errorf("invalid --module value %q: module_id is required", raw)
+		}
+		if module.ModuleVersionID == nil {
+			return nil, fmt.Errorf("invalid --module value %q: module_version_id is required (the UUID of a specific module version)", raw)
+		}
+
+		actionModules = append(actionModules, module)
+	}
+
+	return &actionModules, nil
 }
 
 func printColorDiff(code1, code2 string, fromVersion, toVersion int) {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -132,6 +132,56 @@ func TestActionsDeployCmd(t *testing.T) {
 	})
 }
 
+func TestActionsUpdateCmd(t *testing.T) {
+	t.Run("it carries the existing name forward on a module-only update", func(t *testing.T) {
+		actionID := "1221c74c-cfd6-40db-af13-7bc9bb1c38db"
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		actionAPI := mock.NewMockActionAPI(ctrl)
+		actionAPI.EXPECT().
+			Read(context.Background(), actionID).
+			Return(&management.Action{
+				ID:   auth0.String(actionID),
+				Name: auth0.String("existing-name"),
+				SupportedTriggers: []management.ActionTrigger{
+					{ID: auth0.String("post-login")},
+				},
+				Code: auth0.String("function () {}"),
+			}, nil)
+
+		var captured *management.Action
+		actionAPI.EXPECT().
+			Update(context.Background(), actionID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, a *management.Action, _ ...management.RequestOption) error {
+				captured = a
+				return nil
+			})
+
+		stdout := &bytes.Buffer{}
+		cli := &cli{
+			renderer: &display.Renderer{
+				MessageWriter: io.Discard,
+				ResultWriter:  stdout,
+			},
+			api: &auth0.API{Action: actionAPI},
+		}
+
+		cmd := updateActionCmd(cli)
+		cmd.SetArgs([]string{
+			actionID,
+			"--module", "module_id=mod_123,module_version_id=ver_456",
+		})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "existing-name", captured.GetName())
+		assert.Equal(t, []management.ActionModules{
+			{ModuleID: auth0.String("mod_123"), ModuleVersionID: auth0.String("ver_456")},
+		}, *captured.Modules)
+	})
+}
+
 func TestActionsPickerOptions(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -352,5 +402,56 @@ func TestActionsInputDependenciesToActionDependencies(t *testing.T) {
 		expected := []management.ActionDependency{}
 		assert.Len(t, *res, 0)
 		assert.Equal(t, expected, *res)
+	})
+}
+
+func TestActionsInputModulesToActionModules(t *testing.T) {
+	t.Run("it maps a single module with id and version id", func(t *testing.T) {
+		res, err := inputModulesToActionModules([]string{"module_id=mod_123,module_version_id=ver_456"})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []management.ActionModules{
+			{ModuleID: auth0.String("mod_123"), ModuleVersionID: auth0.String("ver_456")},
+		}, *res)
+	})
+
+	t.Run("it maps multiple modules", func(t *testing.T) {
+		res, err := inputModulesToActionModules([]string{
+			"module_id=mod_123,module_version_id=ver_456",
+			"module_id=mod_789,module_version_id=ver_abc",
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []management.ActionModules{
+			{ModuleID: auth0.String("mod_123"), ModuleVersionID: auth0.String("ver_456")},
+			{ModuleID: auth0.String("mod_789"), ModuleVersionID: auth0.String("ver_abc")},
+		}, *res)
+	})
+
+	t.Run("it handles empty input modules", func(t *testing.T) {
+		res, err := inputModulesToActionModules([]string{})
+		expected := []management.ActionModules{}
+		assert.NoError(t, err)
+		assert.Equal(t, &expected, res)
+	})
+
+	t.Run("it errors on a malformed pair", func(t *testing.T) {
+		_, err := inputModulesToActionModules([]string{"mod_123"})
+		assert.ErrorContains(t, err, "expected comma-separated key=value pairs")
+	})
+
+	t.Run("it errors when module_id is missing", func(t *testing.T) {
+		_, err := inputModulesToActionModules([]string{"module_version_id=ver_456"})
+		assert.ErrorContains(t, err, "module_id is required")
+	})
+
+	t.Run("it errors when module_version_id is missing", func(t *testing.T) {
+		_, err := inputModulesToActionModules([]string{"module_id=mod_123"})
+		assert.ErrorContains(t, err, "module_version_id is required")
+	})
+
+	t.Run("it errors on an unknown key", func(t *testing.T) {
+		_, err := inputModulesToActionModules([]string{"module_id=mod_123,foo=bar"})
+		assert.ErrorContains(t, err, "unknown key")
 	})
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -137,6 +137,14 @@ func (f *Flag) RegisterStringSliceU(cmd *cobra.Command, value *[]string, default
 	registerStringSlice(cmd, f, value, defaultValue, true)
 }
 
+func (f *Flag) RegisterStringArray(cmd *cobra.Command, value *[]string, defaultValue []string) {
+	registerStringArray(cmd, f, value, defaultValue, false)
+}
+
+func (f *Flag) RegisterStringArrayU(cmd *cobra.Command, value *[]string, defaultValue []string) {
+	registerStringArray(cmd, f, value, defaultValue, true)
+}
+
 func (f *Flag) RegisterStringMap(cmd *cobra.Command, value *map[string]string, defaultValue map[string]string) {
 	registerStringMap(cmd, f, value, defaultValue, false)
 }
@@ -322,6 +330,24 @@ func registerStringSlice(cmd *cobra.Command, f *Flag, value *[]string, defaultVa
 
 	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
 		panic(auth0.Error(err, "failed to register string slice flag"))
+	}
+}
+
+func registerStringArray(cmd *cobra.Command, f *Flag, value *[]string, defaultValue []string, isUpdate bool) {
+	cmd.Flags().StringArrayVarP(value, f.LongForm, f.ShortForm, defaultValue, f.Help)
+
+	// Set up flag aliases if specified.
+	if len(f.AlsoKnownAs) > 0 {
+		flag := cmd.Flags().Lookup(f.LongForm)
+		if flag != nil {
+			for _, alias := range f.AlsoKnownAs {
+				cmd.Flags().StringArrayVar(value, alias, defaultValue, f.Help)
+			}
+		}
+	}
+
+	if err := markFlagRequired(cmd, f, isUpdate); err != nil {
+		panic(auth0.Error(err, "failed to register string array flag"))
 	}
 }
 

--- a/internal/display/actions.go
+++ b/internal/display/actions.go
@@ -20,6 +20,7 @@ type actionView struct {
 	UpdatedAt       string
 	CreatedAt       string
 	Code            string
+	Modules         string
 	raw             interface{}
 }
 
@@ -32,7 +33,7 @@ func (v *actionView) AsTableRow() []string {
 }
 
 func (v *actionView) KeyValues() [][]string {
-	return [][]string{
+	keyValues := [][]string{
 		{"ID", ansi.Faint(v.ID)},
 		{"NAME", v.Name},
 		{"TYPE", v.Type},
@@ -41,8 +42,15 @@ func (v *actionView) KeyValues() [][]string {
 		{"LAST DEPLOYED", v.BuiltAt},
 		{"LAST UPDATED", v.UpdatedAt},
 		{"CREATED", v.CreatedAt},
-		{"CODE", v.Code},
 	}
+
+	if v.Modules != "" {
+		keyValues = append(keyValues, []string{"MODULES", v.Modules})
+	}
+
+	keyValues = append(keyValues, []string{"CODE", v.Code})
+
+	return keyValues
 }
 
 func (v *actionView) Object() interface{} {
@@ -118,8 +126,29 @@ func makeActionView(action *management.Action) *actionView {
 		CreatedAt:       timeAgo(action.GetCreatedAt()),
 		UpdatedAt:       timeAgo(action.GetUpdatedAt()),
 		Code:            action.GetCode(),
+		Modules:         formatActionModules(action.Modules),
 		raw:             action,
 	}
+}
+
+func formatActionModules(modules *[]management.ActionModules) string {
+	if modules == nil || len(*modules) == 0 {
+		return ""
+	}
+
+	formatted := make([]string, 0, len(*modules))
+	for _, m := range *modules {
+		entry := m.GetModuleID()
+		if name := m.GetModuleName(); name != "" {
+			entry = name + " (" + m.GetModuleID() + ")"
+		}
+		if version := m.GetModuleVersionNumber(); version != 0 {
+			entry += " v" + strconv.Itoa(version)
+		}
+		formatted = append(formatted, entry)
+	}
+
+	return strings.Join(formatted, ", ")
 }
 
 func actionStatus(v string) string {

--- a/internal/display/actions_test.go
+++ b/internal/display/actions_test.go
@@ -1,0 +1,42 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatActionModules(t *testing.T) {
+	t.Run("it returns an empty string when there are no modules", func(t *testing.T) {
+		assert.Equal(t, "", formatActionModules(nil))
+		assert.Equal(t, "", formatActionModules(&[]management.ActionModules{}))
+	})
+
+	t.Run("it formats a module with only an id", func(t *testing.T) {
+		modules := &[]management.ActionModules{
+			{ModuleID: auth0.String("mod_123")},
+		}
+		assert.Equal(t, "mod_123", formatActionModules(modules))
+	})
+
+	t.Run("it formats a module with name and version", func(t *testing.T) {
+		modules := &[]management.ActionModules{
+			{
+				ModuleID:            auth0.String("mod_123"),
+				ModuleName:          auth0.String("my-module"),
+				ModuleVersionNumber: auth0.Int(2),
+			},
+		}
+		assert.Equal(t, "my-module (mod_123) v2", formatActionModules(modules))
+	})
+
+	t.Run("it joins multiple modules", func(t *testing.T) {
+		modules := &[]management.ActionModules{
+			{ModuleID: auth0.String("mod_123"), ModuleName: auth0.String("first")},
+			{ModuleID: auth0.String("mod_456")},
+		}
+		assert.Equal(t, "first (mod_123), mod_456", formatActionModules(modules))
+	})
+}


### PR DESCRIPTION
### 🔧 Changes

Adds a repeatable `--module` (`-m`) flag to `auth0 actions create` and `auth0 actions update` for associating action modules with an action.

Each flag value is a comma-separated set of `key=value` pairs whose keys mirror the Management API field names, so agents and users can map directly from the API structure without translation:

- `module_id` (required) — the module UUID
- `module_version_id` (required) — the UUID of the specific module version to attach

The flag can be passed multiple times to associate several modules. The associated modules render as a new `MODULES` row in the action's detail output (and in the `modules` array under `--json`).

This PR also fixes two pre-existing bugs in `auth0 actions update` that surfaced when running a flag-only (non-interactive) update:

- The update payload sent `"name": null` because `Name` was never seeded from the existing action, and the SDK's `Action.Name` field has no `omitempty`. The API rejected this with `400 ... Expected type string but found type null`. `Name` is now seeded from the existing action, so a partial update no longer blanks it.
- Answering "No" to the "Do you want to save the action code?" prompt aborted the entire update, silently discarding other changes such as `--module`. The code editor and its save confirmation now run only when the update actually touches code (either `--code` is passed, or the fully interactive no-flag path). This also applies to `--name`, `--runtime`, `--secret`, and `--dependency` updates, which previously hit the same issues.

### 📚 References


### 🔬 Testing

- Added `TestActionsInputModulesToActionModules` covering the parser: single and multiple modules, empty input, malformed pairs, missing `module_id`, missing `module_version_id`, and unknown keys.
- Added `TestActionsUpdateCmd` asserting a module-only update carries the existing name forward and sends the correct modules payload.
- Added `TestFormatActionModules` covering the display rendering (id only, name plus version, and multiple modules).
- Verified end-to-end against a live tenant: create and update with one and multiple modules, confirmed the `MODULES` row renders and the association persists on `actions show`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
