### PR TITLE
docs: update analytics disclosure for tenant domain collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Build, manage and test your [Auth0](https://auth0.com/) integrations from the co
 - [Available Commands](#available-commands)
 - [Customization](#customization)
 - [Agent Integration](#agent-integration)
-- [Anonymous Analytics](#anonymized-analytics-disclosure)
+- [Usage Analytics](#usage-analytics-disclosure)
 
 ## Installation
 
@@ -390,11 +390,11 @@ For AI agents and automation, **agent mode** makes output machine-friendly: stru
 
 Precedence: `--agent-mode` flag > `AUTH0_AGENT_MODE` env var > auto-detection (set `--agent-mode=false` to opt out). Destructive commands still require `--force`; without it (and with prompts disabled) they fail with an error rather than proceeding.
 
-## Anonymized Analytics Disclosure
+## Usage Analytics Disclosure
 
-Anonymized data points are collected during the use of this CLI. This data includes the CLI version, operating system, timestamp, and other technical details that do not personally identify you.
+Usage data points are collected during use of this CLI. This includes the CLI version, operating system, timestamp, the command executed, whether it was run by a human, a CI system, or an AI agent, and — when you're authenticated — the domain of the tenant you're operating against. Tenant domain can identify your Auth0 account and is not anonymized.
 
-Auth0 uses this data to better understand the usage of this tool to prioritize the features, enhancements and fixes that matter most to our users.
+Auth0 uses this data to understand how the tool is used, to prioritize the features, enhancements and fixes that matter most to our users, and to attribute usage to a tenant for support and product purposes.
 
 To **opt-out** of this collection, set the `AUTH0_CLI_ANALYTICS` environment variable to `false`.
 


### PR DESCRIPTION
## Summary

- PR #1632 added tenant domain to Heap command-tracking properties (`commandTrackingProperties()` in `internal/cli/root.go`), sent on every tracked command when authenticated.
- The Anonymized Analytics Disclosure in the README still states collected data "do not personally identify you." Tenant domain identifies a specific Auth0 account, so that claim is no longer accurate for authenticated users.
- Updates the disclosure to describe what's actually collected today: CLI version, OS, timestamp, command, invoker type (human/CI/agent), and tenant domain when authenticated. Renames the section from "Anonymized" to "Usage" Analytics Disclosure to match, and updates the TOC link/anchor accordingly.

## Test plan

- [ ] Confirm the TOC link (`#usage-analytics-disclosure`) resolves correctly on GitHub's rendered README
- [ ] Confirm no other docs/links reference the old "Anonymized Analytics Disclosure" anchor