### PR TITLE
fix: allow shell completion command without authentication

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -166,6 +166,7 @@ func buildRootCmd(cli *cli) *cobra.Command {
 
 func commandRequiresAuthentication(invokedCommandName string) bool {
 	commandsWithNoAuthRequired := []string{
+		"auth0 " + cobra.ShellCompRequestCmd,
 		"auth0 commands",
 		"auth0 completion",
 		"auth0 help",

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -38,6 +38,7 @@ func TestCommandRequiresAuthentication(t *testing.T) {
 		{"auth0 apps list", true},
 		{"auth0 apps create", true},
 		{"auth0 orgs members list", true},
+		{"auth0 __complete", false},
 		{"auth0 completion", false},
 		{"auth0 help", false},
 		{"auth0 login", false},


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Add `"auth0 __complete"` to the `commandRequiresAuthentication` allowlist in `internal/cli/root.go

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References



<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- - Add a corresponding test case in `root_test.go`

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
