### PR TITLE
fix: handle nil role and permissions lists in role commands

### DIFF
--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -87,6 +87,9 @@ func listRolesCmd(cli *cli) *cobra.Command {
 					if err != nil {
 						return nil, false, err
 					}
+					if roleList == nil {
+						return result, false, nil
+					}
 
 					for _, role := range roleList.Roles {
 						result = append(result, role)
@@ -349,6 +352,10 @@ func (c *cli) rolePickerOptions(ctx context.Context) (pickerOptions, error) {
 	}
 
 	var opts pickerOptions
+
+	if list == nil {
+		return nil, errors.New("there are currently no roles to choose from. Create one by running: `auth0 roles create`")
+	}
 
 	for _, c := range list.Roles {
 		value := c.GetID()

--- a/internal/cli/roles_permissions.go
+++ b/internal/cli/roles_permissions.go
@@ -91,6 +91,9 @@ func listRolePermissionsCmd(cli *cli) *cobra.Command {
 					if err != nil {
 						return nil, false, err
 					}
+					if permissionsList == nil {
+						return result, false, nil
+					}
 
 					for _, role := range permissionsList.Permissions {
 						result = append(result, role)

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/auth0/go-auth0/management"
@@ -12,7 +13,49 @@ import (
 
 	"github.com/auth0/auth0-cli/internal/auth0"
 	"github.com/auth0/auth0-cli/internal/auth0/mock"
+	"github.com/auth0/auth0-cli/internal/display"
 )
+
+func TestListRolesCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		roleList *management.RoleList
+	}{
+		{
+			name:     "nil role list (no results)",
+			roleList: nil,
+		},
+		{
+			name:     "empty role list",
+			roleList: &management.RoleList{Roles: []*management.Role{}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			roleAPI := mock.NewMockRoleAPI(ctrl)
+			roleAPI.EXPECT().
+				List(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(test.roleList, nil)
+
+			cli := &cli{
+				renderer: &display.Renderer{
+					MessageWriter: io.Discard,
+					ResultWriter:  io.Discard,
+				},
+				api: &auth0.API{Role: roleAPI},
+			}
+
+			cmd := listRolesCmd(cli)
+			cmd.SetArgs([]string{})
+
+			assert.NoError(t, cmd.Execute())
+		})
+	}
+}
 
 func TestRolesPickerOptions(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Improves the robustness of the roles-related CLI commands by adding better handling for cases where no roles or permissions are returned

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

https://auth0.com/docs/api/management/v2/roles/get-role-permission

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Added a new test, `TestListRolesCmd`, in `roles_test.go`

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
