### PR TITLE
refactor: update session-transfer and bump ACUL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ brew tap auth0/auth0-cli && brew install auth0-beta
 > [!NOTE]
 > The `auth0-beta` formula installs the beta build as the `auth0` binary. Run it with `auth0` once installed.
 
+> [!IMPORTANT]
+> Already have the stable `auth0` CLI? It shadows the beta binary. Add this alias to your shell config so `auth0-beta` runs the beta:
+> ```bash
+> alias auth0-beta="$(brew --prefix auth0-beta)/bin/auth0"
+> ```
+
 Install via [cURL](https://curl.se/):
 
 1. Download the binary. It will be placed in `./auth0`:

--- a/README.md
+++ b/README.md
@@ -162,12 +162,6 @@ brew tap auth0/auth0-cli && brew install auth0-beta
 > [!NOTE]
 > The `auth0-beta` formula installs the beta build as the `auth0` binary. Run it with `auth0` once installed.
 
-> [!IMPORTANT]
-> Already have the stable `auth0` CLI? It shadows the beta binary. Add this alias to your shell config so `auth0-beta` runs the beta:
-> ```bash
-> alias auth0-beta="$(brew --prefix auth0-beta)/bin/auth0"
-> ```
-
 Install via [cURL](https://curl.se/):
 
 1. Download the binary. It will be placed in `./auth0`:

--- a/docs/auth0_apps_session-transfer_update.md
+++ b/docs/auth0_apps_session-transfer_update.md
@@ -28,8 +28,8 @@ auth0 apps session-transfer update [flags]
 ```
   -m, --allowed-auth-methods strings               Comma-separated list of authentication methods (e.g., cookie, query).
   -t, --can-create-token                           Allow creation of session transfer tokens.
-  -d, --delegation-allow-delegated-access          (Early Access) Allow the application to accept Session Transfer Tokens containing an Actor, enabling delegated (impersonation) access. Defaults to false.
-  -b, --delegation-enforce-device-binding string   (Early Access) Device binding enforcement for delegated (impersonation) access: 'ip' or 'asn'. Defaults to 'ip'.
+  -d, --delegation-allow-delegated-access          Allow the application to accept Session Transfer Tokens containing an Actor, enabling delegated (impersonation) access. Defaults to false.
+  -b, --delegation-enforce-device-binding string   Device binding enforcement for delegated (impersonation) access: 'ip' or 'asn'. Defaults to 'ip'.
   -e, --enforce-device-binding string              Device binding enforcement: 'none', 'ip', or 'asn'.
       --json                                       Output in json format.
       --json-compact                               Output in compact json format.

--- a/docs/auth0_apps_session-transfer_update.md
+++ b/docs/auth0_apps_session-transfer_update.md
@@ -19,8 +19,6 @@ auth0 apps session-transfer update [flags]
   auth0 apps session-transfer update <app-id>
   auth0 apps session-transfer update <app-id> --can-create-token --json
   auth0 apps session-transfer update <app-id> --can-create-token=true --allowed-auth-methods=cookie,query --enforce-device-binding=ip
-
-  # Delegation (Early Access): impersonation via Session Transfer
   auth0 apps session-transfer update <app-id> --delegation-allow-delegated-access=true --delegation-enforce-device-binding=asn
 ```
 

--- a/internal/cli/acul_app_scaffolding.go
+++ b/internal/cli/acul_app_scaffolding.go
@@ -51,7 +51,7 @@ type Metadata struct {
 	Description string `json:"description"`
 }
 
-const stableACULVersion = "v2.0.1"
+const stableACULVersion = "v3.0.0"
 
 // loadManifest downloads and parses the manifest.json for the latest release.
 func loadManifest(tag string) (*Manifest, error) {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -168,15 +168,17 @@ var (
 		Name:      "Allow Delegated Access",
 		LongForm:  "delegation-allow-delegated-access",
 		ShortForm: "d",
-		Help: "(Early Access) Allow the application to accept Session Transfer Tokens containing an Actor, " +
+		Help: "Allow the application to accept Session Transfer Tokens containing an Actor, " +
 			"enabling delegated (impersonation) access. Defaults to false.",
+		AlwaysPrompt: true,
 	}
 	appSTDelegationDeviceBinding = Flag{
 		Name:      "Delegation Enforce Device Binding",
 		LongForm:  "delegation-enforce-device-binding",
 		ShortForm: "b",
-		Help: "(Early Access) Device binding enforcement for delegated (impersonation) access: 'ip' or 'asn'. " +
+		Help: "Device binding enforcement for delegated (impersonation) access: 'ip' or 'asn'. " +
 			"Defaults to 'ip'.",
+		AlwaysPrompt: true,
 	}
 	refreshToken = Flag{
 		Name:      "Refresh Token",
@@ -1276,6 +1278,13 @@ func appsSessionTransferUpdateCmd(cli *cli) *cobra.Command {
 				}
 			}
 
+			if current.SessionTransfer.Delegation == nil {
+				current.SessionTransfer.Delegation = &management.SessionTransferDelegation{
+					AllowDelegatedAccess: auth0.Bool(false),
+					EnforceDeviceBinding: auth0.String("ip"),
+				}
+			}
+
 			if err := appSTCanCreateToken.AskBoolU(cmd, &inputs.CanCreateToken, current.SessionTransfer.CanCreateSessionTransferToken); err != nil {
 				return err
 			}
@@ -1286,6 +1295,14 @@ func appsSessionTransferUpdateCmd(cli *cli) *cobra.Command {
 			}
 
 			if err := appSTEnforceDeviceBinding.SelectU(cmd, &inputs.EnforceDeviceBinding, []string{"none", "ip", "asn"}, current.SessionTransfer.EnforceDeviceBinding); err != nil {
+				return err
+			}
+
+			if err := appSTDelegationAllowAccess.AskBoolU(cmd, &inputs.DelegationAllowAccess, current.SessionTransfer.Delegation.AllowDelegatedAccess); err != nil {
+				return err
+			}
+
+			if err := appSTDelegationDeviceBinding.SelectU(cmd, &inputs.DelegationDeviceBinding, []string{"ip", "asn"}, current.SessionTransfer.Delegation.EnforceDeviceBinding); err != nil {
 				return err
 			}
 
@@ -1304,14 +1321,17 @@ func appsSessionTransferUpdateCmd(cli *cli) *cobra.Command {
 				st.EnforceDeviceBinding = current.SessionTransfer.EnforceDeviceBinding
 			}
 
-			if appSTDelegationAllowAccess.IsSet(cmd) || appSTDelegationDeviceBinding.IsSet(cmd) {
-				delegation := &management.SessionTransferDelegation{}
+			if appSTDelegationAllowAccess.IsSet(cmd) || appSTDelegationDeviceBinding.IsSet(cmd) || noLocalFlagSet(cmd) {
+				delegation := &management.SessionTransferDelegation{
+					AllowDelegatedAccess: current.SessionTransfer.Delegation.AllowDelegatedAccess,
+					EnforceDeviceBinding: current.SessionTransfer.Delegation.EnforceDeviceBinding,
+				}
 
-				if appSTDelegationAllowAccess.IsSet(cmd) {
+				if appSTDelegationAllowAccess.IsSet(cmd) || noLocalFlagSet(cmd) {
 					delegation.AllowDelegatedAccess = &inputs.DelegationAllowAccess
 				}
 
-				if appSTDelegationDeviceBinding.IsSet(cmd) {
+				if appSTDelegationDeviceBinding.IsSet(cmd) || noLocalFlagSet(cmd) {
 					delegation.EnforceDeviceBinding = &inputs.DelegationDeviceBinding
 				}
 

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -1245,8 +1245,6 @@ func appsSessionTransferUpdateCmd(cli *cli) *cobra.Command {
   auth0 apps session-transfer update <app-id>
   auth0 apps session-transfer update <app-id> --can-create-token --json
   auth0 apps session-transfer update <app-id> --can-create-token=true --allowed-auth-methods=cookie,query --enforce-device-binding=ip
-
-  # Delegation (Early Access): impersonation via Session Transfer
   auth0 apps session-transfer update <app-id> --delegation-allow-delegated-access=true --delegation-enforce-device-binding=asn`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -1306,8 +1304,6 @@ func appsSessionTransferUpdateCmd(cli *cli) *cobra.Command {
 				st.EnforceDeviceBinding = current.SessionTransfer.EnforceDeviceBinding
 			}
 
-			// Delegation (EA) is sent only when a flag is set, leaving it untouched for
-			// others. The API merges sub-fields, so sending just the changed one is enough.
 			if appSTDelegationAllowAccess.IsSet(cmd) || appSTDelegationDeviceBinding.IsSet(cmd) {
 				delegation := &management.SessionTransferDelegation{}
 


### PR DESCRIPTION


<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Updated the `stableACULVersion` constant in `internal/cli/acul_app_scaffolding.go` from `"v2.0.1"` to `"v3.0.0"`
- Move Delegation session transfer to GA. 



<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
