### PR TITLE
fix(up): rename portal pages property from content to standard

### DIFF
--- a/internal/cli/universal_portals.go
+++ b/internal/cli/universal_portals.go
@@ -851,7 +851,7 @@ type portalSidebar struct {
 
 type portalPages struct {
 	Default string       `json:"default,omitempty"`
-	Content []portalPage `json:"content"`
+	Content []portalPage `json:"standard"`
 }
 
 type portalPage struct {

--- a/internal/cli/universal_portals.go
+++ b/internal/cli/universal_portals.go
@@ -851,7 +851,7 @@ type portalSidebar struct {
 
 type portalPages struct {
 	Default string       `json:"default,omitempty"`
-	Content []portalPage `json:"standard"`
+	Standard []portalPage `json:"standard"`
 }
 
 type portalPage struct {
@@ -957,7 +957,7 @@ func buildDefaultPortal(slug, name, clientID, clientSecret string, forms portalF
 		},
 		Pages: &portalPages{
 			Default: "profile",
-			Content: []portalPage{
+			Standard: []portalPage{
 				{
 					Title: "Profile",
 					Slug:  "profile",

--- a/internal/cli/universal_portals.go
+++ b/internal/cli/universal_portals.go
@@ -850,7 +850,7 @@ type portalSidebar struct {
 }
 
 type portalPages struct {
-	Default string       `json:"default,omitempty"`
+	Default  string       `json:"default,omitempty"`
 	Standard []portalPage `json:"standard"`
 }
 


### PR DESCRIPTION
## Summary

  Renames the `portalPages.Content` JSON tag from `"content"` to `"standard"` to match the portals API.

 Related PR: https://github.com/auth0/auth0-cli/pull/1595

  ## Test plan

  - [ ] Run `auth0 universal-portals setup` end-to-end and confirm portal is created successfully.