### PR TITLE
feat: add tenant domain to Heap command tracking properties

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -379,6 +379,7 @@ func commandTrackingProperties(cli *cli) map[string]string {
 		"forced":        boolString(cli.force),
 		"agent_client":  cli.agentClientName(),
 		"is_api":        boolString(isAPICommand(cli.executedCommandPath)),
+		"tenant":        cli.tenant,
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -179,6 +179,20 @@ func TestIsAPICommand(t *testing.T) {
 	}
 }
 
+func TestCommandTrackingProperties(t *testing.T) {
+	t.Run("includes tenant domain when authenticated", func(t *testing.T) {
+		c := &cli{tenant: "example.us.auth0.com", renderer: &display.Renderer{}}
+		props := commandTrackingProperties(c)
+		assert.Equal(t, "example.us.auth0.com", props["tenant"])
+	})
+
+	t.Run("includes empty tenant when unauthenticated", func(t *testing.T) {
+		c := &cli{tenant: "", renderer: &display.Renderer{}}
+		props := commandTrackingProperties(c)
+		assert.Equal(t, "", props["tenant"])
+	})
+}
+
 func TestMergeProperties(t *testing.T) {
 	base := map[string]string{"interactive": "true", "success": "true"}
 	override := map[string]string{"success": "false", "error_class": "auth"}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `tenant` as a property to `commandTrackingProperties()` in `internal/cli/root.go`.



<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- PR #[1616](https://github.com/auth0/auth0-cli/pull/1616) (Auth0-Cli-Metadata header — the broader invoker-attribution effort this is part of)

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Unit tests added in `internal/cli/root_test.go`

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
