### PR TITLE
feat: add actions modules versions commands

### DIFF
--- a/docs/auth0_actions_modules.md
+++ b/docs/auth0_actions_modules.md
@@ -15,4 +15,5 @@ Action modules are reusable code libraries that actions can import. Manage them 
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 

--- a/docs/auth0_actions_modules_create.md
+++ b/docs/auth0_actions_modules_create.md
@@ -60,5 +60,6 @@ auth0 actions modules create [flags]
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 
 

--- a/docs/auth0_actions_modules_delete.md
+++ b/docs/auth0_actions_modules_delete.md
@@ -55,5 +55,6 @@ auth0 actions modules delete [flags]
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 
 

--- a/docs/auth0_actions_modules_list.md
+++ b/docs/auth0_actions_modules_list.md
@@ -51,5 +51,6 @@ auth0 actions modules list [flags]
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 
 

--- a/docs/auth0_actions_modules_show.md
+++ b/docs/auth0_actions_modules_show.md
@@ -47,5 +47,6 @@ auth0 actions modules show [flags]
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 
 

--- a/docs/auth0_actions_modules_update.md
+++ b/docs/auth0_actions_modules_update.md
@@ -56,5 +56,6 @@ auth0 actions modules update [flags]
 - [auth0 actions modules list](auth0_actions_modules_list.md) - List your action modules
 - [auth0 actions modules show](auth0_actions_modules_show.md) - Show an action module
 - [auth0 actions modules update](auth0_actions_modules_update.md) - Update an action module
+- [auth0 actions modules versions](auth0_actions_modules_versions.md) - Manage action module versions
 
 

--- a/docs/auth0_actions_modules_versions.md
+++ b/docs/auth0_actions_modules_versions.md
@@ -1,0 +1,16 @@
+---
+layout: default
+has_toc: false
+has_children: true
+---
+# auth0 actions modules versions
+
+Every published action module version is an immutable snapshot of the module's code, dependencies, and secrets. List and inspect a module's versions here, roll the draft back to a past version, or publish the current draft as a new version.
+
+## Commands
+
+- [auth0 actions modules versions list](auth0_actions_modules_versions_list.md) - List the versions of an action module
+- [auth0 actions modules versions publish](auth0_actions_modules_versions_publish.md) - Publish an action module draft as a new version
+- [auth0 actions modules versions rollback](auth0_actions_modules_versions_rollback.md) - Roll an action module back to a previous version
+- [auth0 actions modules versions show](auth0_actions_modules_versions_show.md) - Show an action module version
+

--- a/docs/auth0_actions_modules_versions_list.md
+++ b/docs/auth0_actions_modules_versions_list.md
@@ -1,0 +1,52 @@
+---
+layout: default
+parent: auth0 actions modules versions
+has_toc: false
+---
+# auth0 actions modules versions list
+
+List the immutable versions that have been published for an action module.
+
+## Usage
+```
+auth0 actions modules versions list [flags]
+```
+
+## Examples
+
+```
+  auth0 actions modules versions list
+  auth0 actions modules versions ls <module-id>
+  auth0 actions modules versions list <module-id> --number 100
+  auth0 actions modules versions list <module-id> --json
+```
+
+
+## Flags
+
+```
+      --csv            Output in csv format.
+      --json           Output in json format.
+      --json-compact   Output in compact json format.
+  -n, --number int     Number of action modules to retrieve. Minimum 1, maximum 1000. (default 100)
+```
+
+
+## Inherited Flags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 actions modules versions list](auth0_actions_modules_versions_list.md) - List the versions of an action module
+- [auth0 actions modules versions publish](auth0_actions_modules_versions_publish.md) - Publish an action module draft as a new version
+- [auth0 actions modules versions rollback](auth0_actions_modules_versions_rollback.md) - Roll an action module back to a previous version
+- [auth0 actions modules versions show](auth0_actions_modules_versions_show.md) - Show an action module version
+
+

--- a/docs/auth0_actions_modules_versions_publish.md
+++ b/docs/auth0_actions_modules_versions_publish.md
@@ -1,0 +1,50 @@
+---
+layout: default
+parent: auth0 actions modules versions
+has_toc: false
+---
+# auth0 actions modules versions publish
+
+Snapshot an action module's current draft as a new immutable version.
+
+This is equivalent to the `--publish` flag on `auth0 actions modules create` and `auth0 actions modules update`, but lets you publish a draft on its own without making any other change.
+
+## Usage
+```
+auth0 actions modules versions publish [flags]
+```
+
+## Examples
+
+```
+  auth0 actions modules versions publish
+  auth0 actions modules versions publish <module-id>
+```
+
+
+## Flags
+
+```
+      --json           Output in json format.
+      --json-compact   Output in compact json format.
+```
+
+
+## Inherited Flags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 actions modules versions list](auth0_actions_modules_versions_list.md) - List the versions of an action module
+- [auth0 actions modules versions publish](auth0_actions_modules_versions_publish.md) - Publish an action module draft as a new version
+- [auth0 actions modules versions rollback](auth0_actions_modules_versions_rollback.md) - Roll an action module back to a previous version
+- [auth0 actions modules versions show](auth0_actions_modules_versions_show.md) - Show an action module version
+
+

--- a/docs/auth0_actions_modules_versions_rollback.md
+++ b/docs/auth0_actions_modules_versions_rollback.md
@@ -1,0 +1,52 @@
+---
+layout: default
+parent: auth0 actions modules versions
+has_toc: false
+---
+# auth0 actions modules versions rollback
+
+Copy the code, dependencies, and secrets of a previously published version back into the module's draft.
+
+This does not create a new version; it only replaces the draft. Publish afterwards to snapshot the restored draft as a new version.
+
+## Usage
+```
+auth0 actions modules versions rollback [flags]
+```
+
+## Examples
+
+```
+  auth0 actions modules versions rollback
+  auth0 actions modules versions rollback <module-id> <version-id>
+  auth0 actions modules versions rollback <module-id> <version-id> --force
+```
+
+
+## Flags
+
+```
+      --force          Skip confirmation.
+      --json           Output in json format.
+      --json-compact   Output in compact json format.
+```
+
+
+## Inherited Flags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 actions modules versions list](auth0_actions_modules_versions_list.md) - List the versions of an action module
+- [auth0 actions modules versions publish](auth0_actions_modules_versions_publish.md) - Publish an action module draft as a new version
+- [auth0 actions modules versions rollback](auth0_actions_modules_versions_rollback.md) - Roll an action module back to a previous version
+- [auth0 actions modules versions show](auth0_actions_modules_versions_show.md) - Show an action module version
+
+

--- a/docs/auth0_actions_modules_versions_show.md
+++ b/docs/auth0_actions_modules_versions_show.md
@@ -1,0 +1,49 @@
+---
+layout: default
+parent: auth0 actions modules versions
+has_toc: false
+---
+# auth0 actions modules versions show
+
+Display the code, dependencies, and secrets captured by a specific action module version.
+
+## Usage
+```
+auth0 actions modules versions show [flags]
+```
+
+## Examples
+
+```
+  auth0 actions modules versions show
+  auth0 actions modules versions show <module-id> <version-id>
+  auth0 actions modules versions show <module-id> <version-id> --json
+```
+
+
+## Flags
+
+```
+      --json           Output in json format.
+      --json-compact   Output in compact json format.
+```
+
+
+## Inherited Flags
+
+```
+      --debug           Enable debug mode.
+      --no-color        Disable colors.
+      --no-input        Disable interactivity.
+      --tenant string   Specific tenant to use.
+```
+
+
+## Related Commands
+
+- [auth0 actions modules versions list](auth0_actions_modules_versions_list.md) - List the versions of an action module
+- [auth0 actions modules versions publish](auth0_actions_modules_versions_publish.md) - Publish an action module draft as a new version
+- [auth0 actions modules versions rollback](auth0_actions_modules_versions_rollback.md) - Roll an action module back to a previous version
+- [auth0 actions modules versions show](auth0_actions_modules_versions_show.md) - Show an action module version
+
+

--- a/internal/auth0/action_module.go
+++ b/internal/auth0/action_module.go
@@ -20,6 +20,11 @@ type ActionModulePage = core.Page[*int, *managementv3.ActionModuleListItem, *man
 // ActionModulePage.
 type ActionModuleActionPage = core.Page[*int, *managementv3.ActionModuleAction, *managementv3.GetActionModuleActionsResponseContent]
 
+// ActionModuleVersionPage is the paginated response returned by the action
+// module versions list endpoint. It is aliased here for the same reason as
+// ActionModulePage.
+type ActionModuleVersionPage = core.Page[*int, *managementv3.ActionModuleVersion, *managementv3.GetActionModuleVersionsResponseContent]
+
 // ActionModuleAPIV3 is the V3 SDK interface for the /actions/modules endpoint.
 // Action modules are reusable code libraries that actions can import; they are
 // keyed by module ID.
@@ -56,6 +61,12 @@ type ActionModuleAPIV3 interface {
 	//
 	// Required scope: `read:actions`.
 	ListActions(ctx context.Context, id string, request *managementv3.GetActionModuleActionsRequestParameters, opts ...option.RequestOption) (*ActionModuleActionPage, error)
+
+	// Rollback copies the code, dependencies, and secrets of a past version
+	// back into the module's draft.
+	//
+	// Required scope: `update:actions`.
+	Rollback(ctx context.Context, id string, request *managementv3.RollbackActionModuleRequestParameters, opts ...option.RequestOption) (*managementv3.RollbackActionModuleResponseContent, error)
 }
 
 // ActionModuleVersionAPIV3 is the V3 SDK interface for the
@@ -66,4 +77,15 @@ type ActionModuleVersionAPIV3 interface {
 	//
 	// Required scope: `update:actions`.
 	Create(ctx context.Context, id string, opts ...option.RequestOption) (*managementv3.CreateActionModuleVersionResponseContent, error)
+
+	// List retrieves the immutable versions of an action module. The results
+	// are offset-paginated via the Page/PerPage request parameters.
+	//
+	// Required scope: `read:actions`.
+	List(ctx context.Context, id string, request *managementv3.GetActionModuleVersionsRequestParameters, opts ...option.RequestOption) (*ActionModuleVersionPage, error)
+
+	// Get retrieves a specific immutable version of an action module.
+	//
+	// Required scope: `read:actions`.
+	Get(ctx context.Context, id string, versionID string, opts ...option.RequestOption) (*managementv3.GetActionModuleVersionResponseContent, error)
 }

--- a/internal/auth0/mock/action_module_mock.go
+++ b/internal/auth0/mock/action_module_mock.go
@@ -136,6 +136,26 @@ func (mr *MockActionModuleAPIV3MockRecorder) ListActions(ctx, id, request interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActions", reflect.TypeOf((*MockActionModuleAPIV3)(nil).ListActions), varargs...)
 }
 
+// Rollback mocks base method.
+func (m *MockActionModuleAPIV3) Rollback(ctx context.Context, id string, request *management.RollbackActionModuleRequestParameters, opts ...option.RequestOption) (*management.RollbackActionModuleResponseContent, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, id, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Rollback", varargs...)
+	ret0, _ := ret[0].(*management.RollbackActionModuleResponseContent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Rollback indicates an expected call of Rollback.
+func (mr *MockActionModuleAPIV3MockRecorder) Rollback(ctx, id, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, id, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockActionModuleAPIV3)(nil).Rollback), varargs...)
+}
+
 // Update mocks base method.
 func (m *MockActionModuleAPIV3) Update(ctx context.Context, id string, request *management.UpdateActionModuleRequestContent, opts ...option.RequestOption) (*management.UpdateActionModuleResponseContent, error) {
 	m.ctrl.T.Helper()
@@ -197,4 +217,44 @@ func (mr *MockActionModuleVersionAPIV3MockRecorder) Create(ctx, id interface{}, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, id}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockActionModuleVersionAPIV3)(nil).Create), varargs...)
+}
+
+// Get mocks base method.
+func (m *MockActionModuleVersionAPIV3) Get(ctx context.Context, id, versionID string, opts ...option.RequestOption) (*management.GetActionModuleVersionResponseContent, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, id, versionID}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Get", varargs...)
+	ret0, _ := ret[0].(*management.GetActionModuleVersionResponseContent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockActionModuleVersionAPIV3MockRecorder) Get(ctx, id, versionID interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, id, versionID}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockActionModuleVersionAPIV3)(nil).Get), varargs...)
+}
+
+// List mocks base method.
+func (m *MockActionModuleVersionAPIV3) List(ctx context.Context, id string, request *management.GetActionModuleVersionsRequestParameters, opts ...option.RequestOption) (*auth0.ActionModuleVersionPage, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, id, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "List", varargs...)
+	ret0, _ := ret[0].(*auth0.ActionModuleVersionPage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockActionModuleVersionAPIV3MockRecorder) List(ctx, id, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, id, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockActionModuleVersionAPIV3)(nil).List), varargs...)
 }

--- a/internal/cli/actions_modules.go
+++ b/internal/cli/actions_modules.go
@@ -86,6 +86,7 @@ func actionsModulesCmd(cli *cli) *cobra.Command {
 	cmd.AddCommand(updateActionModuleCmd(cli))
 	cmd.AddCommand(deleteActionModuleCmd(cli))
 	cmd.AddCommand(actionsModulesActionsCmd(cli))
+	cmd.AddCommand(actionsModulesVersionsCmd(cli))
 
 	return cmd
 }

--- a/internal/cli/actions_modules_versions.go
+++ b/internal/cli/actions_modules_versions.go
@@ -1,0 +1,301 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	"github.com/spf13/cobra"
+
+	"github.com/auth0/auth0-cli/internal/ansi"
+	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/prompt"
+)
+
+var actionModuleVersionID = Argument{
+	Name: "Version Id",
+	Help: "Id of the action module version.",
+}
+
+func actionsModulesVersionsCmd(cli *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Manage action module versions",
+		Long: "Every published action module version is an immutable snapshot of the module's code, dependencies, and secrets. " +
+			"List and inspect a module's versions here, roll the draft back to a past version, or publish the current draft as a new version.",
+	}
+
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+	cmd.AddCommand(listActionModuleVersionsCmd(cli))
+	cmd.AddCommand(showActionModuleVersionCmd(cli))
+	cmd.AddCommand(rollbackActionModuleVersionCmd(cli))
+	cmd.AddCommand(publishActionModuleVersionCmd(cli))
+
+	return cmd
+}
+
+func listActionModuleVersionsCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ModuleID string
+		Number   int
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List the versions of an action module",
+		Long:    "List the immutable versions that have been published for an action module.",
+		Example: `  auth0 actions modules versions list
+  auth0 actions modules versions ls <module-id>
+  auth0 actions modules versions list <module-id> --number 100
+  auth0 actions modules versions list <module-id> --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if inputs.Number < 1 || inputs.Number > 1000 {
+				return fmt.Errorf("number flag invalid, please pass a number between 1 and 1000")
+			}
+
+			if len(args) == 0 {
+				if err := actionModuleID.Pick(cmd, &inputs.ModuleID, cli.actionModulePickerOptions); err != nil {
+					return err
+				}
+			} else {
+				inputs.ModuleID = args[0]
+			}
+
+			versions, err := collectV3Pages(cmd.Context(), inputs.Number,
+				func(ctx context.Context) (*auth0.ActionModuleVersionPage, error) {
+					return cli.apiv3.ActionModuleVersion.List(ctx, inputs.ModuleID, &managementv3.GetActionModuleVersionsRequestParameters{})
+				})
+			if err != nil {
+				return fmt.Errorf("failed to list versions for action module with ID %q: %w", inputs.ModuleID, err)
+			}
+
+			cli.renderer.ActionModuleVersionList(versions)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.jsonCompact, "json-compact", false, "Output in compact json format.")
+	cmd.Flags().BoolVar(&cli.csv, "csv", false, "Output in csv format.")
+	cmd.MarkFlagsMutuallyExclusive("json", "json-compact", "csv")
+
+	actionModuleNumber.RegisterInt(cmd, &inputs.Number, defaultPageSize)
+
+	return cmd
+}
+
+func showActionModuleVersionCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ModuleID  string
+		VersionID string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Args:  cobra.MaximumNArgs(2),
+		Short: "Show an action module version",
+		Long:  "Display the code, dependencies, and secrets captured by a specific action module version.",
+		Example: `  auth0 actions modules versions show
+  auth0 actions modules versions show <module-id> <version-id>
+  auth0 actions modules versions show <module-id> <version-id> --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pickActionModuleAndVersion(cli, cmd, args, &inputs.ModuleID, &inputs.VersionID); err != nil {
+				return err
+			}
+
+			var version *managementv3.GetActionModuleVersionResponseContent
+			if err := ansi.Waiting(func() (err error) {
+				version, err = cli.apiv3.ActionModuleVersion.Get(cmd.Context(), inputs.ModuleID, inputs.VersionID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read version %q of action module with ID %q: %w", inputs.VersionID, inputs.ModuleID, err)
+			}
+
+			cli.renderer.ActionModuleVersionShow(version)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.jsonCompact, "json-compact", false, "Output in compact json format.")
+	cmd.MarkFlagsMutuallyExclusive("json", "json-compact")
+
+	return cmd
+}
+
+func rollbackActionModuleVersionCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ModuleID  string
+		VersionID string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Args:  cobra.MaximumNArgs(2),
+		Short: "Roll an action module back to a previous version",
+		Long: "Copy the code, dependencies, and secrets of a previously published version back into the module's draft.\n\n" +
+			"This does not create a new version; it only replaces the draft. Publish afterwards to snapshot the restored draft as a new version.",
+		Example: `  auth0 actions modules versions rollback
+  auth0 actions modules versions rollback <module-id> <version-id>
+  auth0 actions modules versions rollback <module-id> <version-id> --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pickActionModuleAndVersion(cli, cmd, args, &inputs.ModuleID, &inputs.VersionID); err != nil {
+				return err
+			}
+
+			if !cli.force && canPrompt(cmd) {
+				if confirmed := prompt.Confirm("This replaces the module's draft with the selected version. Are you sure you want to proceed?"); !confirmed {
+					return nil
+				}
+			}
+
+			if err := ansi.Spinner("Rolling back action module", func() error {
+				_, err := cli.apiv3.ActionModule.Rollback(cmd.Context(), inputs.ModuleID, &managementv3.RollbackActionModuleRequestParameters{
+					ModuleVersionID: inputs.VersionID,
+				})
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to roll back action module with ID %q to version %q: %w", inputs.ModuleID, inputs.VersionID, err)
+			}
+
+			// Re-read the module so the output reflects the restored draft.
+			var module *managementv3.GetActionModuleResponseContent
+			if err := ansi.Waiting(func() (err error) {
+				module, err = cli.apiv3.ActionModule.Get(cmd.Context(), inputs.ModuleID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read action module with ID %q: %w", inputs.ModuleID, err)
+			}
+
+			cli.renderer.ActionModuleShow(module)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.force, "force", false, "Skip confirmation.")
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.jsonCompact, "json-compact", false, "Output in compact json format.")
+	cmd.MarkFlagsMutuallyExclusive("json", "json-compact")
+
+	return cmd
+}
+
+func publishActionModuleVersionCmd(cli *cli) *cobra.Command {
+	var inputs struct {
+		ModuleID string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "publish",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Publish an action module draft as a new version",
+		Long: "Snapshot an action module's current draft as a new immutable version.\n\n" +
+			"This is equivalent to the `--publish` flag on `auth0 actions modules create` and `auth0 actions modules update`, " +
+			"but lets you publish a draft on its own without making any other change.",
+		Example: `  auth0 actions modules versions publish
+  auth0 actions modules versions publish <module-id>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				if err := actionModuleID.Pick(cmd, &inputs.ModuleID, cli.actionModulePickerOptions); err != nil {
+					return err
+				}
+			} else {
+				inputs.ModuleID = args[0]
+			}
+
+			// Read the module first so we can skip a redundant publish when the
+			// draft already matches the latest version.
+			var current *managementv3.GetActionModuleResponseContent
+			if err := ansi.Waiting(func() (err error) {
+				current, err = cli.apiv3.ActionModule.Get(cmd.Context(), inputs.ModuleID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read action module with ID %q: %w", inputs.ModuleID, err)
+			}
+
+			if current.GetAllChangesPublished() {
+				cli.renderer.Infof("The module is already fully published; there are no draft changes to publish.")
+				cli.renderer.ActionModuleShow(current)
+				return nil
+			}
+
+			if err := ansi.Spinner("Publishing action module", func() error {
+				_, err := cli.apiv3.ActionModuleVersion.Create(cmd.Context(), inputs.ModuleID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to publish action module with ID %q: %w", inputs.ModuleID, err)
+			}
+
+			// Re-read so the output reflects the newly published version.
+			var published *managementv3.GetActionModuleResponseContent
+			if err := ansi.Waiting(func() (err error) {
+				published, err = cli.apiv3.ActionModule.Get(cmd.Context(), inputs.ModuleID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("failed to read action module with ID %q: %w", inputs.ModuleID, err)
+			}
+
+			cli.renderer.ActionModuleShow(published)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&cli.json, "json", false, "Output in json format.")
+	cmd.Flags().BoolVar(&cli.jsonCompact, "json-compact", false, "Output in compact json format.")
+	cmd.MarkFlagsMutuallyExclusive("json", "json-compact")
+
+	return cmd
+}
+
+// pickActionModuleAndVersion resolves the module and version IDs from the
+// positional args, falling back to interactive pickers for whichever is
+// missing. The version picker is scoped to the resolved module.
+func pickActionModuleAndVersion(cli *cli, cmd *cobra.Command, args []string, moduleID, versionID *string) error {
+	if len(args) >= 1 {
+		*moduleID = args[0]
+	} else {
+		if err := actionModuleID.Pick(cmd, moduleID, cli.actionModulePickerOptions); err != nil {
+			return err
+		}
+	}
+
+	if len(args) >= 2 {
+		*versionID = args[1]
+		return nil
+	}
+
+	return actionModuleVersionID.Pick(cmd, versionID, cli.actionModuleVersionPickerOptions(*moduleID))
+}
+
+// actionModuleVersionPickerOptions returns a picker of the versions for the
+// given module, most recent first as returned by the API.
+func (c *cli) actionModuleVersionPickerOptions(moduleID string) pickerOptionsFunc {
+	return func(ctx context.Context) (pickerOptions, error) {
+		versions, err := collectV3Pages(ctx, 0,
+			func(ctx context.Context) (*auth0.ActionModuleVersionPage, error) {
+				return c.apiv3.ActionModuleVersion.List(ctx, moduleID, &managementv3.GetActionModuleVersionsRequestParameters{})
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		var opts pickerOptions
+		for _, v := range versions {
+			label := fmt.Sprintf("v%d %s", v.GetVersionNumber(), ansi.Faint("("+v.GetID()+")"))
+			opts = append(opts, pickerOption{value: v.GetID(), label: label})
+		}
+
+		if len(opts) == 0 {
+			return nil, errors.New("this action module has no published versions to choose from. Publish one by running: `auth0 actions modules versions publish`")
+		}
+
+		return opts, nil
+	}
+}

--- a/internal/cli/actions_modules_versions_test.go
+++ b/internal/cli/actions_modules_versions_test.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	managementv3 "github.com/auth0/go-auth0/v3/management"
+	"github.com/auth0/go-auth0/v3/management/core"
+	"github.com/auth0/go-auth0/v3/management/option"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/auth0-cli/internal/auth0"
+	"github.com/auth0/auth0-cli/internal/auth0/mock"
+)
+
+func actionModuleVersionPage(results ...*managementv3.ActionModuleVersion) *auth0.ActionModuleVersionPage {
+	return &auth0.ActionModuleVersionPage{
+		Results: results,
+		NextPageFunc: func(context.Context) (*auth0.ActionModuleVersionPage, error) {
+			return nil, core.ErrNoPages
+		},
+	}
+}
+
+func TestListActionModuleVersionsCmd(t *testing.T) {
+	t.Run("lists the versions of the module supplied positionally", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			List(gomock.Any(), "am_1", gomock.Any()).
+			Return(actionModuleVersionPage(
+				&managementv3.ActionModuleVersion{ID: auth0.String("ver_1"), VersionNumber: auth0.Int(1)},
+				&managementv3.ActionModuleVersion{ID: auth0.String("ver_2"), VersionNumber: auth0.Int(2)},
+			), nil)
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := listActionModuleVersionsCmd(cli)
+		cmd.SetArgs([]string{"am_1"})
+
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("rejects an out-of-range number flag", func(t *testing.T) {
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModuleVersion: mock.NewMockActionModuleVersionAPIV3(gomock.NewController(t))},
+			renderer: testRenderer(),
+		}
+
+		cmd := listActionModuleVersionsCmd(cli)
+		cmd.SetArgs([]string{"am_1", "--number", "0"})
+
+		assert.EqualError(t, cmd.Execute(), "number flag invalid, please pass a number between 1 and 1000")
+	})
+
+	t.Run("wraps the API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			List(gomock.Any(), "am_1", gomock.Any()).
+			Return(nil, errors.New("boom"))
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := listActionModuleVersionsCmd(cli)
+		cmd.SetArgs([]string{"am_1"})
+
+		assert.EqualError(t, cmd.Execute(), `failed to list versions for action module with ID "am_1": boom`)
+	})
+}
+
+func TestShowActionModuleVersionCmd(t *testing.T) {
+	t.Run("shows the version supplied positionally", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			Get(gomock.Any(), "am_1", "ver_1").
+			Return(&managementv3.GetActionModuleVersionResponseContent{
+				ID:            auth0.String("ver_1"),
+				VersionNumber: auth0.Int(1),
+			}, nil)
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := showActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1", "ver_1"})
+
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("wraps the API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			Get(gomock.Any(), "am_1", "ver_1").
+			Return(nil, errors.New("boom"))
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := showActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1", "ver_1"})
+
+		assert.EqualError(t, cmd.Execute(), `failed to read version "ver_1" of action module with ID "am_1": boom`)
+	})
+}
+
+func TestRollbackActionModuleVersionCmd(t *testing.T) {
+	t.Run("rolls back then re-reads the module", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mock.NewMockActionModuleAPIV3(ctrl)
+
+		gomock.InOrder(
+			api.EXPECT().
+				Rollback(gomock.Any(), "am_1", gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, req *managementv3.RollbackActionModuleRequestParameters, _ ...option.RequestOption) (*managementv3.RollbackActionModuleResponseContent, error) {
+					assert.Equal(t, "ver_1", req.ModuleVersionID)
+					return &managementv3.RollbackActionModuleResponseContent{ID: auth0.String("am_1")}, nil
+				}),
+			api.EXPECT().
+				Get(gomock.Any(), "am_1").
+				Return(&managementv3.GetActionModuleResponseContent{ID: auth0.String("am_1")}, nil),
+		)
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModule: api},
+			renderer: testRenderer(),
+		}
+
+		cmd := rollbackActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1", "ver_1", "--force"})
+
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("wraps the API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mock.NewMockActionModuleAPIV3(ctrl)
+		api.EXPECT().
+			Rollback(gomock.Any(), "am_1", gomock.Any()).
+			Return(nil, errors.New("boom"))
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModule: api},
+			renderer: testRenderer(),
+		}
+
+		cmd := rollbackActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1", "ver_1", "--force"})
+
+		assert.EqualError(t, cmd.Execute(), `failed to roll back action module with ID "am_1" to version "ver_1": boom`)
+	})
+}
+
+func TestPublishActionModuleVersionCmd(t *testing.T) {
+	t.Run("publishes when the draft has unpublished changes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mock.NewMockActionModuleAPIV3(ctrl)
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+
+		gomock.InOrder(
+			api.EXPECT().
+				Get(gomock.Any(), "am_1").
+				Return(&managementv3.GetActionModuleResponseContent{
+					ID:                  auth0.String("am_1"),
+					AllChangesPublished: auth0.Bool(false),
+				}, nil),
+			versions.EXPECT().
+				Create(gomock.Any(), "am_1").
+				Return(&managementv3.CreateActionModuleVersionResponseContent{VersionNumber: auth0.Int(2)}, nil),
+			api.EXPECT().
+				Get(gomock.Any(), "am_1").
+				Return(&managementv3.GetActionModuleResponseContent{ID: auth0.String("am_1")}, nil),
+		)
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModule: api, ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := publishActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1"})
+
+		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("skips publish when the draft is already fully published", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		api := mock.NewMockActionModuleAPIV3(ctrl)
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		// Versions.Create must never be called when everything is published.
+
+		api.EXPECT().
+			Get(gomock.Any(), "am_1").
+			Return(&managementv3.GetActionModuleResponseContent{
+				ID:                  auth0.String("am_1"),
+				AllChangesPublished: auth0.Bool(true),
+			}, nil)
+
+		cli := &cli{
+			apiv3:    &auth0.APIV3{ActionModule: api, ActionModuleVersion: versions},
+			renderer: testRenderer(),
+		}
+
+		cmd := publishActionModuleVersionCmd(cli)
+		cmd.SetArgs([]string{"am_1"})
+
+		assert.NoError(t, cmd.Execute())
+	})
+}
+
+func TestActionModuleVersionPickerOptions(t *testing.T) {
+	t.Run("labels versions by number and id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			List(gomock.Any(), "am_1", gomock.Any()).
+			Return(actionModuleVersionPage(
+				&managementv3.ActionModuleVersion{ID: auth0.String("ver_2"), VersionNumber: auth0.Int(2)},
+			), nil)
+
+		cli := &cli{apiv3: &auth0.APIV3{ActionModuleVersion: versions}}
+
+		opts, err := cli.actionModuleVersionPickerOptions("am_1")(context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, opts, 1)
+		assert.Equal(t, "ver_2", opts[0].value)
+	})
+
+	t.Run("errors when the module has no versions", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		versions := mock.NewMockActionModuleVersionAPIV3(ctrl)
+		versions.EXPECT().
+			List(gomock.Any(), "am_1", gomock.Any()).
+			Return(actionModuleVersionPage(), nil)
+
+		cli := &cli{apiv3: &auth0.APIV3{ActionModuleVersion: versions}}
+
+		_, err := cli.actionModuleVersionPickerOptions("am_1")(context.Background())
+		assert.ErrorContains(t, err, "no published versions")
+	})
+}

--- a/internal/display/action_module.go
+++ b/internal/display/action_module.go
@@ -265,6 +265,125 @@ func makeActionModuleActionView(action *managementv3.ActionModuleAction) *action
 	}
 }
 
+// actionModuleVersionResponse is satisfied by both the version list item and
+// the single-version get response, which share the same getter surface. It lets
+// one view constructor serve both.
+type actionModuleVersionResponse interface {
+	GetID() string
+	GetModuleID() string
+	GetVersionNumber() int
+	GetCode() string
+	GetDependencies() []*managementv3.ActionModuleDependency
+	GetSecrets() []*managementv3.ActionModuleSecret
+	GetCreatedAt() time.Time
+}
+
+type actionModuleVersionView struct {
+	ID           string
+	ModuleID     string
+	Version      string
+	CreatedAt    string
+	Dependencies string
+	Secrets      string
+	Code         string
+
+	raw interface{}
+}
+
+func (v *actionModuleVersionView) AsTableHeader() []string {
+	return []string{"ID", "Version", "Created At"}
+}
+
+func (v *actionModuleVersionView) AsTableRow() []string {
+	return []string{
+		ansi.Faint(v.ID),
+		v.Version,
+		v.CreatedAt,
+	}
+}
+
+func (v *actionModuleVersionView) KeyValues() [][]string {
+	keyValues := [][]string{
+		{"ID", ansi.Faint(v.ID)},
+		{"MODULE ID", ansi.Faint(v.ModuleID)},
+		{"VERSION", v.Version},
+		{"CREATED AT", v.CreatedAt},
+	}
+
+	if v.Dependencies != "" {
+		keyValues = append(keyValues, []string{"DEPENDENCIES", v.Dependencies})
+	}
+	if v.Secrets != "" {
+		keyValues = append(keyValues, []string{"SECRETS", v.Secrets})
+	}
+
+	// CODE is rendered as a separate block below the table, matching the module
+	// show output.
+
+	return keyValues
+}
+
+func (v *actionModuleVersionView) Object() interface{} {
+	return v.raw
+}
+
+func (r *Renderer) ActionModuleVersionList(versions []*managementv3.ActionModuleVersion) {
+	resource := "action module versions"
+
+	r.Heading(resource)
+
+	if len(versions) == 0 {
+		r.EmptyState(resource, "Publish one with 'auth0 actions modules versions publish'")
+		return
+	}
+
+	var results []View
+	for _, v := range versions {
+		results = append(results, makeActionModuleVersionView(v))
+	}
+
+	r.Results(results)
+}
+
+func (r *Renderer) ActionModuleVersionShow(version *managementv3.GetActionModuleVersionResponseContent) {
+	r.Heading("action module version")
+	view := makeActionModuleVersionView(version)
+	r.Result(view)
+	r.actionModuleVersionCode(view)
+}
+
+// actionModuleVersionCode prints the version's source as its own labelled block
+// beneath the key/value table, matching actionModuleCode.
+func (r *Renderer) actionModuleVersionCode(view *actionModuleVersionView) {
+	if r.Format == OutputFormatJSON || r.Format == OutputFormatJSONCompact {
+		return
+	}
+	if view.Code == "" {
+		return
+	}
+
+	fmt.Fprintf(r.ResultWriter, "\n%s\n%s", ansi.Faint("CODE"), highlightJavaScript(view.Code))
+}
+
+func makeActionModuleVersionView(version actionModuleVersionResponse) *actionModuleVersionView {
+	number := version.GetVersionNumber()
+	label := "-"
+	if number != 0 {
+		label = "v" + strconv.Itoa(number)
+	}
+
+	return &actionModuleVersionView{
+		ID:           version.GetID(),
+		ModuleID:     version.GetModuleID(),
+		Version:      label,
+		CreatedAt:    timeAgo(version.GetCreatedAt()),
+		Dependencies: formatActionModuleDependencies(version.GetDependencies()),
+		Secrets:      formatActionModuleSecrets(version.GetSecrets()),
+		Code:         version.GetCode(),
+		raw:          version,
+	}
+}
+
 func formatActionModuleDependencies(dependencies []*managementv3.ActionModuleDependency) string {
 	if len(dependencies) == 0 {
 		return ""

--- a/test/integration/action-modules-versions-test-cases.yaml
+++ b/test/integration/action-modules-versions-test-cases.yaml
@@ -4,22 +4,22 @@ config:
 
 tests:
   001 - given a test action module, it successfully publishes a version:
-    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-id.sh) --json
+    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-versions-module-id.sh) --json
     exit-code: 0
     stdout:
       json:
-        name: "integration-test-module"
+        name: "integration-test-module-versions"
         all_changes_published: "true"
 
   002 - given a fully published module, publish reports there is nothing to publish:
-    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-id.sh)
+    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-versions-module-id.sh)
     exit-code: 0
     stderr:
       contains:
         - "already fully published"
 
   003 - given a published module, it successfully lists the versions:
-    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-id.sh)
+    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-versions-module-id.sh)
     exit-code: 0
     stdout:
       contains:
@@ -28,14 +28,14 @@ tests:
         - CREATED AT
 
   004 - given a published module, it successfully lists the versions in json:
-    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-id.sh) --json
+    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-versions-module-id.sh) --json
     exit-code: 0
     stdout:
       contains:
         - "version_number"
 
   005 - given a published module version, it successfully shows the version details:
-    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh)
+    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-versions-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh)
     exit-code: 0
     stdout:
       contains:
@@ -43,7 +43,7 @@ tests:
         - CREATED AT
 
   006 - given a published module version, it successfully shows the version details in json:
-    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --json
+    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-versions-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --json
     exit-code: 0
     stdout:
       json:
@@ -51,8 +51,8 @@ tests:
         version_number: "1"
 
   007 - given a published module version, it successfully rolls the draft back:
-    command: auth0 actions modules versions rollback $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --force
+    command: auth0 actions modules versions rollback $(./test/integration/scripts/get-action-module-versions-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --force
     exit-code: 0
     stdout:
       contains:
-        - "NAME            integration-test-module"
+        - "NAME            integration-test-module-versions"

--- a/test/integration/action-modules-versions-test-cases.yaml
+++ b/test/integration/action-modules-versions-test-cases.yaml
@@ -1,0 +1,58 @@
+config:
+  inherit-env: true
+  retries: 1
+
+tests:
+  001 - given a test action module, it successfully publishes a version:
+    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-id.sh) --json
+    exit-code: 0
+    stdout:
+      json:
+        name: "integration-test-module"
+        all_changes_published: "true"
+
+  002 - given a fully published module, publish reports there is nothing to publish:
+    command: auth0 actions modules versions publish $(./test/integration/scripts/get-action-module-id.sh)
+    exit-code: 0
+    stderr:
+      contains:
+        - "already fully published"
+
+  003 - given a published module, it successfully lists the versions:
+    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-id.sh)
+    exit-code: 0
+    stdout:
+      contains:
+        - ID
+        - VERSION
+        - CREATED AT
+
+  004 - given a published module, it successfully lists the versions in json:
+    command: auth0 actions modules versions list $(./test/integration/scripts/get-action-module-id.sh) --json
+    exit-code: 0
+    stdout:
+      contains:
+        - "version_number"
+
+  005 - given a published module version, it successfully shows the version details:
+    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh)
+    exit-code: 0
+    stdout:
+      contains:
+        - VERSION
+        - CREATED AT
+
+  006 - given a published module version, it successfully shows the version details in json:
+    command: auth0 actions modules versions show $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --json
+    exit-code: 0
+    stdout:
+      json:
+        code: "module.exports = {}"
+        version_number: "1"
+
+  007 - given a published module version, it successfully rolls the draft back:
+    command: auth0 actions modules versions rollback $(./test/integration/scripts/get-action-module-id.sh) $(./test/integration/scripts/get-action-module-version-id.sh) --force
+    exit-code: 0
+    stdout:
+      contains:
+        - "NAME            integration-test-module"

--- a/test/integration/scripts/get-action-module-version-id.sh
+++ b/test/integration/scripts/get-action-module-version-id.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+FILE=./test/integration/identifiers/action-module-version-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
+module_id=$( ./test/integration/scripts/get-action-module-id.sh )
+
+# Ensure the module has at least one published version to inspect.
+auth0 actions modules versions publish "$module_id" >/dev/null 2>&1
+
+version=$( auth0 actions modules versions list "$module_id" --json )
+
+mkdir -p ./test/integration/identifiers
+echo "$version" | jq -r '.[0]["id"]' > $FILE
+cat $FILE

--- a/test/integration/scripts/get-action-module-version-id.sh
+++ b/test/integration/scripts/get-action-module-version-id.sh
@@ -6,7 +6,7 @@ if [ -f "$FILE" ]; then
     exit 0
 fi
 
-module_id=$( ./test/integration/scripts/get-action-module-id.sh )
+module_id=$( ./test/integration/scripts/get-action-module-versions-module-id.sh )
 
 # Ensure the module has at least one published version to inspect.
 auth0 actions modules versions publish "$module_id" >/dev/null 2>&1

--- a/test/integration/scripts/get-action-module-versions-module-id.sh
+++ b/test/integration/scripts/get-action-module-versions-module-id.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# The versions suite needs a module of its own. The shared module from
+# get-action-module-id.sh is deleted by the actions modules suite, which runs
+# first, leaving a stale cached ID behind.
+FILE=./test/integration/identifiers/action-module-versions-module-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
+module=$( auth0 actions modules create -n "integration-test-module-versions" -c "module.exports = {}" -d "lodash=4.0.0" -s "SECRET=value" --json )
+
+mkdir -p ./test/integration/identifiers
+echo "$module" | jq -r '.["id"]' > $FILE
+cat $FILE


### PR DESCRIPTION
### 🔧 Changes

Adds the `auth0 actions modules versions` command group for managing an action module's immutable published versions. Every published version is a snapshot of the module's code, dependencies, and secrets at publish time.

New commands:

- `auth0 actions modules versions list [id]` — list a module's versions, with `--number`, `--json`, `--json-compact`, and `--csv` output.
- `auth0 actions modules versions show [id] [version-id]` — display the code, dependencies, and secrets captured by a specific version.
- `auth0 actions modules versions rollback [id] [version-id]` — copy a past version's code, dependencies, and secrets back into the module's draft. This replaces the draft only; it does not create a new version. Supports `--force` to skip confirmation.
- `auth0 actions modules versions publish [id]` — snapshot the module's current draft as a new immutable version. This is equivalent to the `--publish` flag on `create`/`update`, but lets you publish a draft on its own.

Behavior notes:

- `publish` reads the module first and skips a redundant publish when the draft already matches the latest version, showing the current module instead.
- `rollback` and `publish` re-read the module after the write so the output reflects the restored draft or the newly published version.
- Version code is rendered as a syntax-highlighted block beneath the details table, matching the module show output. Secret values are never displayed, only names.
- Extends `ActionModuleAPIV3` with `Rollback` and `ActionModuleVersionAPIV3` with `List` and `Get` over the go-auth0 v3 SDK, with regenerated mocks.

### 📚 References

DXCDT-2172

Stacked on #1606 (base branch `DXCDT-2171/actions-modules-tree`).

### 🔬 Testing

- Table-driven unit tests cover the list, show, rollback, and publish flows, the already-fully-published skip path, the API error paths, and the version picker (both the labelled-options case and the no-versions error).
- Commander integration tests in `test/integration/action-modules-versions-test-cases.yaml` exercise publish, the already-published message, list, list in JSON, show, show in JSON, and rollback. Verified locally against a live tenant via commander (7/7 passing).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
